### PR TITLE
Update stack to 2.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.5.3
+FROM apache/airflow:2.6.1
 
 USER root
 RUN apt-get update

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@
 # The following variables are supported:
 #
 # AIRFLOW_IMAGE_NAME           - Docker image name used to run Airflow.
-#                                Default: apache/airflow:2.5.3
+#                                Default: apache/airflow:2.6.1
 # AIRFLOW_UID                  - User ID in Airflow containers
 #                                Default: 50000
 # AIRFLOW_PROJ_DIR             - Base path to which all the files will be volumed.
@@ -50,7 +50,7 @@ x-airflow-common:
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
-  # image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.5.3}
+  # image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.6.1}
   build: .
   environment:
     &airflow-common-env
@@ -90,6 +90,7 @@ x-airflow-common:
     - ${AIRFLOW_PROJ_DIR:-.}/dags:/opt/airflow/dags
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
+    - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR:-.}/weather:/opt/airflow/weather
     - /var/run/docker.sock:/var/run/docker.sock
   user: "${AIRFLOW_UID:-50000}:0"

--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -31,7 +31,7 @@ app.config['DEBUG'] = True
 
 @app.route('/')
 def status():
-    return 'Airflow 2.5.3 `git pull` webhook @ ' + time.ctime()
+    return 'Airflow 2.6.1 `git pull` webhook @ ' + time.ctime()
 
 @app.route('/webhook', methods=['POST'])
 def handle_webhook():


### PR DESCRIPTION
In the process of writing some stack-update instructions for https://github.com/cityofaustin/atd-airflow/pull/109, I worked through the process of updating my local stack to 2.6.1.

It spins up and operates with no obvious regressions. I slacked with @mddilley briefly, and we agreed that it was worthwhile to push up the changes and make a small PR. 

~I think we're still ironing out the README and related testing processes, so this PR will probably be best to handle a little down the road, but should make it into the main branch at some point.~

After some helpful slack conversation, it sounds like this PR may be ready to move forward.