### PR TITLE
change knack banner time to 645a

### DIFF
--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -37,7 +37,7 @@ env_vars["SHAREDDRIVE_FILEPATH"] = atd_shared_drive["SHAREDDRIVE_FILEPATH"]
 with DAG(
     dag_id="atd_knack_banner",
     default_args=default_args,
-    schedule_interval="0 8 * * *",
+    schedule_interval="45 12 * * *",
     dagrun_timeout=timedelta(minutes=60),
     tags=["production", "knack", "banner"],
     catchup=False,


### PR DESCRIPTION
Endpoint is unavailable from is unavailable from 4-6am while they refresh their tables.

Changing the time to 6:45a to get the new data from banner. 