### PR TITLE
Have docker auto-remove containers when they finish

### DIFF
--- a/dags/weather.py
+++ b/dags/weather.py
@@ -54,7 +54,8 @@ def etl_weather():
             image=docker_image, 
             # this docker image needs a place to write its output. the path is as seen from the host
             # server, because we've passed down the docker socket into the container running the flow.
-            volumes=[AIRFLOW_CHECKOUT_PATH + '/weather:/opt/weather']
+            volumes=[AIRFLOW_CHECKOUT_PATH + '/weather:/opt/weather'],
+            auto_remove=True,
             )
         return str(logs)
 


### PR DESCRIPTION
This change is in response to a `docker system prune` that took ages earlier on data03. There is nothing inherently wrong with leaving the containers hanging around after they have quit, but this is just a little tidier.

With approval, this will merge into the main `airflow-v2` branch, which is standing as `main` until it gets itself into `main`.  I'll take that approval and PR `airflow-v2` into `production`, and then trigger the webhook via smee, so this will be a nice test of that system as well, as it stands now in production.