### PR TITLE
Update OCR script in anticipation of new CR3 format

### DIFF
--- a/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
+++ b/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
@@ -5,27 +5,60 @@ import os
 import re
 import sys
 import json
-from   uuid import uuid4
+from uuid import uuid4
 import boto3
 import argparse
 import requests
-from   pdf2image import convert_from_path, convert_from_bytes
+from pdf2image import convert_from_path, convert_from_bytes
 import pytesseract
 
 # Configure the available arguments to the program
-parser = argparse.ArgumentParser(description='Extract CR3 diagrams and narratives')
-parser.add_argument('-v', action='store_true', help='Be verbose')
-parser.add_argument('-d', action='store_true', help='Check for digitally created PDFs')
-parser.add_argument('--cr3-source', metavar=('bucket', 'path'), nargs=2, required=True, help='Where can we hope to find CR3 files on S3?')
-parser.add_argument('--batch-size', metavar='int', default=1, help='How many cr3s to attempt to process?')
-parser.add_argument('--update-narrative', action='store_true', help='Update narrative in database')
-parser.add_argument('--update-timestamp', action='store_true', help='Update timestamp in database')
-parser.add_argument('--save-diagram-s3', metavar=('bucket', 'path'), nargs=2, help='Save diagram PNG in a S3 bucket and path')
-parser.add_argument('--save-diagram-disk', metavar=('path'), nargs=1, help='Save diagram PNG to disk in a certain directory')
-parser.add_argument('--crash-id', metavar='int', type=int, nargs=1, default=[0], help='Specific crash ID to operate on')
+parser = argparse.ArgumentParser(description="Extract CR3 diagrams and narratives")
+parser.add_argument("-v", action="store_true", help="Be verbose")
+parser.add_argument("-d", action="store_true", help="Check for digitally created PDFs")
+parser.add_argument(
+    "--cr3-source",
+    metavar=("bucket", "path"),
+    nargs=2,
+    required=True,
+    help="Where can we hope to find CR3 files on S3?",
+)
+parser.add_argument(
+    "--batch-size",
+    metavar="int",
+    default=1,
+    help="How many cr3s to attempt to process?",
+)
+parser.add_argument(
+    "--update-narrative", action="store_true", help="Update narrative in database"
+)
+parser.add_argument(
+    "--update-timestamp", action="store_true", help="Update timestamp in database"
+)
+parser.add_argument(
+    "--save-diagram-s3",
+    metavar=("bucket", "path"),
+    nargs=2,
+    help="Save diagram PNG in a S3 bucket and path",
+)
+parser.add_argument(
+    "--save-diagram-disk",
+    metavar=("path"),
+    nargs=1,
+    help="Save diagram PNG to disk in a certain directory",
+)
+parser.add_argument(
+    "--crash-id",
+    metavar="int",
+    type=int,
+    nargs=1,
+    default=[0],
+    help="Specific crash ID to operate on",
+)
 args = parser.parse_args()
 
-s3 = boto3.client('s3')
+s3 = boto3.client("s3")
+
 
 def update_crash_processed_date(crash_id: int) -> bool:
     """
@@ -34,7 +67,7 @@ def update_crash_processed_date(crash_id: int) -> bool:
     :param int: crash_id
     """
 
-    if (args.v):
+    if args.v:
         print("update_crash_processed_date(" + str(crash_id) + ")")
     query = """
     mutation update_crash_processsed_date($crash_id: Int) {
@@ -48,15 +81,10 @@ def update_crash_processed_date(crash_id: int) -> bool:
         headers={
             "Accept": "*/*",
             "content-type": "application/json",
-            "x-hasura-admin-secret": os.getenv("HASURA_ADMIN_KEY")
-            },
-        json={
-            "query": query,
-            "variables": {
-                "crash_id": crash_id
-                }
-            }
-        )
+            "x-hasura-admin-secret": os.getenv("HASURA_ADMIN_KEY"),
+        },
+        json={"query": query, "variables": {"crash_id": crash_id}},
+    )
     try:
         return response.json()["data"]["update_atd_txdot_crashes"]["affected_rows"] > 0
     except (KeyError, TypeError):
@@ -84,21 +112,19 @@ def update_crash_narrative(crash_id: int, narrative: str) -> bool:
         headers={
             "Accept": "*/*",
             "content-type": "application/json",
-            "x-hasura-admin-secret": os.getenv("HASURA_ADMIN_KEY")
-            },
+            "x-hasura-admin-secret": os.getenv("HASURA_ADMIN_KEY"),
+        },
         json={
             "query": query,
-            "variables": {
-                "crash_id": crash_id,
-                "narrative": narrative
-                }
-            }
-        )
+            "variables": {"crash_id": crash_id, "narrative": narrative},
+        },
+    )
     try:
         return response.json()["data"]["update_atd_txdot_crashes"]["affected_rows"] > 0
     except (KeyError, TypeError):
         sys.stderr.write("ERROR")
         sys.stderr.write(response.json())
+
 
 def update_crash_metadata(crash_id: int, metadata: dict) -> bool:
     """
