### PR TITLE
Move daily inventory snapshot to a separate DAG and restore previous inventory DAG

### DIFF
--- a/dags/atd_knack_inventory_daily_status.py
+++ b/dags/atd_knack_inventory_daily_status.py
@@ -1,0 +1,79 @@
+from copy import deepcopy
+from datetime import datetime, timedelta
+from airflow.models import DAG
+from airflow.models import Variable
+from airflow.operators.docker_operator import DockerOperator
+from _slack_operators import task_fail_slack_alert
+
+default_args = {
+    "owner": "airflow",
+    "description": "Append inventory item counts in the Data Tracker to Socrata open dataset",
+    "depend_on_past": False,
+    "start_date": datetime(2020, 9, 1),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+docker_image = "atddocker/atd-knack-services:production"
+app_name = "data-tracker"
+container = "view_2863"
+env = "prod"
+
+# assemble env vars
+env_vars = Variable.get("atd_knack_services_postgrest", deserialize_json=True)
+atd_knack_auth = Variable.get("atd_knack_auth", deserialize_json=True)
+env_vars["SOCRATA_API_KEY_ID"] = Variable.get("atd_service_bot_socrata_api_key_id")
+env_vars["SOCRATA_API_KEY_SECRET"] = Variable.get(
+    "atd_service_bot_socrata_api_key_secret"
+)
+env_vars["KNACK_APP_ID"] = atd_knack_auth[app_name][env]["app_id"]
+env_vars["KNACK_API_KEY"] = atd_knack_auth[app_name][env]["api_key"]
+
+with DAG(
+    dag_id="atd_knack_inventory_items_nightly_snapshot",
+    default_args=default_args,
+    schedule_interval="13 4 * * *",  # at 4:13am UTC
+    dagrun_timeout=timedelta(minutes=300),
+    tags=["production", "knack"],
+    catchup=False,
+) as dag:
+    """
+    Push Data Tracker inventory items to PostgREST. We always push all records (by setting
+    data to 1970-01-01) because it is required to create a snapshot of the
+    inventory quantities on-hand.
+    """
+    t1 = DockerOperator(
+        task_id="atd_knack_data_tracker_inventory_items_to_postgrest",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f'./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} -d "1970-01-01"',  # noqa
+        docker_url="tcp://localhost:2376",
+        network_mode="bridge",
+        environment=env_vars,
+        tty=True,
+    )
+    """
+    Append Data Tracker inventory items snapshot to Socrata. This creates a daily running
+    on-hand quantity report.
+    See: https://github.com/cityofaustin/atd-data-tech/issues/7581
+    """
+    t2 = DockerOperator(
+        task_id="atd_knack_data_tracker_inventory_items_daily_snapshot_to_socrata",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f'./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} -d "1970-01-01"',  # noqa
+        docker_url="tcp://localhost:2376",
+        network_mode="bridge",
+        environment=env_vars,
+        tty=True,
+    )
+
+    t1 >> t2
+
+if __name__ == "__main__":
+    dag.cli()

--- a/dags/atd_knack_inventory_items.py
+++ b/dags/atd_knack_inventory_items.py
@@ -27,10 +27,6 @@ env = "prod"
 # assemble env vars
 env_vars = Variable.get("atd_knack_services_postgrest", deserialize_json=True)
 atd_knack_auth = Variable.get("atd_knack_auth", deserialize_json=True)
-env_vars["SOCRATA_API_KEY_ID"] = Variable.get("atd_service_bot_socrata_api_key_id")
-env_vars["SOCRATA_API_KEY_SECRET"] = Variable.get(
-    "atd_service_bot_socrata_api_key_secret"
-)
 
 with DAG(
     dag_id="atd_knack_inventory_items_finance_to_data_tracker",
@@ -42,9 +38,6 @@ with DAG(
 ) as dag:
 
     date = "{{ prev_execution_date_success or '1970-01-01' }}"
-    """
-    Push Finance & Purchasing inventory items to PostgREST
-    """
     env_vars_t1 = deepcopy(env_vars)
     env_vars_t1["KNACK_APP_ID"] = atd_knack_auth[app_name_src][env]["app_id"]
     env_vars_t1["KNACK_API_KEY"] = atd_knack_auth[app_name_src][env]["api_key"]
@@ -60,11 +53,7 @@ with DAG(
         environment=env_vars_t1,
         tty=True,
     )
-    """
-    Push Data Tracker inventory items to PostgREST. We always push all records (by setting
-    data to 1970-01-01) because it is required for task #4—to create a snapshot of the
-    inventory quantities on-hand.
-    """
+
     env_vars_t2 = deepcopy(env_vars)
     env_vars_t2["KNACK_APP_ID"] = atd_knack_auth[app_name_dest][env]["app_id"]
     env_vars_t2["KNACK_API_KEY"] = atd_knack_auth[app_name_dest][env]["api_key"]
@@ -74,16 +63,13 @@ with DAG(
         image=docker_image,
         api_version="auto",
         auto_remove=True,
-        command=f'./atd-knack-services/services/records_to_postgrest.py -a {app_name_dest} -c {container_dest} -d "1970-01-01"',  # noqa
+        command=f'./atd-knack-services/services/records_to_postgrest.py -a {app_name_dest} -c {container_dest} -d "{date}"',  # noqa
         docker_url="tcp://localhost:2376",
         network_mode="bridge",
         environment=env_vars_t2,
         tty=True,
     )
 
-    """
-    Update Data Tracker inventory items based from Finance & Purchasing system inventory items
-    """
     env_vars["KNACK_APP_ID_SRC"] = atd_knack_auth[app_name_src][env]["app_id"]
     env_vars["KNACK_APP_ID_DEST"] = atd_knack_auth[app_name_dest][env]["app_id"]
     env_vars["KNACK_API_KEY_DEST"] = atd_knack_auth[app_name_dest][env]["api_key"]
@@ -99,28 +85,8 @@ with DAG(
         environment=env_vars,
         tty=True,
     )
-    """
-    Append Data Tracker inventory items snapshot to Socrata. This creates a daily running
-    on-hand quantity report.
-    See: https://github.com/cityofaustin/atd-data-tech/issues/7581
-    """
-    env_vars_t4 = deepcopy(env_vars)
-    env_vars_t4["KNACK_APP_ID"] = atd_knack_auth[app_name_dest][env]["app_id"]
-    env_vars_t4["KNACK_API_KEY"] = atd_knack_auth[app_name_dest][env]["api_key"]
 
-    t4 = DockerOperator(
-        task_id="atd_knack_data_tracker_inventory_items_daily_snapshot_to_socrata",
-        image=docker_image,
-        api_version="auto",
-        auto_remove=True,
-        command=f'./atd-knack-services/services/records_to_socrata.py -a {app_name_dest} -c {container_dest} -d "1970-01-01"',  # noqa
-        docker_url="tcp://localhost:2376",
-        network_mode="bridge",
-        environment=env_vars_t4,
-        tty=True,
-    )
-
-    t1 >> t2 >> t3 >> t4
+    t1 >> t2 >> t3
 
 if __name__ == "__main__":
     dag.cli()


### PR DESCRIPTION
This PR reverts #84. It restores the original [`atd_knack_inventory_items.py`](https://github.com/cityofaustin/atd-airflow/blob/master/dags/atd_knack_inventory_items.py) DAG and moves the snapshot task to a separate DAG. It is a second attempt to complete https://github.com/cityofaustin/atd-data-tech/issues/7581.

The problem is that `atd_knack_inventory_items.py` is scheduled to run multiple times per day (it keeps inventory items in sync between the Finance & Purchasing System and the Data Tracker). The new daily inventory snapshot task should only run once a day, because it must only append one new set of inventory records **per day** to the [open dataset](https://data.austintexas.gov/Transportation-and-Mobility/Arterial-Management-Materials-Warehouse-Inventory/hcaw-evi2).