### PR TITLE
Set retries on failure for Knack ETLs

### DIFF
--- a/dags/atd_knack_arterial_management.py
+++ b/dags/atd_knack_arterial_management.py
@@ -11,7 +11,7 @@ default_args = {
     "start_date": datetime(2021, 4, 28),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_cctv_cameras.py
+++ b/dags/atd_knack_cctv_cameras.py
@@ -11,7 +11,7 @@ default_args = {
     "start_date": datetime(2021, 1, 1),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_detectors.py
+++ b/dags/atd_knack_detectors.py
@@ -11,7 +11,7 @@ default_args = {
     "start_date": datetime(2021, 4, 15),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_dms.py
+++ b/dags/atd_knack_dms.py
@@ -11,7 +11,7 @@ default_args = {
     "start_date": datetime(2021, 3, 31),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_flashing_beacons.py
+++ b/dags/atd_knack_flashing_beacons.py
@@ -11,7 +11,7 @@ default_args = {
     "start_date": datetime(2021, 4, 14),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_markings_attachments.py
+++ b/dags/atd_knack_markings_attachments.py
@@ -10,7 +10,7 @@ DEFAULT_ARGS = {
     "start_date": datetime(2020, 9, 1),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_markings_jobs.py
+++ b/dags/atd_knack_markings_jobs.py
@@ -10,7 +10,7 @@ DEFAULT_ARGS = {
     "start_date": datetime(2020, 9, 1),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_markings_materials.py
+++ b/dags/atd_knack_markings_materials.py
@@ -10,7 +10,7 @@ DEFAULT_ARGS = {
     "start_date": datetime(2020, 9, 1),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_markings_spec_actuals.py
+++ b/dags/atd_knack_markings_spec_actuals.py
@@ -10,7 +10,7 @@ DEFAULT_ARGS = {
     "start_date": datetime(2020, 9, 1),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_markings_work_orders.py
+++ b/dags/atd_knack_markings_work_orders.py
@@ -10,7 +10,7 @@ DEFAULT_ARGS = {
     "start_date": datetime(2020, 9, 1),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_metadata_data_tracker.py
+++ b/dags/atd_knack_metadata_data_tracker.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from airflow.models import DAG
 from airflow.models import Variable
 from airflow.operators.docker_operator import DockerOperator
+from _slack_operators import task_fail_slack_alert
 
 default_args = {
     "owner": "airflow",
@@ -14,6 +15,7 @@ default_args = {
     "email_on_retry": False,
     "retries": 0,
     "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
 }
 
 docker_image = "atddocker/atd-knack-services:production"

--- a/dags/atd_knack_metadata_data_tracker.py
+++ b/dags/atd_knack_metadata_data_tracker.py
@@ -13,7 +13,7 @@ default_args = {
     "start_date": datetime(2020, 9, 1),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_metrobike_kiosks.py
+++ b/dags/atd_knack_metrobike_kiosks.py
@@ -11,7 +11,7 @@ default_args = {
     "start_date": datetime(2021, 1, 1),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_mmc_issues.py
+++ b/dags/atd_knack_mmc_issues.py
@@ -11,7 +11,7 @@ default_args = {
     "start_date": datetime(2020, 9, 1),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_pole_attachments.py
+++ b/dags/atd_knack_pole_attachments.py
@@ -11,7 +11,7 @@ default_args = {
     "start_date": datetime(2021, 4, 26),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_signal_retiming.py
+++ b/dags/atd_knack_signal_retiming.py
@@ -11,7 +11,7 @@ default_args = {
     "start_date": datetime(2021, 4, 21),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_signal_work_orders.py
+++ b/dags/atd_knack_signal_work_orders.py
@@ -11,7 +11,7 @@ default_args = {
     "start_date": datetime(2021, 4, 7),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_signals.py
+++ b/dags/atd_knack_signals.py
@@ -11,7 +11,7 @@ default_args = {
     "start_date": datetime(2020, 9, 1),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_travel_sensors.py
+++ b/dags/atd_knack_travel_sensors.py
@@ -11,7 +11,7 @@ default_args = {
     "start_date": datetime(2021, 4, 18),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }


### PR DESCRIPTION
- Sets Knack ETLs to retry twice on failure
- Adds Slack task fail alert to Data Tracker metadata publisher
