### PR TITLE
5671 - add dag for signal work orders

### DIFF
--- a/dags/atd_knack_signal_work_orders.py
+++ b/dags/atd_knack_signal_work_orders.py
@@ -6,9 +6,9 @@ from _slack_operators import task_fail_slack_alert
 
 default_args = {
     "owner": "airflow",
-    "description": "Load dms (view_1564) records from Knack to Postgrest to AGOL and Socrata",  # noqa:E501
+    "description": "Load traffic signal work orders (view_1829) records from Knack to Postgrest to Socrata",  # noqa:E501
     "depend_on_past": False,
-    "start_date": datetime(2021, 3, 31),
+    "start_date": datetime(2021, 4, 7),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 0,
@@ -21,9 +21,8 @@ docker_image = "atddocker/atd-knack-services:production"
 # command args
 script_task_1 = "records_to_postgrest"
 script_task_2 = "records_to_socrata"
-script_task_3 = "records_to_agol"
 app_name = "data-tracker"
-container = "view_1564"
+container = "view_1829"
 env = "prod"
 
 # assemble env vars
@@ -36,13 +35,11 @@ env_vars["SOCRATA_API_KEY_SECRET"] = Variable.get(
     "atd_service_bot_socrata_api_key_secret"
 )
 env_vars["SOCRATA_APP_TOKEN"] = Variable.get("atd_service_bot_socrata_app_token")
-env_vars["AGOL_USERNAME"] = Variable.get("agol_username")
-env_vars["AGOL_PASSWORD"] = Variable.get("agol_password")
 
 with DAG(
-    dag_id="atd_knack_dms",
+    dag_id="atd_knack_signal_work_orders",
     default_args=default_args,
-    schedule_interval="10 3 * * *",
+    schedule_interval="50 * * * *",
     dagrun_timeout=timedelta(minutes=60),
     tags=["production", "knack"],
     catchup=False,
@@ -51,7 +48,7 @@ with DAG(
     # this is a failsafe catch records that may have been missed via incremental loading
     date_filter = "{{ '1970-01-01' if ds.endswith('15') else prev_execution_date_success or '1970-01-01' }}"  # noqa:E501
     t1 = DockerOperator(
-        task_id="atd_knack_dms_to_postgrest",
+        task_id="atd_knack_traffic_signal_work_orders_to_postgrest",
         image=docker_image,
         api_version="auto",
         auto_remove=True,
@@ -63,7 +60,7 @@ with DAG(
     )
 
     t2 = DockerOperator(
-        task_id="atd_knack_dms_to_socrata",
+        task_id="atd_knack_traffic_signal_work_orders_to_socrata",
         image=docker_image,
         api_version="auto",
         auto_remove=True,
@@ -74,19 +71,7 @@ with DAG(
         tty=True,
     )
 
-    t3 = DockerOperator(
-        task_id="atd_knack_dms_to_agol",
-        image=docker_image,
-        api_version="auto",
-        auto_remove=True,
-        command=f"./atd-knack-services/services/{script_task_3}.py -a {app_name} -c {container} -d '{date_filter}'",  # noqa:E501
-        docker_url="tcp://localhost:2376",
-        network_mode="bridge",
-        environment=env_vars,
-        tty=True,
-    )
-
-    t1 >> [t2, t3]
+    t1 >> t2
 
 if __name__ == "__main__":
     dag.cli()

--- a/dags/atd_knack_signal_work_orders.py
+++ b/dags/atd_knack_signal_work_orders.py
@@ -39,7 +39,7 @@ env_vars["SOCRATA_APP_TOKEN"] = Variable.get("atd_service_bot_socrata_app_token"
 with DAG(
     dag_id="atd_knack_signal_work_orders",
     default_args=default_args,
-    schedule_interval="50 * * * *",
+    schedule_interval="50 8 * * *",
     dagrun_timeout=timedelta(minutes=60),
     tags=["production", "knack"],
     catchup=False,


### PR DESCRIPTION
Issue: cityofaustin/atd-data-tech#5671

Adds the dag for the signal work orders. 

Here is the corresponding atd-knack-services PR: https://github.com/cityofaustin/atd-knack-services/pull/67
Corresponding atd-data-deploy PR: https://github.com/cityofaustin/atd-data-deploy/pull/83