### PR TITLE
Creates DAG to publish signal studies

### DIFF
--- a/dags/atd_knack_signal_studies.py
+++ b/dags/atd_knack_signal_studies.py
@@ -1,0 +1,100 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+default_args = {
+    "owner": "airflow",
+    "description": "Publishes all signal stuides records from Knack to Socrata",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 12, 1),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiKey",
+    },
+    "SOCRATA_API_KEY_ID": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SOCRATA_API_KEY_SECRET": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SOCRATA_APP_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "PGREST_ENDPOINT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.endpoint",
+    },
+    "PGREST_JWT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.jwt",
+    },
+}
+
+with DAG(
+    dag_id=f"atd_knack_services_signal_studies",
+    default_args=default_args,
+    schedule_interval=None,
+    dagrun_timeout=timedelta(minutes=5),
+    tags=["repo:atd-knack-services", "knack", "github", "socrata"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/atd-knack-services:production"
+    app_name = "data-tracker"
+    container = "view_3488"
+
+    @task(
+        task_id="get_env_vars",
+        execution_timeout=timedelta(seconds=30),
+    )
+    def get_env_vars():
+        from utils.onepassword import load_dict
+
+        return load_dict(REQUIRED_SECRETS)
+
+    env_vars = get_env_vars()
+
+    t1 = DockerOperator(
+        task_id="atd_knack_signal_studies_to_postgrest",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container}",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t2 = DockerOperator(
+        task_id="atd_knack_signal_studies_to_socrata",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container}",
+        environment=env_vars,
+        tty=True,
+        mount_tmp_dir=False,
+    )
+
+    t1 >> t2

--- a/dags/atd_knack_signal_studies.py
+++ b/dags/atd_knack_signal_studies.py
@@ -11,7 +11,7 @@ DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",
-    "description": "Publishes all signal stuides records from Knack to Socrata",
+    "description": "Publishes all signal studies records from Knack to Socrata",
     "depends_on_past": False,
     "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
     "email_on_failure": False,


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/7168

## Associated repo
- https://github.com/cityofaustin/atd-knack-services

## Testing

1. Start your local rig
2. Trigger the `atd_knack_services_signal_studies` DAG.
3. You should see all three tasks succeed with ~420 records processed.
4. [This](https://data.austintexas.gov/Transportation-and-Mobility/Traffic-and-Pedestrian-Signal-Evaluations-BETA-/h4cy-hpgs) is the dataset you just updated


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates