### PR TITLE
update restart policy in docker compose

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -30,7 +30,7 @@ services:
             args:
                 airflow_configuration: config/airflow-dev.cfg
                 airflow_environment: development
-        restart: always
+        restart: unless-stopped
         depends_on:
             - postgres
         environment:

--- a/docker-compose-localexecutor.yml
+++ b/docker-compose-localexecutor.yml
@@ -56,7 +56,7 @@ services:
             - 8080
             - 5555
             - 8793
-        restart: always
+        restart: unless-stopped
         depends_on:
             - postgres
             - redis


### PR DESCRIPTION
This PR is a reflection of what Frank edited manually when fixing the airflow setup (https://github.com/cityofaustin/atd-data-tech/issues/9299)

Since the airflow repo is pulled down every 5 minutes by a cron job, the new configuration was being reset. 