### PR TITLE
Add dag for cr3 diagram extract

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ _AIRFLOW_WWW_USER_USERNAME=admin
 _AIRFLOW_WWW_USER_PASSWORD=<Pick your initial admin password here>
 AIRFLOW_PROJ_DIR=<The absolute path of your Airflow repository checkout>
 # this fernet key is for testing purposes only
-_AIRFLOW__CORE__FERNET_KEYY=PTkIRwL-c46jgnaohlkkXfVikC-roKa95ipXfqST7JM=
+_AIRFLOW__CORE__FERNET_KEY=PTkIRwL-c46jgnaohlkkXfVikC-roKa95ipXfqST7JM=
 OP_API_TOKEN=<Get from 1Password entry named "Connect Server: Production Access Token: API Accessible Secrets">
 OP_CONNECT=<Get from 1Password entry named "Endpoint for 1Password Connect Server API">
 OP_VAULT_ID=<Get from 1Password entry named "Vault ID of API Accessible Secrets vault">

--- a/dags/utils/onepassword.py
+++ b/dags/utils/onepassword.py
@@ -9,7 +9,7 @@ VAULT_ID = os.getenv("OP_VAULT_ID")
 
 
 def get_client():
-    """Get oneopassword connect client
+    """Get onepassword connect client
 
     Returns:
         Client

--- a/dags/vz_cr3_extract_ocr_narrative.py
+++ b/dags/vz_cr3_extract_ocr_narrative.py
@@ -1,5 +1,5 @@
 import os
-import pendulum
+from pendulum import datetime, duration
 from datetime import datetime, timedelta
 
 from airflow.decorators import task

--- a/dags/vz_cr3_extract_ocr_narrative.py
+++ b/dags/vz_cr3_extract_ocr_narrative.py
@@ -1,6 +1,5 @@
 import os
 from pendulum import datetime, duration
-from datetime import datetime, timedelta
 
 from airflow.decorators import task
 from airflow.models import DAG
@@ -47,13 +46,13 @@ with DAG(
     default_args=default_args,
     # Every 5 minutes, at 8A, 9A, and 10A
     schedule_interval="*/5 8-10 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
-    dagrun_timeout=timedelta(minutes=5),
+    dagrun_timeout=pendulum.duration(minutes=5),
     tags=["repo:atd-vz-data", "vision-zero"],
     catchup=False,
 ) as dag:
     @task(
         task_id="get_env_vars",
-        execution_timeout=timedelta(seconds=30),
+        execution_timeout=pendulum.duration(seconds=30),
     )
     def get_env_vars():
         from utils.onepassword import load_dict

--- a/dags/vz_cr3_extract_ocr_narrative.py
+++ b/dags/vz_cr3_extract_ocr_narrative.py
@@ -20,8 +20,6 @@ default_args = {
     "on_failure_callback": task_fail_slack_alert,
 }
 
