### PR TITLE
change knack banner run time

### DIFF
--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -37,7 +37,7 @@ env_vars["SHAREDDRIVE_FILEPATH"] = atd_shared_drive["SHAREDDRIVE_FILEPATH"]
 with DAG(
     dag_id="atd_knack_banner",
     default_args=default_args,
-    schedule_interval="45 12 * * *",
+    schedule_interval="0 8 * * *",
     dagrun_timeout=timedelta(minutes=60),
     tags=["production", "knack", "banner"],
     catchup=False,

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -37,7 +37,7 @@ env_vars["SHAREDDRIVE_FILEPATH"] = atd_shared_drive["SHAREDDRIVE_FILEPATH"]
 with DAG(
     dag_id="atd_knack_banner",
     default_args=default_args,
-    schedule_interval="0 12 * * *",
+    schedule_interval="45 12 * * *",
     dagrun_timeout=timedelta(minutes=60),
     tags=["production", "knack", "banner"],
     catchup=False,


### PR DESCRIPTION
The dag was running smoothly at 7am everyday, but since the time change, it now runs at 6am. And for some reason does not like running at 6am. 

Changing the time to 6:45am local time. 