### PR TITLE
Make 1Password util for Airflow 2 DAGs to grab secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ docker compose down --volumes --remove-orphans
 
 ### 1Password utility
 
-The 1Password utility is a light wrapper of the 1PW SDK methods. The purpose of the utility is to reduce imports of the 1Password lib and vault ID in each DAG that requires vault secrets.
+The 1Password utility is a light wrapper of the [1Password Connect Python SDK](https://github.com/1Password/connect-sdk-python) methods. The purpose of the utility is to reduce imports of the 1Password library, its methods, and vault ID in each DAG that requires secrets.
 
 ### Slack operator utility
 
-The Slack operator utility makes use of the integration between the Airflow and a Slack app webhook. The purpose of the utility is to add failure notifications to DAGs using the [callback](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/callbacks.html#callback-types) parameters. Failure, critical failture, and success notifications are configured.
+The Slack operator utility makes use of the integration between the Airflow and a Slack app webhook. The purpose of the utility is to add Slack notifications to DAGs using the [callback](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/callbacks.html#callback-types) parameters. Failure, critical failure, and success notifications are implemented.
 
 ## Ideas
 * Make it disable all DAGs on start locally so it fails to safe

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ docker exec -it airflow-airflow-worker-1 bash
 docker compose down --volumes --remove-orphans
 ```
 
+## Utilities
+
+### 1Password utility
+
+The 1Password utility is a light wrapper of the 1PW SDK methods. The purpose of the utility is to reduce imports of the 1Password lib and vault ID in each DAG that requires vault secrets.
+
+### Slack operator utility
+
+The Slack operator utility makes use of the integration between the Airflow and a Slack app webhook. The purpose of the utility is to add failure notifications to DAGs using the [callback](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/callbacks.html#callback-types) parameters. Failure, critical failture, and success notifications are configured.
+
 ## Ideas
 * Make it disable all DAGs on start locally so it fails to safe
 * Fix UID being applied by `webhook` image on `git pull`

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -4,15 +4,10 @@ from datetime import datetime, timedelta
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
 
-from onepasswordconnectsdk.client import Client, new_client
-import onepasswordconnectsdk
-
 from utils.slack_operator import task_fail_slack_alert
+from utils.onepassword import load_dict
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
-ONEPASSWORD_CONNECT_HOST = os.getenv("OP_CONNECT")
-ONEPASSWORD_CONNECT_TOKEN = os.getenv("OP_API_TOKEN")
-VAULT_ID = os.getenv("OP_VAULT_ID")
 
 default_args = {
     "owner": "airflow",
@@ -31,22 +26,18 @@ REQUIRED_SECRETS = {
     "KNACK_APP_ID": {
         "opitem": "Service Bot",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.knackAppId",
-        "opvault": VAULT_ID,
     },
     "KNACK_API_KEY": {
         "opitem": "Service Bot",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.knackApiKey",
-        "opvault": VAULT_ID,
     },
     "GITHUB_ACCESS_TOKEN": {
         "opitem": "Service Bot",
         "opfield": "shared.githubAccessToken",
-        "opvault": VAULT_ID,
     },
 }
 
-client: Client = new_client(ONEPASSWORD_CONNECT_HOST, ONEPASSWORD_CONNECT_TOKEN)
-env_vars = onepasswordconnectsdk.load_dict(client, REQUIRED_SECRETS)
+env_vars = load_dict(REQUIRED_SECRETS)
 
 with DAG(
     dag_id=f"atd_service_bot_issues_to_dts_portal_{DEPLOYMENT_ENVIRONMENT}",

--- a/dags/atd_service_bot_intake.py
+++ b/dags/atd_service_bot_intake.py
@@ -26,27 +26,22 @@ REQUIRED_SECRETS = {
     "KNACK_APP_ID": {
         "opitem": "Service Bot",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.knackAppId",
-        "opvault": VAULT_ID,
     },
     "KNACK_API_KEY": {
         "opitem": "Service Bot",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.knackApiKey",
-        "opvault": VAULT_ID,
     },
     "GITHUB_ACCESS_TOKEN": {
         "opitem": "Service Bot",
         "opfield": "shared.githubAccessToken",
-        "opvault": VAULT_ID,
     },
     "KNACK_DTS_PORTAL_SERVICE_BOT_USERNAME": {
         "opitem": "Service Bot",
         "opfield": "shared.dtsPortalLoginEmail",
-        "opvault": VAULT_ID,
     },
     "KNACK_DTS_PORTAL_SERVICE_BOT_PASSWORD": {
         "opitem": "Service Bot",
         "opfield": "shared.dtsPortalLoginPassword",
-        "opvault": VAULT_ID,
     },
 }
 

--- a/dags/atd_service_bot_intake.py
+++ b/dags/atd_service_bot_intake.py
@@ -4,15 +4,10 @@ from datetime import datetime, timedelta
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
 
-from onepasswordconnectsdk.client import Client, new_client
-import onepasswordconnectsdk
-
 from utils.slack_operator import task_fail_slack_alert
+from utils.onepassword import load_dict
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
-ONEPASSWORD_CONNECT_HOST = os.getenv("OP_CONNECT")
-ONEPASSWORD_CONNECT_TOKEN = os.getenv("OP_API_TOKEN")
-VAULT_ID = os.getenv("OP_VAULT_ID")
 
 default_args = {
     "owner": "airflow",
@@ -55,9 +50,7 @@ REQUIRED_SECRETS = {
     },
 }
 
-client: Client = new_client(ONEPASSWORD_CONNECT_HOST, ONEPASSWORD_CONNECT_TOKEN)
-env_vars = onepasswordconnectsdk.load_dict(client, REQUIRED_SECRETS)
-
+env_vars = load_dict(REQUIRED_SECRETS)
 
 with DAG(
     dag_id=f"atd_service_bot_issue_intake_{DEPLOYMENT_ENVIRONMENT}",

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -4,15 +4,10 @@ from datetime import datetime, timedelta
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
 
-from onepasswordconnectsdk.client import Client, new_client
-import onepasswordconnectsdk
-
 from utils.slack_operator import task_fail_slack_alert
+from utils.onepassword import load_dict
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
-ONEPASSWORD_CONNECT_HOST = os.getenv("OP_CONNECT")
-ONEPASSWORD_CONNECT_TOKEN = os.getenv("OP_API_TOKEN")
-VAULT_ID = os.getenv("OP_VAULT_ID")
 
 default_args = {
     "owner": "airflow",
@@ -31,42 +26,34 @@ REQUIRED_SECRETS = {
     "GITHUB_ACCESS_TOKEN": {
         "opitem": "Service Bot",
         "opfield": "shared.githubAccessToken",
-        "opvault": VAULT_ID,
     },
     "ZENHUB_ACCESS_TOKEN": {
         "opitem": "Service Bot",
         "opfield": "shared.zenhubAccessToken",
-        "opvault": VAULT_ID,
     },
     "SOCRATA_API_KEY_ID": {
         "opitem": "Service Bot",
         "opfield": "shared.socrataApiKeyID",
-        "opvault": VAULT_ID,
     },
     "SOCRATA_API_KEY_SECRET": {
         "opitem": "Service Bot",
         "opfield": "shared.socrataApiKeySecret",
-        "opvault": VAULT_ID,
     },
     "SOCRATA_APP_TOKEN": {
         "opitem": "Service Bot",
         "opfield": "shared.socrataAppToken",
-        "opvault": VAULT_ID,
     },
     "SOCRATA_RESOURCE_ID": {
         "opitem": "Service Bot",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.socrataResourceId",
-        "opvault": VAULT_ID,
     },
     "SOCRATA_ENDPOINT": {
         "opitem": "Service Bot",
         "opfield": f"shared.socrataEndpoint",
-        "opvault": VAULT_ID,
     },
 }
 
-client: Client = new_client(ONEPASSWORD_CONNECT_HOST, ONEPASSWORD_CONNECT_TOKEN)
-env_vars = onepasswordconnectsdk.load_dict(client, REQUIRED_SECRETS)
+env_vars = load_dict(REQUIRED_SECRETS)
 
 with DAG(
     dag_id=f"atd_service_bot_github_to_socrata_{DEPLOYMENT_ENVIRONMENT}",

--- a/dags/utils/onepassword.py
+++ b/dags/utils/onepassword.py
@@ -10,13 +10,22 @@ VAULT_ID = os.getenv("OP_VAULT_ID")
 client: Client = new_client(ONEPASSWORD_CONNECT_HOST, ONEPASSWORD_CONNECT_TOKEN)
 
 
-def load_dict(REQUIRED_SECRETS):
-    # Add vault ID to each secret
-    for value in REQUIRED_SECRETS.values():
+def load_dict(required_secrets):
+    """Return dict of specified keys and secrets from 1Password vault.
+
+    Keyword arguments:
+    required_secrets -- a dict of specified keys and values of location config w/o vault id
+    """
+    for value in required_secrets.values():
         value["opvault"] = VAULT_ID
 
     return onepasswordconnectsdk.load_dict(client, REQUIRED_SECRETS)
 
 
 def get_item_by_title(entry_name):
+    """Return a specific item by item title and vault id.
+
+    Keyword arguments:
+    entry_name -- string value of the 1Password entry name in the vault
+    """
     return client.get_item_by_title(entry_name, VAULT_ID)

--- a/dags/utils/onepassword.py
+++ b/dags/utils/onepassword.py
@@ -1,0 +1,12 @@
+from onepasswordconnectsdk.client import Client, new_client
+import onepasswordconnectsdk
+
+ONEPASSWORD_CONNECT_HOST = os.getenv("OP_CONNECT")
+ONEPASSWORD_CONNECT_TOKEN = os.getenv("OP_API_TOKEN")
+VAULT_ID = os.getenv("OP_VAULT_ID")
+
+client: Client = new_client(ONEPASSWORD_CONNECT_HOST, ONEPASSWORD_CONNECT_TOKEN)
+
+
+def load_dict(REQUIRED_SECRETS):
+    return onepasswordconnectsdk.load_dict(client, REQUIRED_SECRETS)

--- a/dags/utils/onepassword.py
+++ b/dags/utils/onepassword.py
@@ -19,7 +19,7 @@ def load_dict(required_secrets):
     for value in required_secrets.values():
         value["opvault"] = VAULT_ID
 
-    return onepasswordconnectsdk.load_dict(client, REQUIRED_SECRETS)
+    return onepasswordconnectsdk.load_dict(client, required_secrets)
 
 
 def get_item_by_title(entry_name):

--- a/dags/utils/onepassword.py
+++ b/dags/utils/onepassword.py
@@ -16,3 +16,7 @@ def load_dict(REQUIRED_SECRETS):
         value["opvault"] = VAULT_ID
 
     return onepasswordconnectsdk.load_dict(client, REQUIRED_SECRETS)
+
+
+def get_item_by_title(entry_name):
+    return client.get_item_by_title(entry_name, VAULT_ID)

--- a/dags/utils/onepassword.py
+++ b/dags/utils/onepassword.py
@@ -1,3 +1,5 @@
+import os
+
 from onepasswordconnectsdk.client import Client, new_client
 import onepasswordconnectsdk
 
@@ -9,4 +11,8 @@ client: Client = new_client(ONEPASSWORD_CONNECT_HOST, ONEPASSWORD_CONNECT_TOKEN)
 
 
 def load_dict(REQUIRED_SECRETS):
+    # Add vault ID to each secret
+    for value in REQUIRED_SECRETS.values():
+        value["opvault"] = VAULT_ID
+
     return onepasswordconnectsdk.load_dict(client, REQUIRED_SECRETS)


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12432

This PR adds a 1Password utility to reduce lib imports and config in DAGs. I added a bit of info on the utils so far. Open to any feedback on the format of that info. I know the 1PW discussion is on-going. 🙏

## Testing

1. [Spin up the local stack
](https://github.com/cityofaustin/atd-airflow/blob/airflow-v2/README.md#local-setup)
2. This is working if the service bot DAGs are visible in the Airflow dashboard and there are no DAG import errors.