### PR TITLE
Add dag for atd-knack-banner employee updates

### DIFF
--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -40,7 +40,7 @@ env_vars["KNACK_API_KEY"] = atd_knack_auth[app_name][env]["api_key"]
 with DAG(
     dag_id="atd_knack_banner",
     default_args=default_args, #check this
-    schedule_interval="0 5 * * 0", #todo: update, weekly on sunday? when
+    schedule_interval="0 5 * * 0", # is a weekly on sunday update enough?
     dagrun_timeout=timedelta(minutes=60),
     tags=["production", "knack", "banner"],
     catchup=False,
@@ -48,13 +48,13 @@ with DAG(
     t1 = DockerOperator(
         task_id="atd_knack_banner_update_employees",
         image=docker_image,
-        api_version="auto", #check this
-        auto_remove=True, #and this
+        api_version="auto",
+        auto_remove=True,
         command=f'./atd-knack-banner/update_employees.py',  # noqa:E501
-        docker_url="tcp://localhost:2376", #check this
-        network_mode="bridge", # check this
+        docker_url="tcp://localhost:2376", # check this
+        network_mode="bridge",
         environment=env_vars,
-        tty=True, #hm?
+        tty=True,
     )
 
     t1

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -16,30 +16,27 @@ default_args = {
     "on_failure_callback": task_fail_slack_alert,
 }
 
-docker_image = "atddocker/atd-knack-banner" # the old one said atd-knack-services:production, what is the : for?
+docker_image = "atddocker/atd-knack-banner"
 
 # command args
 app_name = "hr"
 env = "prod"
 
 # assemble env vars
-env_vars = Variable.get("atd_knack_services_postgrest", deserialize_json=True) # check the format of this
-env_vars = {} # ? 
+env_vars = Variable.get("atd_knack_banner", deserialize_json=True)
 atd_knack_auth = Variable.get("atd_knack_auth", deserialize_json=True)
+atd_shared_drive = Variable.get("atd_shared_drive", deserialize_json=True)
 env_vars["KNACK_APP_NAME"] = app_name
 env_vars["KNACK_APP_ID"] = atd_knack_auth[app_name][env]["app_id"]
 env_vars["KNACK_API_KEY"] = atd_knack_auth[app_name][env]["api_key"]
-
-# BANNER_API_KEY=
-# BANNER_URL=
-# SHAREDDRIVE_USERNAME=
-# SHAREDDRIVE_PASSWORD=
-# SHAREDDRIVE_FILEPATH=
+env_vars["SHAREDDRIVE_USERNAME"] = atd_shared_drive["SHAREDDRIVE_USERNAME"]
+env_vars["SHAREDDRIVE_PASSWORD"] = atd_shared_drive["SHAREDDRIVE_PASSWORD"]
+env_vars["SHAREDDRIVE_FILEPATH"] = atd_shared_drive["SHAREDDRIVE_FILEPATH"]
 
 
 with DAG(
     dag_id="atd_knack_banner",
-    default_args=default_args, #check this
+    default_args=default_args,
     schedule_interval="0 5 * * 0", # is a weekly on sunday update enough?
     dagrun_timeout=timedelta(minutes=60),
     tags=["production", "knack", "banner"],

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -48,7 +48,7 @@ with DAG(
         api_version="auto",
         auto_remove=True,
         command=f'./atd-knack-banner/update_employees.py',  # noqa:E501
-        docker_url="tcp://localhost:2376", # check this
+        docker_url="tcp://localhost:2376",
         network_mode="bridge",
         environment=env_vars,
         tty=True,

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timedelta
+from airflow.models import DAG
+from airflow.models import Variable
+from airflow.operators.docker_operator import DockerOperator
+from _slack_operators import task_fail_slack_alert
+
+default_args = {
+    "owner": "airflow",
+    "description": "Fetch data from banner and hr emails and update knack HR app",  # noqa:E501
+    "depend_on_past": False,
+    "start_date": datetime(2021, 9, 15),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+docker_image = "atddocker/atd-knack-banner" # the old one said atd-knack-services:production, what is the : for?
+
+# command args
+app_name = "hr"
+env = "prod"
+
+# assemble env vars
+env_vars = Variable.get("atd_knack_services_postgrest", deserialize_json=True) # check the format of this
+env_vars = {} # ? 
+atd_knack_auth = Variable.get("atd_knack_auth", deserialize_json=True)
+env_vars["KNACK_APP_NAME"] = app_name
+env_vars["KNACK_APP_ID"] = atd_knack_auth[app_name][env]["app_id"]
+env_vars["KNACK_API_KEY"] = atd_knack_auth[app_name][env]["api_key"]
+
+# BANNER_API_KEY=
+# BANNER_URL=
+# SHAREDDRIVE_USERNAME=
+# SHAREDDRIVE_PASSWORD=
+# SHAREDDRIVE_FILEPATH=
+
+
+with DAG(
+    dag_id="atd_knack_banner",
+    default_args=default_args, #check this
+    schedule_interval="0 5 * * 0", #todo: update, weekly on sunday? when
+    dagrun_timeout=timedelta(minutes=60),
+    tags=["production", "knack", "banner"],
+    catchup=False,
+) as dag:
+    t1 = DockerOperator(
+        task_id="atd_knack_banner_update_employees",
+        image=docker_image,
+        api_version="auto", #check this
+        auto_remove=True, #and this
+        command=f'./atd-knack-banner/update_employees.py',  # noqa:E501
+        docker_url="tcp://localhost:2376", #check this
+        network_mode="bridge", # check this
+        environment=env_vars,
+        tty=True, #hm?
+    )
+
+    t1
+
+if __name__ == "__main__":
+    dag.cli()

--- a/docker-images.json
+++ b/docker-images.json
@@ -6,6 +6,7 @@
     "atddocker/atd-service-bot",
     "atddocker/atd-finance-data",
     "atddocker/atd-road-conditions",
-    "atddocker/atd-kits"
+    "atddocker/atd-kits",
+    "atddocker/atd-knack-banner"
   ]
 }


### PR DESCRIPTION
Knack banner PR: https://github.com/cityofaustin/atd-knack-banner/pull/1

This dag cannot be started until atd-knack-banner docker image is in atddocker hub.

I've added the new environment variables to the airflow variable list. 