### PR TITLE
Reference correct signs/markings time log view

### DIFF
--- a/dags/atd_knack_signs_markings_time_logs.py
+++ b/dags/atd_knack_signs_markings_time_logs.py
@@ -22,7 +22,7 @@ docker_image = "atddocker/atd-knack-services:production"
 script_task_1 = "records_to_postgrest"
 script_task_2 = "records_to_socrata"
 app_name = "signs-markings"
-container = "view_3516"
+container = "view_3307"
 env = "prod"
 
 # assemble env vars


### PR DESCRIPTION
I forgot this DAG was live when I modified the source view in atd-knack-services [#82](https://github.com/cityofaustin/atd-knack-services/pull/82)