### PR TITLE
Fix up the certbot script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ logs/*
 *.http
 *sql
 .DS_Store
+db/*

--- a/toolbox/certbot/README.md
+++ b/toolbox/certbot/README.md
@@ -13,3 +13,12 @@ The renew script is set up as a cron job as root user that runs every 12 hours w
 ```bash
 $ renew_domain_with_certbot.sh airflow.austinmobility.io
 ```
+
+## Verify certificate renewal
+
+If you'd like to check the current expiration of a certificate, you can run:
+```bash
+$ openssl x509 -dates -noout -in /path/to/certificate/certname.pem
+```
+
+See https://www.openssl.org/docs/man1.1.1/man1/x509.html

--- a/toolbox/certbot/renew_domain_with_certbot.sh
+++ b/toolbox/certbot/renew_domain_with_certbot.sh
@@ -31,11 +31,11 @@ rm $DOMAIN.pem
 docker pull certbot/dns-route53:v2.6.0
 
 docker run -it --rm --name certbot \
--e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
--e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \ 
+-e AWS_ACCESS_KEY_ID=$(echo $AWS_ACCESS_KEY_ID | tr -d '\r' ) \
+-e AWS_SECRET_ACCESS_KEY=$(echo $AWS_SECRET_ACCESS_KEY | tr -d '\r' ) \
 -v "/etc/letsencrypt:/etc/letsencrypt" \
--v "/var/lib/letsencrypt:/var/lib/letsencrypt" \ 
-certbot/dns-route53 certonly --dns-route53 -d $DOMAIN
+-v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
+certbot/dns-route53 certonly --dns-route53 --force-renewal -d $DOMAIN
 
 cat /etc/letsencrypt/live/$DOMAIN/cert.pem > $ATD_AIRFLOW_HOMEDIR/haproxy/ssl/$DOMAIN.pem
 


### PR DESCRIPTION
## Associated issues
I checked in on the SSL cert renewal script this morning, and found a few problems:
- we need to use the certbot force renewal flag so it doesn't ask if we want to renew a cert that isn't expired yet (we do want that and we don't want the script to hang while waiting for user input that is never coming)
- we need to remove the carriage returns at the end of the AWS secrets passed to the certbot util (it was erroring out because of this)
- Some spaces left in the code were breaking the long `docker run` commands (i should look at my code editor highlighting more often...)

## Associated repo
n/a

## Testing

**Steps to test:**
To check that this worked when I ran it, you can connect to atd-data03 and use the `openssl` command in the readme in this diff to check the two certs in `/usr/airflow/atd-airflow/haproxy/ssl/`. You should see that the certs expire sometime in October.

**or**

If you want to run the script, connect to atd-data03 and, as root, run:
```bash
$ /usr/airflow/atd-airflow/toolbox/certbot/renew.sh
```


---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Add note to 1PW secrets moved to API vault and check for duplicates~