### PR TITLE
Port atd_metrobike_trips to airflow V2

### DIFF
--- a/dags/atd_metrobike_trips.py
+++ b/dags/atd_metrobike_trips.py
@@ -1,16 +1,20 @@
 # Test locally with: docker compose run --rm airflow-cli dags test atd_metrobike_trips
 
+import os
+
 from datetime import datetime, timedelta
 
 from airflow.decorators import task
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
 
+from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",
-    "description": "Fetch metrobike trip data from dropbox and publish to Socrata",
     "depend_on_past": False,
     "start_date": datetime(2020, 12, 31),
     "email_on_failure": False,
@@ -19,8 +23,6 @@ default_args = {
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }
-
-docker_image = "atddocker/atd-metrobike:production"
 
 # assemble env vars
 
@@ -43,33 +45,23 @@ REQUIRED_SECRETS = {
     },
 }
 
+# runs weekly in prod environment at 1:33am Monday
 with DAG(
     dag_id="atd_metrobike_trips",
+    description="Fetch metrobike trip data from dropbox and publish to Socrata",
     default_args=default_args,
-    schedule_interval="33 1 * * 1",  # runs weekly at 1:33am Monday
+    schedule_interval="33 1 * * 1" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=timedelta(minutes=60),
-    tags=["repo:atd-metrobike", "metrobike"],
+    tags=["repo:atd-metrobike", "metrobike", "socrata"],
     catchup=False,
 ) as dag:
-
-    @task(
-        task_id="get_env_vars",
-        execution_timeout=timedelta(seconds=30),
-    )
-    def get_env_vars():
-        from utils.onepassword import load_dict
-
-        return load_dict(REQUIRED_SECRETS)
-
-    env_vars = get_env_vars()
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperator(
         task_id="atd_metrobike_trips_socrata",
-        image=docker_image,
-        api_version="auto",
+        image="atddocker/atd-metrobike:production",
         auto_remove=True,
         command="python publish_trips.py",
-        network_mode="bridge",
         environment=env_vars,
         tty=True,
         force_pull=True,

--- a/dags/atd_metrobike_trips.py
+++ b/dags/atd_metrobike_trips.py
@@ -1,0 +1,78 @@
+# Test locally with: docker compose run --rm airflow-cli dags test atd_metrobike_trips
+
+from datetime import datetime, timedelta
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+
+from utils.slack_operator import task_fail_slack_alert
+
+default_args = {
+    "owner": "airflow",
+    "description": "Fetch metrobike trip data from dropbox and publish to Socrata",
+    "depend_on_past": False,
+    "start_date": datetime(2020, 12, 31),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+docker_image = "atddocker/atd-metrobike:production"
+
+# assemble env vars
+
+REQUIRED_SECRETS = {
+    "SOCRATA_API_KEY_SECRET": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SOCRATA_API_KEY_ID": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SOCRATA_APP_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "METROBIKE_DROPBOX_TOKEN": {
+        "opitem": "Metrobike",
+        "opfield": "production.Dropbox Token",
+    },
+}
+
+with DAG(
+    dag_id="atd_metrobike_trips",
+    default_args=default_args,
+    schedule_interval="33 1 * * 1",  # runs weekly at 1:33am Monday
+    dagrun_timeout=timedelta(minutes=60),
+    tags=["repo:atd-metrobike", "metrobike"],
+    catchup=False,
+) as dag:
+
+    @task(
+        task_id="get_env_vars",
+        execution_timeout=timedelta(seconds=30),
+    )
+    def get_env_vars():
+        from utils.onepassword import load_dict
+
+        return load_dict(REQUIRED_SECRETS)
+
+    env_vars = get_env_vars()
+
+    t1 = DockerOperator(
+        task_id="atd_metrobike_trips_socrata",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command="python publish_trips.py",
+        network_mode="bridge",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+    )
+
+    t1


### PR DESCRIPTION
Porting this airflow v1 [metrobike trip publishing ETL](https://github.com/cityofaustin/atd-airflow/blob/master/dags/atd_metrobike_trips.py) to v2.

## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/9388
We don't have a epic for porting v1 to v2 for airflow, yet.

## Associated repo
[atd-metrobike](https://github.com/cityofaustin/atd-metrobike
)

## Testing

**Steps to test:**
1. `git pull` this branch down
2. `docker compose run --rm airflow-cli dags test atd_metrobike_trips`
3. 99% of the time this will end up being a non-op as the ETL will `return` if it detects that the data in Socrata is already up to date with the data stored in the dropbox folder. This is configured to run weekly on Monday mornings.
4. check for `atd_metrobike_trips_socrata ran successfully!` in the logs

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
- [ ] Turn off Airflow V1 DAG