### PR TITLE
Fetches 1pass secrets in task

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ with DAG(
 
 The Slack operator utility makes use of the integration between the Airflow and a Slack app webhook. The purpose of the utility is to add Slack notifications to DAGs using the [callback](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/callbacks.html#callback-types) parameters. Failure, critical failure, and success notifications are implemented.
 
-To configure the Slack operator in your local instance, from the Airflow UI go to **Admin** > **Connections** and choose **Slack API** as the **connection type**. You can find the remainings in 1Password under the **Airflow - Slack Bot** item.
+To configure the Slack operator in your local instance, from the Airflow UI go to **Admin** > **Connections** and choose **Slack API** as the **connection type**. You can find the remaining settings in 1Password under the **Airflow - Slack Bot** item.
 
 ## Useful Commands
 

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -44,7 +44,6 @@ with DAG(
     dagrun_timeout=timedelta(minutes=60),
     tags=["repo:atd-service-bot", "knack", "github"],
     catchup=False,
-    render_template_as_native_obj=True,
 ) as dag:
     @task(
         task_id="get_env_vars",

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -54,16 +54,16 @@ with DAG(
         from utils.onepassword import load_dict
         env_vars = load_dict(REQUIRED_SECRETS)
         return env_vars
-
-    t1 = DockerOperator(
+    
+    env_vars = get_env_vars()
+    
+    DockerOperator(
         task_id="github_to_dts_portal",
         image=docker_image,
         api_version="auto",
         auto_remove=True,
         command="./atd-service-bot/gh_index_issues_to_dts_portal.py",
-        environment="{{ task_instance.xcom_pull(task_ids='get_env_vars') }}",
+        environment=env_vars,
         tty=True,
         force_pull=True,
     )
-
-    get_env_vars() >> t1

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -1,11 +1,11 @@
 import os
 from datetime import datetime, timedelta
 
+from airflow.decorators import task
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
 
 from utils.slack_operator import task_fail_slack_alert
-from utils.onepassword import load_dict
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 
@@ -37,8 +37,6 @@ REQUIRED_SECRETS = {
     },
 }
 
-env_vars = load_dict(REQUIRED_SECRETS)
-
 with DAG(
     dag_id=f"atd_service_bot_issues_to_dts_portal_{DEPLOYMENT_ENVIRONMENT}",
     default_args=default_args,
@@ -46,16 +44,26 @@ with DAG(
     dagrun_timeout=timedelta(minutes=60),
     tags=["repo:atd-service-bot", "knack", "github"],
     catchup=False,
+    render_template_as_native_obj=True,
 ) as dag:
+    @task(
+        task_id="get_env_vars",
+        execution_timeout=timedelta(seconds=30),
+    )
+    def get_env_vars():
+        from utils.onepassword import load_dict
+        env_vars = load_dict(REQUIRED_SECRETS)
+        return env_vars
+
     t1 = DockerOperator(
         task_id="github_to_dts_portal",
         image=docker_image,
         api_version="auto",
         auto_remove=True,
         command="./atd-service-bot/gh_index_issues_to_dts_portal.py",
-        environment=env_vars,
+        environment="{{ task_instance.xcom_pull(task_ids='get_env_vars') }}",
         tty=True,
         force_pull=True,
     )
 
-    t1
+    get_env_vars() >> t1

--- a/dags/atd_service_bot_intake.py
+++ b/dags/atd_service_bot_intake.py
@@ -52,7 +52,6 @@ with DAG(
     dagrun_timeout=timedelta(minutes=5),
     tags=["repo:atd-service-bot", "knack", "github"],
     catchup=False,
-    render_template_as_native_obj=True,
 ) as dag:
     @task(
         task_id="get_env_vars",

--- a/dags/atd_service_bot_intake.py
+++ b/dags/atd_service_bot_intake.py
@@ -60,18 +60,17 @@ with DAG(
     )
     def get_env_vars():
         from utils.onepassword import load_dict
-        env_vars = load_dict(REQUIRED_SECRETS)
-        return env_vars
+        return load_dict(REQUIRED_SECRETS)
+
+    env_vars = get_env_vars()
     
-    t1 = DockerOperator(
+    DockerOperator(
         task_id="dts_sr_to_github",
         image=docker_image,
         api_version="auto",
         auto_remove=True,
         command="./atd-service-bot/intake.py",
-        environment="{{ task_instance.xcom_pull(task_ids='get_env_vars') }}",
+        environment=env_vars,
         tty=True,
         force_pull=True,
     )
-
-    get_env_vars() >> t1

--- a/dags/atd_service_bot_intake.py
+++ b/dags/atd_service_bot_intake.py
@@ -1,11 +1,11 @@
 import os
 from datetime import datetime, timedelta
 
+from airflow.decorators import task
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
 
 from utils.slack_operator import task_fail_slack_alert
-from utils.onepassword import load_dict
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 
@@ -45,8 +45,6 @@ REQUIRED_SECRETS = {
     },
 }
 
-env_vars = load_dict(REQUIRED_SECRETS)
-
 with DAG(
     dag_id=f"atd_service_bot_issue_intake_{DEPLOYMENT_ENVIRONMENT}",
     default_args=default_args,
@@ -54,16 +52,26 @@ with DAG(
     dagrun_timeout=timedelta(minutes=5),
     tags=["repo:atd-service-bot", "knack", "github"],
     catchup=False,
+    render_template_as_native_obj=True,
 ) as dag:
+    @task(
+        task_id="get_env_vars",
+        execution_timeout=timedelta(seconds=30),
+    )
+    def get_env_vars():
+        from utils.onepassword import load_dict
+        env_vars = load_dict(REQUIRED_SECRETS)
+        return env_vars
+    
     t1 = DockerOperator(
         task_id="dts_sr_to_github",
         image=docker_image,
         api_version="auto",
         auto_remove=True,
         command="./atd-service-bot/intake.py",
-        environment=env_vars,
+        environment="{{ task_instance.xcom_pull(task_ids='get_env_vars') }}",
         tty=True,
         force_pull=True,
     )
 
-    t1
+    get_env_vars() >> t1

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -73,16 +73,17 @@ with DAG(
         from utils.onepassword import load_dict
         env_vars = load_dict(REQUIRED_SECRETS)
         return env_vars
-
-    t1 = DockerOperator(
+    
+    env_vars = get_env_vars()
+    
+    DockerOperator(
         task_id="dts_github_to_socrata",
         image=docker_image,
         api_version="auto",
         auto_remove=True,
         command="./atd-service-bot/issues_to_socrata.py",
-        environment="{{ task_instance.xcom_pull(task_ids='get_env_vars') }}",
+        environment=env_vars,
         tty=True,
         force_pull=True,
     )
 
-    get_env_vars() >> t1

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -63,7 +63,6 @@ with DAG(
     dagrun_timeout=timedelta(minutes=60),
     tags=["repo:atd-service-bot", "socrata", "github"],
     catchup=False,
-    render_template_as_native_obj=True,
 ) as dag:
     @task(
         task_id="get_env_vars",

--- a/dags/utils/onepassword.py
+++ b/dags/utils/onepassword.py
@@ -7,7 +7,14 @@ ONEPASSWORD_CONNECT_HOST = os.getenv("OP_CONNECT")
 ONEPASSWORD_CONNECT_TOKEN = os.getenv("OP_API_TOKEN")
 VAULT_ID = os.getenv("OP_VAULT_ID")
 
-client: Client = new_client(ONEPASSWORD_CONNECT_HOST, ONEPASSWORD_CONNECT_TOKEN)
+
+def get_client():
+    """Get oneopassword connect client
+
+    Returns:
+        Client
+    """
+    return new_client(ONEPASSWORD_CONNECT_HOST, ONEPASSWORD_CONNECT_TOKEN)
 
 
 def load_dict(required_secrets):
@@ -16,6 +23,7 @@ def load_dict(required_secrets):
     Keyword arguments:
     required_secrets -- a dict of specified keys and values of location config w/o vault id
     """
+    client = get_client()
     for value in required_secrets.values():
         value["opvault"] = VAULT_ID
 
@@ -28,4 +36,5 @@ def get_item_by_title(entry_name):
     Keyword arguments:
     entry_name -- string value of the 1Password entry name in the vault
     """
+    client = get_client()
     return client.get_item_by_title(entry_name, VAULT_ID)


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/12723

This PR mostly just establishes a pattern to access 1Password secrets through [XComs](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/xcoms.html).  It is meant to avoid making many unnecessary API calls to the 1pass connect server, as discussed in [this slack thread](https://austininnovation.slack.com/archives/CHZE6BC6L/p1687530254736569)

I got carried away with README edits! I'm happy to revise/revert: feedback is very welcome.

## Associated repo
- atd-airflow

## Testing

**Steps to test:**
1. Checkout this branch and spin up Airflow as usual:
```
$ docker compose up
```
2. Trigger any of our existing service bot DAGs: they should run normally

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates