### PR TITLE
move knack banner dag to one hour later

### DIFF
--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -37,7 +37,7 @@ env_vars["SHAREDDRIVE_FILEPATH"] = atd_shared_drive["SHAREDDRIVE_FILEPATH"]
 with DAG(
     dag_id="atd_knack_banner",
     default_args=default_args,
-    schedule_interval="45 12 * * *",
+    schedule_interval="45 13 * * *",
     dagrun_timeout=timedelta(minutes=60),
     tags=["production", "knack", "banner"],
     catchup=False,


### PR DESCRIPTION
Still failing at 6:45a, but when I run manually after 7:30a it works. Raul said the endpoint was unavailable from 4a-6a, but maybe the window of unavailability is wider than that. Pushing it to be 7:45a. 