### PR TITLE
Create DAGs for signs work orders

### DIFF
--- a/dags/atd_knack_metadata_data_tracker.py
+++ b/dags/atd_knack_metadata_data_tracker.py
@@ -32,7 +32,7 @@ env_vars["KNACK_APP_ID"] = atd_knack_auth[app_name][env]["app_id"]
 with DAG(
     dag_id="atd_knack_metadata_data_tracker_to_postgrest",
     default_args=default_args,
-    schedule_interval="01 01 * * *",
+    schedule_interval="55 5 * * *",
     dagrun_timeout=timedelta(minutes=60),
     tags=["production", "knack"],
     catchup=False,

--- a/dags/atd_knack_mmc_activities.py
+++ b/dags/atd_knack_mmc_activities.py
@@ -37,7 +37,7 @@ env_vars["SOCRATA_APP_TOKEN"] = Variable.get("atd_service_bot_socrata_app_token"
 with DAG(
     dag_id="atd_knack_mmc_activities_to_s3_to_socrata",
     default_args=default_args,
-    schedule_interval="33 06 * * *",
+    schedule_interval="20 6 * * *",
     dagrun_timeout=timedelta(minutes=300),
     tags=["production", "knack"],
     catchup=False,

--- a/dags/atd_knack_mmc_issues.py
+++ b/dags/atd_knack_mmc_issues.py
@@ -39,7 +39,7 @@ env_vars["AGOL_PASSWORD"] = Variable.get("agol_password")
 with DAG(
     dag_id="atd_knack_mmc_issues",
     default_args=default_args,
-    schedule_interval="43 01 * * *",
+    schedule_interval="10 6 * * *",
     dagrun_timeout=timedelta(minutes=60),
     tags=["production", "knack"],
     catchup=False,

--- a/dags/atd_knack_signals.py
+++ b/dags/atd_knack_signals.py
@@ -40,7 +40,7 @@ env_vars["AGOL_PASSWORD"] = Variable.get("agol_password")
 with DAG(
     dag_id="atd_knack_signals",
     default_args=default_args,
-    schedule_interval="11 01 * * *",
+    schedule_interval="* 6 * * *",
     dagrun_timeout=timedelta(minutes=60),
     tags=["production", "knack"],
     catchup=False,

--- a/dags/atd_knack_signs_asset_specs.py
+++ b/dags/atd_knack_signs_asset_specs.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta
+from airflow.models import DAG
+from airflow.models import Variable
+from airflow.operators.docker_operator import DockerOperator
+from _slack_operators import *
+
+default_args = {
+    "owner": "airflow",
+    "description": "Publish sign work order specifications to Postgres, AGOL",
+    "depend_on_past": False,
+    "start_date": datetime(2020, 12, 31),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+docker_image = "atddocker/atd-knack-services:production"
+app_name = "signs-markings"
+env = "prod"
+container = "view_3106"
+
+env_vars = Variable.get("atd_knack_services_postgrest", deserialize_json=True)
+env_vars["AGOL_USERNAME"] = Variable.get("agol_username")
+env_vars["AGOL_PASSWORD"] = Variable.get("agol_password")
+atd_knack_auth = Variable.get("atd_knack_auth", deserialize_json=True)
+env_vars["KNACK_APP_ID"] = atd_knack_auth[app_name][env]["app_id"]
+env_vars["KNACK_API_KEY"] = atd_knack_auth[app_name][env]["api_key"]
+
+with DAG(
+    dag_id="atd_knack_signs_work_order_specifications",
+    default_args=default_args,
+    schedule_interval="35 6 * * *",
+    dagrun_timeout=timedelta(minutes=60),
+    tags=["production", "knack"],
+    catchup=False,
+) as dag:
+    date_filter = "{{ prev_execution_date_success or '2020-12-31' }}"
+
+    t1 = DockerOperator(
+        task_id="signs_asset_specs_to_postgrest",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f'./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} -d "{date_filter}"',  # noqa:E501
+        docker_url="tcp://localhost:2376",
+        network_mode="bridge",
+        environment=env_vars,
+        tty=True,
+    )
+
+    t2 = DockerOperator(
+        task_id="signs_asset_specs_to_agol",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f'./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} -d "{date_filter}"',  # noqa
+        docker_url="tcp://localhost:2376",
+        network_mode="bridge",
+        environment=env_vars,
+        tty=True,
+    )
+
+    t1 >> t2
+
+if __name__ == "__main__":
+    dag.cli()

--- a/dags/atd_knack_signs_attachments.py
+++ b/dags/atd_knack_signs_attachments.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta
+from airflow.models import DAG
+from airflow.models import Variable
+from airflow.operators.docker_operator import DockerOperator
+from _slack_operators import *
+
+default_args = {
+    "owner": "airflow",
+    "description": "Publish sign work order attachments to Postgres, AGOL",
+    "depend_on_past": False,
+    "start_date": datetime(2020, 12, 31),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+docker_image = "atddocker/atd-knack-services:production"
+app_name = "signs-markings"
+env = "prod"
+container = "view_3127"
+
+env_vars = Variable.get("atd_knack_services_postgrest", deserialize_json=True)
+env_vars["AGOL_USERNAME"] = Variable.get("agol_username")
+env_vars["AGOL_PASSWORD"] = Variable.get("agol_password")
+atd_knack_auth = Variable.get("atd_knack_auth", deserialize_json=True)
+env_vars["KNACK_APP_ID"] = atd_knack_auth[app_name][env]["app_id"]
+env_vars["KNACK_API_KEY"] = atd_knack_auth[app_name][env]["api_key"]
+
+with DAG(
+    dag_id="atd_knack_signs_work_order_attachments",
+    default_args=default_args,
+    schedule_interval="40 6 * * *",
+    dagrun_timeout=timedelta(minutes=60),
+    tags=["production", "knack"],
+    catchup=False,
+) as dag:
+    date_filter = "{{ prev_execution_date_success or '2020-12-31' }}"
+
+    t1 = DockerOperator(
+        task_id="signs_attachmentss_to_postgrest",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f'./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} -d "{date_filter}"',  # noqa:E501
+        docker_url="tcp://localhost:2376",
+        network_mode="bridge",
+        environment=env_vars,
+        tty=True,
+    )
+
+    t2 = DockerOperator(
+        task_id="signs_attachments_specs_to_agol",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f'./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} -d "{date_filter}"',  # noqa
+        docker_url="tcp://localhost:2376",
+        network_mode="bridge",
+        environment=env_vars,
+        tty=True,
+    )
+
+    t1 >> t2
+
+if __name__ == "__main__":
+    dag.cli()

--- a/dags/atd_knack_signs_materials.py
+++ b/dags/atd_knack_signs_materials.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta
+from airflow.models import DAG
+from airflow.models import Variable
+from airflow.operators.docker_operator import DockerOperator
+from _slack_operators import *
+
+default_args = {
+    "owner": "airflow",
+    "description": "Publish sign work order materials to Postgres, AGOL",
+    "depend_on_past": False,
+    "start_date": datetime(2020, 12, 31),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+docker_image = "atddocker/atd-knack-services:production"
+app_name = "signs-markings"
+env = "prod"
+container = "view_3126"
+
+env_vars = Variable.get("atd_knack_services_postgrest", deserialize_json=True)
+env_vars["AGOL_USERNAME"] = Variable.get("agol_username")
+env_vars["AGOL_PASSWORD"] = Variable.get("agol_password")
+atd_knack_auth = Variable.get("atd_knack_auth", deserialize_json=True)
+env_vars["KNACK_APP_ID"] = atd_knack_auth[app_name][env]["app_id"]
+env_vars["KNACK_API_KEY"] = atd_knack_auth[app_name][env]["api_key"]
+
+with DAG(
+    dag_id="atd_knack_signs_work_order_materials",
+    default_args=default_args,
+    schedule_interval="45 6 * * *",
+    dagrun_timeout=timedelta(minutes=60),
+    tags=["production", "knack"],
+    catchup=False,
+) as dag:
+    date_filter = "{{ prev_execution_date_success or '2020-12-31' }}"
+
+    t1 = DockerOperator(
+        task_id="signs_materials_to_postgrest",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f'./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} -d "{date_filter}"',  # noqa:E501
+        docker_url="tcp://localhost:2376",
+        network_mode="bridge",
+        environment=env_vars,
+        tty=True,
+    )
+
+    t2 = DockerOperator(
+        task_id="signs_materials_to_agol",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f'./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} -d "{date_filter}"',  # noqa
+        docker_url="tcp://localhost:2376",
+        network_mode="bridge",
+        environment=env_vars,
+        tty=True,
+    )
+
+    t1 >> t2
+
+if __name__ == "__main__":
+    dag.cli()

--- a/dags/atd_knack_signs_work_orders.py
+++ b/dags/atd_knack_signs_work_orders.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta
+from airflow.models import DAG
+from airflow.models import Variable
+from airflow.operators.docker_operator import DockerOperator
+from _slack_operators import *
+
+default_args = {
+    "owner": "airflow",
+    "description": "Publish sign work order data to Postgres, AGOL",
+    "depend_on_past": False,
+    "start_date": datetime(2020, 12, 31),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+docker_image = "atddocker/atd-knack-services:production"
+app_name = "signs-markings"
+env = "prod"
+container = "view_3107"
+
+env_vars = Variable.get("atd_knack_services_postgrest", deserialize_json=True)
+env_vars["AGOL_USERNAME"] = Variable.get("agol_username")
+env_vars["AGOL_PASSWORD"] = Variable.get("agol_password")
+atd_knack_auth = Variable.get("atd_knack_auth", deserialize_json=True)
+env_vars["KNACK_APP_ID"] = atd_knack_auth[app_name][env]["app_id"]
+env_vars["KNACK_API_KEY"] = atd_knack_auth[app_name][env]["api_key"]
+
+with DAG(
+    dag_id="atd_knack_signs_work_orders",
+    default_args=default_args,
+    schedule_interval="30 6 * * *",
+    dagrun_timeout=timedelta(minutes=60),
+    tags=["production", "knack"],
+    catchup=False,
+) as dag:
+    date_filter = "{{ prev_execution_date_success or '2020-12-31' }}"
+
+    t1 = DockerOperator(
+        task_id="signs_work_orders_to_postgrest",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f'./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} -d "{date_filter}"',  # noqa:E501
+        docker_url="tcp://localhost:2376",
+        network_mode="bridge",
+        environment=env_vars,
+        tty=True,
+    )
+
+    t2 = DockerOperator(
+        task_id="signs_work_orders_to_agol",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f'./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} -d "{date_filter}"',  # noqa
+        docker_url="tcp://localhost:2376",
+        network_mode="bridge",
+        environment=env_vars,
+        tty=True,
+    )
+
+    t1 >> t2
+
+if __name__ == "__main__":
+    dag.cli()


### PR DESCRIPTION
Deploys the fixes implemented for [#4862](https://github.com/cityofaustin/atd-data-tech/issues/4862) and improves the sequencing of all our Knack ETLs.