-docker_image = "atddocker/atd-vz-cr3-extract:production"
-
 REQUIRED_SECRETS = {
     "HASURA_ENDPOINT": {
         "opitem": "Vision Zero CRIS Import",
@@ -62,7 +60,7 @@ with DAG(
     
     DockerOperator(
         task_id="ocr_narrative_extract",
-        image=docker_image,
+        image="atddocker/atd-vz-cr3-extract:production",
         api_version="auto",
         auto_remove=True,
         command="./cr3_extract_diagram/cr3_extract_diagram_ocr_narrative.py -v -d --update-narrative --update-timestamp --batch 100 --cr3-source atd-vision-zero-editor production/cris-cr3-files --save-diagram-s3 atd-vision-zero-website cr3_crash_diagrams/production",

--- a/dags/vz_cr3_extract_ocr_narrative.py
+++ b/dags/vz_cr3_extract_ocr_narrative.py
@@ -1,0 +1,71 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+default_args = {
+    "owner": "airflow",
+    "description": "Extracts the diagram and narrative out of CR3 pdfs",
+    "depends_on_past": False,
+    "start_date": datetime(2019, 1, 1),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+docker_image = "atddocker/atd-vz-cr3-extract:production"
+
+REQUIRED_SECRETS = {
+    "HASURA_ENDPOINT": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": "production.GraphQL Endpoint",
+    },
+    "HASURA_ADMIN_KEY": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": "production.GraphQL Endpoint key",
+    }, 
+    "AWS_ACCESS_KEY_ID": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": "production.AWS Access key",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": "production.AWS Secret key",
+    }
+}
+
+with DAG(
+    dag_id=f"vz_cr3_ocr_narrative_extract_{DEPLOYMENT_ENVIRONMENT}",
+    default_args=default_args,
+    schedule_interval="*/5 8-10 * * *", # Every 5 minutes, at 8A, 9A, and 10A 
+    dagrun_timeout=timedelta(minutes=5),
+    tags=["repo:atd-vz-data", "vision-zero"],
+    catchup=False,
+) as dag:
+    @task(
+        task_id="get_env_vars",
+        execution_timeout=timedelta(seconds=30),
+    )
+    def get_env_vars():
+        from utils.onepassword import load_dict
+        return load_dict(REQUIRED_SECRETS)
+
+    env_vars = get_env_vars()
+    
+    DockerOperator(
+        task_id="ocr_narrative_extract",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command="./cr3_extract_diagram/cr3_extract_diagram_ocr_narrative.py -v -d --update-narrative --update-timestamp --batch 100 --cr3-source atd-vision-zero-editor production/cris-cr3-files --save-diagram-s3 atd-vision-zero-website cr3_crash_diagrams/production",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+    )

--- a/dags/vz_cr3_extract_ocr_narrative.py
+++ b/dags/vz_cr3_extract_ocr_narrative.py
@@ -45,7 +45,8 @@ REQUIRED_SECRETS = {
 with DAG(
     dag_id=f"vz_cr3_ocr_narrative_extract_{DEPLOYMENT_ENVIRONMENT}",
     default_args=default_args,
-    schedule_interval="*/5 8-10 * * *", # Every 5 minutes, at 8A, 9A, and 10A 
+    # Every 5 minutes, at 8A, 9A, and 10A
+    schedule_interval="*/5 8-10 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=timedelta(minutes=5),
     tags=["repo:atd-vz-data", "vision-zero"],
     catchup=False,

--- a/dags/vz_cr3_extract_ocr_narrative.py
+++ b/dags/vz_cr3_extract_ocr_narrative.py
@@ -44,13 +44,13 @@ with DAG(
     default_args=default_args,
     # Every 5 minutes, at 8A, 9A, and 10A
     schedule_interval="*/5 8-10 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
-    dagrun_timeout=pendulum.duration(minutes=5),
+    dagrun_timeout=duration(minutes=5),
     tags=["repo:atd-vz-data", "vision-zero"],
     catchup=False,
 ) as dag:
     @task(
         task_id="get_env_vars",
-        execution_timeout=pendulum.duration(seconds=30),
+        execution_timeout=duration(seconds=30),
     )
     def get_env_vars():
         from utils.onepassword import load_dict
@@ -67,4 +67,5 @@ with DAG(
         environment=env_vars,
         tty=True,
         force_pull=True,
+        mount_tmp_dir=False,
     )

--- a/dags/vz_cr3_extract_ocr_narrative.py
+++ b/dags/vz_cr3_extract_ocr_narrative.py
@@ -1,4 +1,5 @@
 import os
+import pendulum
 from datetime import datetime, timedelta
 
 from airflow.decorators import task
@@ -13,7 +14,7 @@ default_args = {
     "owner": "airflow",
     "description": "Extracts the diagram and narrative out of CR3 pdfs",
     "depends_on_past": False,
-    "start_date": datetime(2019, 1, 1),
+    "start_date": pendulum.datetime(2019, 1, 1, tz="America/Chicago"),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 0,


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/11731

This is the prefect 1 version of the ETL: https://github.com/cityofaustin/atd-prefect/blob/main/flows/vision-zero/cr3_ocr_narrative_extract_diagram/cr3_ocr_narrative_extract_diagram.py

## Associated repo

The script used to live in this airflow repo, you can see it still in the master branch. I have moved it and made it into a Docker image, copying the pattern Frank started with the other VZ ETLs

https://github.com/cityofaustin/atd-vz-data/pull/1250

## Testing

**Steps to test:**

Running locally, trigger the dag: vz_cr3_ocr_narrative_extract_development

The original dag was scheduled `schedule_interval="*/10 18-23,2-5 * * *"`, but the prefect version looks to be scheduled every 5 minutes, between 8a-11a. So I went with the prefect schedule for this dag. 

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates