### PR TITLE
Add boto3 to airflow image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+production_env
 
 # Spyder project settings
 .spyderproject

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN set -ex \
     && pip install pdf2image \
     && pip install pytesseract \
     && pip install boto3 \
+    && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,s3,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
     && pip install 'redis==3.2' \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN set -ex \
     && pip install SQLAlchemy \
     && pip install pdf2image \
     && pip install pytesseract \
-    && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,s3,ssh${AIRFLOW_DEPS:+,}${AIRFLOW_DEPS}]==${AIRFLOW_VERSION} \
+    && pip install boto3 \
     && pip install 'redis==3.2' \
     && if [ -n "${PYTHON_DEPS}" ]; then pip install ${PYTHON_DEPS}; fi \
     && apt-get purge --auto-remove -yqq $buildDeps \

--- a/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
+++ b/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
@@ -285,7 +285,7 @@ for crash in response.json()['data']['atd_txdot_crashes']:
             crash['cr3_file_metadata']['diagram_s3_file'] = str(diagram_uuid) + '.png'
             update_crash_metadata(crash['crash_id'], crash['cr3_file_metadata'])
         except:
-            sys.stderr.write("Error: Faild setting s3 object containing the diagram PNG file\n")
+            sys.stderr.write("Error: Failed setting s3 object containing the diagram PNG file\n")
             continue
 
     # do we want to save a PNG file from the image data to disk?
@@ -296,7 +296,7 @@ for crash in response.json()['data']['atd_txdot_crashes']:
             path = args.save_diagram_disk[0] + '/' + str(crash['crash_id']) + '.png'
             diagram_image.save(path)
         except:
-            sys.stderr.write("Error: Faild diagram PNG file to disk\n")
+            sys.stderr.write("Error: Failed diagram PNG file to disk\n")
 
 
     # do we want to store the OCR'd text results from the attempt in the database for the current crash id?


### PR DESCRIPTION
## Overview
This is a minor change that came out of building the airflow image locally to investigate the OCR mechanism used on VZ CR3 files. Included are the following changes:

* Add boto3 to the airflow image. I imagine it was added by one of us who built and published the image to dockerhub, but the change to the dockerfile didn't make it back into this repo.
* Two corrections for spelling errors in comments
* The addition of an environment file name that is more descriptive to where it points and is not hidden as a system file. This gives us a place to keep environment variable files in our local checkout without fear of checking them in one day by mistake.