@@ -120,16 +146,13 @@ def update_crash_metadata(crash_id: int, metadata: dict) -> bool:
         headers={
             "Accept": "*/*",
             "content-type": "application/json",
-            "x-hasura-admin-secret": os.getenv("HASURA_ADMIN_KEY")
-            },
+            "x-hasura-admin-secret": os.getenv("HASURA_ADMIN_KEY"),
+        },
         json={
             "query": query,
-            "variables": {
-                "crash_id": crash_id,
-                "metadata": metadata
-                }
-            }
-        )
+            "variables": {"crash_id": crash_id, "metadata": metadata},
+        },
+    )
     try:
         return response.json()["data"]["update_atd_txdot_crashes"]["affected_rows"] > 0
     except (KeyError, TypeError):
@@ -153,7 +176,7 @@ query find_cr3s($limit: Int) {
   }
 }
 """
-batch_variables = { "limit": int(args.batch_size) }
+batch_variables = {"limit": int(args.batch_size)}
 
 get_single_cr3 = """
 query find_cr3s($crash_id: Int, $limit: Int) {
@@ -167,12 +190,12 @@ query find_cr3s($crash_id: Int, $limit: Int) {
   }
 }
 """
-single_cr3_variables = { "crash_id": args.crash_id[0], "limit": int(args.batch_size) }
+single_cr3_variables = {"crash_id": args.crash_id[0], "limit": int(args.batch_size)}
 
-graphql = ''
+graphql = ""
 variables = {}
 
-if (args.crash_id[0]):
+if args.crash_id[0]:
     graphql = get_single_cr3
     variables = single_cr3_variables
 else:
@@ -180,31 +203,28 @@ else:
     variables = batch_variables
 
 response = requests.post(
-  url=os.getenv("HASURA_ENDPOINT"),
-  headers={
-    "Accept": "*/*",
-    "content-type": "application/json",
-    "x-hasura-admin-secret": os.getenv("HASURA_ADMIN_KEY")
+    url=os.getenv("HASURA_ENDPOINT"),
+    headers={
+        "Accept": "*/*",
+        "content-type": "application/json",
+        "x-hasura-admin-secret": os.getenv("HASURA_ADMIN_KEY"),
     },
-  json={
-    "query": graphql,
-    "variables": variables
-    }
-  )
+    json={"query": graphql, "variables": variables},
+)
 
-for crash in response.json()['data']['atd_txdot_crashes']:
+for crash in response.json()["data"]["atd_txdot_crashes"]:
     # be verbose
-    if (args.v):
-        print('Preparing to operate on crash_id: ' + str(crash['crash_id']))
+    if args.v:
+        print("Preparing to operate on crash_id: " + str(crash["crash_id"]))
 
     # do we want to indicate in the database that an attempt was made to process the CR3.
-    if (args.update_timestamp):
-        update_crash_processed_date(crash['crash_id'])
+    if args.update_timestamp:
+        update_crash_processed_date(crash["crash_id"])
 
     # build url and download the CR3
-    if (args.v):
-        print('Pulling CR3 PDF from S3');
-    key = args.cr3_source[1] + '/' + str(crash['crash_id']) + '.pdf'
+    if args.v:
+        print("Pulling CR3 PDF from S3")
+    key = args.cr3_source[1] + "/" + str(crash["crash_id"]) + ".pdf"
     obj = []
     try:
         pdf = s3.get_object(Bucket=args.cr3_source[0], Key=key)
@@ -213,97 +233,114 @@ for crash in response.json()['data']['atd_txdot_crashes']:
         continue
 
     # render the pdf into an array of raster images
-    if (args.v):
-        print('Rendering PDF into images');
+    if args.v:
+        print("Rendering PDF into images")
     pages = []
     try:
-        pages = convert_from_bytes(pdf['Body'].read(), 150)
-    except: 
-        sys.stderr.write("Error: PDF Read for crash_id (" + str(crash['crash_id']) + ") failed.\n")
+        pages = convert_from_bytes(pdf["Body"].read(), 150)
+    except:
+        sys.stderr.write(
+            "Error: PDF Read for crash_id (" + str(crash["crash_id"]) + ") failed.\n"
+        )
         continue
 
-
-    if (args.d):
-        if (args.v):
-            print('Excuting a check for a digitally created PDF');
+    if args.d:
+        if args.v:
+            print("Excuting a check for a digitally created PDF")
         digital_end_to_end = True
         # these pixels are expected to be black on digitally created PDFs
-        pixels = [(110,3520), (3080, 3046), (3050, 2264), (2580, 6056), (1252, 154), (2582, 4166), (1182, 1838)]
+        pixels = [
+            (110, 3520),
+            (3080, 3046),
+            (3050, 2264),
+            (2580, 6056),
+            (1252, 154),
+            (2582, 4166),
+            (1182, 1838),
+        ]
         for pixel in pixels:
             rgb_pixel = pages[1].getpixel(pixel)
-            if not(rgb_pixel[0] == 0 and rgb_pixel[1] == 0 and rgb_pixel[2] == 0):
+            if not (rgb_pixel[0] == 0 and rgb_pixel[1] == 0 and rgb_pixel[2] == 0):
                 digital_end_to_end = False
-            if (args.v):
-                print('Pixel' + "(%04d,%04d)" % pixel + ': ' + str(rgb_pixel))
-        if (args.v):
-            print('PDF Digital End to End?: ' + str(digital_end_to_end));
-        if not(digital_end_to_end):
-            if (args.v):
+            if args.v:
+                print("Pixel" + "(%04d,%04d)" % pixel + ": " + str(rgb_pixel))
+        if args.v:
+            print("PDF Digital End to End?: " + str(digital_end_to_end))
+        if not (digital_end_to_end):
+            if args.v:
                 sys.stderr.write("Error: Non-digitally created PDF detected.\n")
             continue
 
-
     # crop out the narrative and diagram into PIL.Image objects
-    if (args.v):
-        print('Cropping narrative and diagram from images');
+    if args.v:
+        print("Cropping narrative and diagram from images")
     try:
-        narrative_image = pages[1].crop((96,3683,2580,6049))
-        diagram_image = pages[1].crop((2589,3531,5001,6048))
+        narrative_image = pages[1].crop((96, 3683, 2580, 6049))
+        diagram_image = pages[1].crop((2589, 3531, 5001, 6048))
     except:
-        sys.stderr.write("Error: Failed to extract the image of the narative and diagram from image in memory\n")
+        sys.stderr.write(
+            "Error: Failed to extract the image of the narative and diagram from image in memory\n"
+        )
         continue
 
-
     # use tesseract to OCR the text
-    if (args.v):
-        print('OCRing narrative')
-    narrative = ''
+    if args.v:
+        print("OCRing narrative")
+    narrative = ""
     try:
-        narrative = (pytesseract.image_to_string(narrative_image))
-        if (args.v):
+        narrative = pytesseract.image_to_string(narrative_image)
+        if args.v:
             print("Extracted Text:\n")
             print(narrative)
     except:
         sys.stderr.write("Error: Failed to OCR the narrative\n")
         continue
 
-
     # do we want to save a PNG file from the image data that was cropped out where the crash diagram is expected to be?
-    if (args.save_diagram_s3):
+    if args.save_diagram_s3:
         diagram_uuid = uuid4()
-        if (args.v):
-            print('Saving PNG of diagram to S3')
+        if args.v:
+            print("Saving PNG of diagram to S3")
         try:
             # never touch the disk; store the image data in a few steps to get to a variable of binary data
             buffer = io.BytesIO()
-            diagram_image.save(buffer, format='PNG')
-            output_diagram = s3.put_object(Body=buffer.getvalue(), Bucket=args.save_diagram_s3[0], Key=args.save_diagram_s3[1] + '/' + str(diagram_uuid) + '.png')
-            if (args.v):
-                print("update_crash_metadata(crash_id: " + str(crash['crash_id']) + ", ...) with diagram filename")
-            if not(isinstance(crash['cr3_file_metadata'], dict)):
-                crash['cr3_file_metadata'] = {}
-            crash['cr3_file_metadata']['diagram_s3_file'] = str(diagram_uuid) + '.png'
-            update_crash_metadata(crash['crash_id'], crash['cr3_file_metadata'])
+            diagram_image.save(buffer, format="PNG")
+            output_diagram = s3.put_object(
+                Body=buffer.getvalue(),
+                Bucket=args.save_diagram_s3[0],
+                Key=args.save_diagram_s3[1] + "/" + str(diagram_uuid) + ".png",
+            )
+            if args.v:
+                print(
+                    "update_crash_metadata(crash_id: "
+                    + str(crash["crash_id"])
+                    + ", ...) with diagram filename"
+                )
+            if not (isinstance(crash["cr3_file_metadata"], dict)):
+                crash["cr3_file_metadata"] = {}
+            crash["cr3_file_metadata"]["diagram_s3_file"] = str(diagram_uuid) + ".png"
+            update_crash_metadata(crash["crash_id"], crash["cr3_file_metadata"])
         except:
-            sys.stderr.write("Error: Failed setting s3 object containing the diagram PNG file\n")
+            sys.stderr.write(
+                "Error: Failed setting s3 object containing the diagram PNG file\n"
+            )
             continue
 
     # do we want to save a PNG file from the image data to disk?
-    if (args.save_diagram_disk):
-        if (args.v):
-            print('Saving PNG of diagram to disk')
+    if args.save_diagram_disk:
+        if args.v:
+            print("Saving PNG of diagram to disk")
         try:
-            path = args.save_diagram_disk[0] + '/' + str(crash['crash_id']) + '.png'
+            path = args.save_diagram_disk[0] + "/" + str(crash["crash_id"]) + ".png"
             diagram_image.save(path)
         except:
             sys.stderr.write("Error: Failed diagram PNG file to disk\n")
 
-
     # do we want to store the OCR'd text results from the attempt in the database for the current crash id?
-    if (args.update_narrative):
-        update_crash_narrative(crash['crash_id'], narrative)
+    if args.update_narrative:
+        update_crash_narrative(crash["crash_id"], narrative)
 
-    '''
+    """
     if (args.save_diagram_s3 and args.update_narrative):
         if (args.v):
             print("update_crash_metadata(crash_id: " + str(crash['crash_id']) + ", ...) with success flag")
@@ -311,7 +348,7 @@ for crash in response.json()['data']['atd_txdot_crashes']:
             crash['cr3_file_metadata'] = {}
         crash['cr3_file_metadata']['successful_ocr_diagram_extraction'] = True
         update_crash_metadata(crash['crash_id'], crash['cr3_file_metadata'])
-    '''
+    """
 
-    if (args.v):
+    if args.v:
         print("\n")

--- a/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
+++ b/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
@@ -243,7 +243,8 @@ for crash in response.json()["data"]["atd_txdot_crashes"]:
         if args.v:
             print("Executing a check for a digitally created PDF")
         digital_end_to_end = True
-        new_cr3_form = False
+        # assume new cr3 form unless proven otherwise
+        new_cr3_form = True
         # these pixels are expected to be black on digitally created PDFs previous to 1/1/2023
         pixels = [
             (110, 3520),
@@ -261,18 +262,21 @@ for crash in response.json()["data"]["atd_txdot_crashes"]:
             (1690, 2574),
             (4834, 279)
         ]
-        if pages[1].size[0] < 5000:
-            new_cr3_form = True
-            if args.v:
-                print("CR3 created with new 2023 version format")
-        test_pixels = new_pixels if new_cr3_form else pixels
-        for pixel in test_pixels:
+        for pixel in new_pixels:
             rgb_pixel = pages[1].getpixel(pixel)
             if not (rgb_pixel[0] == 0 and rgb_pixel[1] == 0 and rgb_pixel[2] == 0):
-                digital_end_to_end = False
+                new_cr3_form = False
                 continue
             if args.v:
                 print("Pixel" + "(%04d,%04d)" % pixel + ": " + str(rgb_pixel))
+        if not new_cr3_form:
+            for pixel in pixels:
+                rgb_pixel = pages[1].getpixel(pixel)
+                if not (rgb_pixel[0] == 0 and rgb_pixel[1] == 0 and rgb_pixel[2] == 0):
+                    digital_end_to_end = False
+                    continue
+                if args.v:
+                    print("Pixel" + "(%04d,%04d)" % pixel + ": " + str(rgb_pixel))
         if args.v:
             print("PDF Digital End to End?: " + str(digital_end_to_end))
         if not digital_end_to_end:

--- a/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
+++ b/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
@@ -255,15 +255,13 @@ for crash in response.json()["data"]["atd_txdot_crashes"]:
             (1182, 1838),
         ]
         new_pixels = [
-            (140, 668),
-            (670, 388),
-            (288, 1364),
-            (1088, 1566),
-            (79, 1361),
-            (1216, 105),
+            (215, 2567),
+            (872, 2568),
+            (3338, 3060),
+            (1690, 2574),
+            (4834, 279)
         ]
-        # new cr3 form size is 1275x1650
-        if pages[1].size[1] < 2000:
+        if pages[1].size[0] < 5000:
             new_cr3_form = True
             if args.v:
                 print("CR3 created with new 2023 version format")
@@ -287,8 +285,8 @@ for crash in response.json()["data"]["atd_txdot_crashes"]:
         print("Cropping narrative and diagram from images")
     try:
         if new_cr3_form:
-            narrative_image = pages[1].crop((80, 775, 655, 1356))
-            diagram_image = pages[1].crop((655, 775, 1215, 1356))
+            narrative_image = pages[1].crop((90, 3026, 2496, 5466))
+            diagram_image = pages[1].crop((2496, 3036, 4836, 5464))
         else:
             narrative_image = pages[1].crop((96, 3683, 2580, 6049))
             diagram_image = pages[1].crop((2589, 3531, 5001, 6048))

--- a/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
+++ b/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
@@ -265,6 +265,8 @@ for crash in response.json()["data"]["atd_txdot_crashes"]:
         # new cr3 form size is 1275x1650
         if pages[1].size[1] < 2000:
             new_cr3_form = True
+            if args.v:
+                print("CR3 created with new 2023 version format")
         test_pixels = new_pixels if new_cr3_form else pixels
         for pixel in test_pixels:
             rgb_pixel = pages[1].getpixel(pixel)
@@ -284,8 +286,12 @@ for crash in response.json()["data"]["atd_txdot_crashes"]:
     if args.v:
         print("Cropping narrative and diagram from images")
     try:
-        narrative_image = pages[1].crop((96, 3683, 2580, 6049))
-        diagram_image = pages[1].crop((2589, 3531, 5001, 6048))
+        if new_cr3_form:
+            narrative_image = pages[1].crop((80, 775, 655, 1356))
+            diagram_image = pages[1].crop((655, 775, 1215, 1356))
+        else:
+            narrative_image = pages[1].crop((96, 3683, 2580, 6049))
+            diagram_image = pages[1].crop((2589, 3531, 5001, 6048))
     except:
         sys.stderr.write(
             "Error: Failed to extract the image of the narative and diagram from image in memory\n"

--- a/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
+++ b/dags/python_scripts/cr3_extract_diagram_ocr_narrative.py
@@ -243,7 +243,8 @@ for crash in response.json()["data"]["atd_txdot_crashes"]:
         if args.v:
             print("Executing a check for a digitally created PDF")
         digital_end_to_end = True
-        # these pixels are expected to be black on digitally created PDFs
+        new_cr3_form = False
+        # these pixels are expected to be black on digitally created PDFs previous to 1/1/2023
         pixels = [
             (110, 3520),
             (3080, 3046),
@@ -253,10 +254,23 @@ for crash in response.json()["data"]["atd_txdot_crashes"]:
             (2582, 4166),
             (1182, 1838),
         ]
-        for pixel in pixels:
+        new_pixels = [
+            (140, 668),
+            (670, 388),
+            (288, 1364),
+            (1088, 1566),
+            (79, 1361),
+            (1216, 105),
+        ]
+        # new cr3 form size is 1275x1650
+        if pages[1].size[1] < 2000:
+            new_cr3_form = True
+        test_pixels = new_pixels if new_cr3_form else pixels
+        for pixel in test_pixels:
             rgb_pixel = pages[1].getpixel(pixel)
             if not (rgb_pixel[0] == 0 and rgb_pixel[1] == 0 and rgb_pixel[2] == 0):
                 digital_end_to_end = False
+                continue
             if args.v:
                 print("Pixel" + "(%04d,%04d)" % pixel + ": " + str(rgb_pixel))
         if args.v:


### PR DESCRIPTION
Related issue: 
https://github.com/cityofaustin/atd-data-tech/issues/9704

-- edited 4/4

Now that we have a copy of actual new cr3 forms, I reworked the script to check if the pixels are black on the newer cr3, as the pdfs are slightly different. If the pdf doesnt match up with the new pixels, then it goes to check in the old pixels. 

I tested this by downloading a new cr3 and checking the pixels and cropped image locally in a python console. I am not sure what the best way is to test the whole script, besides letting it run in production. 