### PR TITLE
Alter GraphQL query for batch processing of CR3s to newest first

### DIFF
--- a/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
+++ b/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
@@ -144,6 +144,7 @@ query find_cr3s($limit: Int) {
       crash_id: {_gt: 10000}
       crash_date: {_gte: "2015-01-01"}
       },
+    order_by: {crash_date: desc},
     limit: $limit) {
       crash_id,
       cr3_ocr_extraction_date,


### PR DESCRIPTION
Based on a conversation in the dev-sync meeting and a suggestion from
@sergiogcx, the query which pulls a batch of crash records for OCR /
diagram extraction is modified to request more recent crashes first.
The intent is to be processing crashes most likely to be viewed by
VZE viewers.