### PR TITLE
Build Airflow containers with ARM64 support

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - production
-      - multi-arch-building
 
 jobs:
   docker:
@@ -25,7 +24,6 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/atd-airflow:testing
-          # tags: |
-            # ${{ secrets.DOCKER_USERNAME }}/atd-airflow:production
-            # ${{ secrets.DOCKER_USERNAME }}/atd-airflow:latest
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/atd-airflow:production
+            ${{ secrets.DOCKER_USERNAME }}/atd-airflow:latest

--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -4,14 +4,12 @@ on:
   push:
     branches:
       - production
+      - multi-arch-building
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -25,7 +23,9 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v4
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ secrets.DOCKER_USERNAME }}/atd-airflow:production
-            ${{ secrets.DOCKER_USERNAME }}/atd-airflow:latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/atd-airflow:testing
+          # tags: |
+            # ${{ secrets.DOCKER_USERNAME }}/atd-airflow:production
+            # ${{ secrets.DOCKER_USERNAME }}/atd-airflow:latest


### PR DESCRIPTION
## Associated issues

none

## Testing

Mac Users:

Really, if you can spin up your local setup with the `atddocker/atd-airflow:testing` then you should be good to go.

AMD64 (windows & linux folks) - it was never broken!

**Steps to test:**

Modify your docker compose file around line 10 to use the `testing` tag. Don't forget to set it back because I'll remove this tag when I merge this.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates