### PR TITLE
Pin Python Library Versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-onepasswordconnectsdk
-docker
+onepasswordconnectsdk==1.*
+docker=6.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 onepasswordconnectsdk==1.*
-docker=6.*
+docker==6.*


### PR DESCRIPTION
Based on a comment on PR #100 by @mddilley from @johnclary, this PR adds version pinning to the libraries we're bringing in on top of what is made available to us by the Airflow base image. These version choices are made by building the image a-new, and `grep`ing out the pertinent lines of `pip freeze` and then wildcarding after the major release. 