### PR TITLE
Fix the cr3 crash diagram dag

### DIFF
--- a/dags/vz_cr3_extract_ocr_narrative.py
+++ b/dags/vz_cr3_extract_ocr_narrative.py
@@ -13,7 +13,7 @@ default_args = {
     "owner": "airflow",
     "description": "Extracts the diagram and narrative out of CR3 pdfs",
     "depends_on_past": False,
-    "start_date": pendulum.datetime(2019, 1, 1, tz="America/Chicago"),
+    "start_date": datetime(2019, 1, 1, tz="America/Chicago"),
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 0,


### PR DESCRIPTION
I updated one of the places Frank caught in my PR, but not both places. When I went to turn it on on atd-03, i got an error message

<img width="692" alt="Screenshot 2023-07-14 at 10 08 59 AM" src="https://github.com/cityofaustin/atd-airflow/assets/12474808/fde23ec5-1871-494e-92dd-f0b422dc3ffa">

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates