### PR TITLE
11302 missing locations dag fails

### DIFF
--- a/dags/atd_visionzero_reassociate_missing_locations_production.py
+++ b/dags/atd_visionzero_reassociate_missing_locations_production.py
@@ -18,7 +18,8 @@ environment_vars = Variable.get("atd_visionzero_hasura_sql_production", deserial
 args = {
     "owner": "airflow",
     "start_date": days_ago(2),
-    "on_failure_callback": task_fail_slack_alert
+    "on_failure_callback": task_fail_slack_alert,
+    "retries": 2,
 }
 
 #

--- a/dags/python_scripts/atd_vzd_update_cr3_locations.py
+++ b/dags/python_scripts/atd_vzd_update_cr3_locations.py
@@ -71,7 +71,10 @@ def make_update() -> dict:
         }
     )
     response.encoding = "utf-8"
-    return response.json()
+    if response.status_code == 200:
+        return response.json()
+    else:
+        return {"errors": {"status_code": response.status_code, "reason": response.reason}}
 
 
 def main():


### PR DESCRIPTION
Triaged this faililng dag and the current error message we get is from the `response.json()` error and not the scripts error

The real fix is to refactor the SQL part to be more efficient (https://github.com/cityofaustin/atd-data-tech/issues/11302)

In the meantime, I'm opening this to improve the error logging and adding a retry. When I run the python script locally it doesn't time out consistently. 

The new error message will look like this (but with the airflow stuff in front)
```
Hasura Endpoint: https://vzd.austinmobility.io/v1/query
Please wait, this could take a minute or two.
Response: 
{"errors": {"status_code": 504, "reason": "Gateway Time-out"}}
Error detected, exiting...

Process finished with exit code 1
```

instead of 

```
[2023-01-30 03:01:49,558] {{bash_operator.py:126}} INFO - Hasura Endpoint: https://vzd.austinmobility.io/v1/query
[2023-01-30 03:01:49,558] {{bash_operator.py:126}} INFO - Please wait, this could take a minute or two.
[2023-01-30 03:01:49,558] {{bash_operator.py:126}} INFO - Response:
[2023-01-30 03:01:49,558] {{bash_operator.py:126}} INFO - {"errors": "Expecting value: line 1 column 1 (char 0)"}
[2023-01-30 03:01:49,558] {{bash_operator.py:126}} INFO - Error detected, exiting...
[2023-01-30 03:01:49,582] {{bash_operator.py:130}} INFO - Command exited with return code 1
```
