### PR TITLE
Converts prefect 2 knack services flows to Airflow DAGs

### DIFF
--- a/dags/atd_knack_artbox_signals.py
+++ b/dags/atd_knack_artbox_signals.py
@@ -1,0 +1,117 @@
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration, now
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+from utils.knack import get_date_filter_arg
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS_ARTBOX_POSTGREST = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack Smark Mobility",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack Smark Mobility",
+        "opfield": f"production.apiKey",
+    },
+    "PGREST_ENDPOINT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.endpoint",
+    },
+    "PGREST_JWT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.jwt",
+    },
+}
+
+REQUIRED_SECRETS_SIGNALS_TO_SMO = {
+    "KNACK_APP_ID_DEST": {
+        "opitem": "Knack Smark Mobility",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY_DEST": {
+        "opitem": "Knack Smark Mobility",
+        "opfield": f"production.apiKey",
+    },
+    "KNACK_APP_ID_SRC": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY_SRC": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiKey",
+    },
+    "PGREST_ENDPOINT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.endpoint",
+    },
+    "PGREST_JWT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.jwt",
+    },
+}
+
+
+"""This DAG keeps signals in sync between Data Tracker and SMO app. It:
+- publishes the current signal records in the SMO app to PostgREST (records_to_postgrest.py)
+- Assumes the current data tracker signals are in postgrest (that's managed in another DAG)
+- compares the current signals in data tracker and SMO, and updates records in SMO (records_to_knack.py)
+
+"""
+with DAG(
+    dag_id=f"atd_knack_artbox_signals",
+    description="Load signals (view_197) records from Knack data tracker to smart mobility",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=5),
+    tags=["repo:atd-knack-services", "knack", "data-tracker", "smart-mobility"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/atd-knack-services:production"
+    app_name_src = "data-tracker"
+    container_src = "view_197"
+    app_name_dest = "smart-mobility"
+    container_dest = "view_396"
+
+    date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
+    env_vars_t1 = get_env_vars_task(REQUIRED_SECRETS_ARTBOX_POSTGREST)
+    env_vars_t2 = get_env_vars_task(REQUIRED_SECRETS_SIGNALS_TO_SMO)
+
+    t1 = DockerOperator(
+        task_id="atd_knack_artbox_signals_to_postgrest",
+        image=docker_image,
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name_dest} -c {container_dest} {date_filter_arg}",
+        environment=env_vars_t1,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t2 = DockerOperator(
+        task_id="atd_knack_data_tracker_signals_to_smo",
+        image=docker_image,
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_knack.py -a {app_name_src} -c {container_src} {date_filter_arg} -dest {app_name_dest}",
+        environment=env_vars_t2,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+    date_filter_arg >> t1 >> t2

--- a/dags/atd_knack_artbox_signals.py
+++ b/dags/atd_knack_artbox_signals.py
@@ -78,7 +78,7 @@ with DAG(
     dag_id=f"atd_knack_artbox_signals",
     description="Load signals (view_197) records from Knack data tracker to smart mobility",
     default_args=DEFAULT_ARGS,
-    schedule_interval="" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="30 0 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=5),
     tags=["repo:atd-knack-services", "knack", "data-tracker", "smart-mobility"],
     catchup=False,

--- a/dags/atd_knack_corridor_retiming.py
+++ b/dags/atd_knack_corridor_retiming.py
@@ -1,0 +1,94 @@
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration, now
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+from utils.knack import get_date_filter_arg
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiKey",
+    },
+    "SOCRATA_API_KEY_ID": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SOCRATA_API_KEY_SECRET": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SOCRATA_APP_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "PGREST_ENDPOINT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.endpoint",
+    },
+    "PGREST_JWT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.jwt",
+    }
+}
+
+
+with DAG(
+    dag_id=f"atd_knack_corridor_retiming",
+    description="Load corridor retiming data from Knack to Postgrest to Socata",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="45 11 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=5),
+    tags=["repo:atd-knack-services", "knack", "socrata", "data-tracker"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/atd-knack-services:production"
+    app_name = "data-tracker"
+    container = "view_3814"
+
+    date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="atd_knack_corridor_retiming_to_postgrest",
+        image=docker_image,
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t2 = DockerOperator(
+        task_id="atd_knack_corridor_retiming_to_socrata",
+        image=docker_image,
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        mount_tmp_dir=False,
+    )
+
+    date_filter_arg >> t1 >> t2

--- a/dags/atd_knack_data_tracker_location_updater.py
+++ b/dags/atd_knack_data_tracker_location_updater.py
@@ -1,0 +1,79 @@
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.knack import get_date_filter_arg
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiKey",
+    },
+    "AGOL_USERNAME": {
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.username",
+    },
+    "AGOL_PASSWORD": {
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.password",
+    },
+    "PGREST_ENDPOINT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.endpoint",
+    },
+    "PGREST_JWT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.jwt",
+    },
+}
+
+with DAG(
+    dag_id=f"atd_knack_data_tracker_location_updater",
+    description="Assigns signal records to CSR issues in data tracker based on CSR location",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="* * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=5),
+    tags=["repo:atd-knack-services", "knack", "data-tracker"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/atd-knack-services:production"
+    app_name = "data-tracker"
+    container = "view_1201" 
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+    
+    date_filter_arg = get_date_filter_arg()
+
+    t1 = DockerOperator(
+        task_id="update_locations",
+        image= "atddocker/atd-knack-services:production",
+        auto_remove=True,
+        command=f"./atd-knack-services/services/knack_location_updater.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    date_filter_arg >> t1

--- a/dags/atd_knack_data_tracker_location_updater.py
+++ b/dags/atd_knack_data_tracker_location_updater.py
@@ -38,23 +38,15 @@ REQUIRED_SECRETS = {
         "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
         "opfield": "production.password",
     },
-    "PGREST_ENDPOINT": {
-        "opitem": "atd-knack-services PostgREST",
-        "opfield": "production.endpoint",
-    },
-    "PGREST_JWT": {
-        "opitem": "atd-knack-services PostgREST",
-        "opfield": "production.jwt",
-    },
 }
 
 with DAG(
     dag_id=f"atd_knack_data_tracker_location_updater",
     description="Assigns signal records to CSR issues in data tracker based on CSR location",
     default_args=DEFAULT_ARGS,
-    schedule_interval="* * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="19 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=5),
-    tags=["repo:atd-knack-services", "knack", "data-tracker"],
+    tags=["repo:atd-knack-services", "knack", "data-tracker", "agol"],
     catchup=False,
 ) as dag:
     docker_image = "atddocker/atd-knack-services:production"

--- a/dags/atd_knack_data_tracker_sr_asset_assign.py
+++ b/dags/atd_knack_data_tracker_sr_asset_assign.py
@@ -1,0 +1,72 @@
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiKey",
+    },
+    "KNACK_API_USER_EMAIL": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiUserEmail",
+    },
+    "KNACK_API_USER_PW": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiUserPassword",
+    },
+    "AGOL_USERNAME": {
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.username",
+    },
+    "AGOL_PASSWORD": {
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.password",
+    },
+}
+
+with DAG(
+    dag_id=f"atd_knack_data_tracker_sr_asset_assign",
+    description="Assigns signal records to CSR issues in data tracker based on CSR location",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="* * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=5),
+    tags=["repo:atd-knack-services", "knack", "data-tracker"],
+    catchup=False,
+) as dag:
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="atd_knack_signals_to_postgrest",
+        image= "atddocker/atd-knack-services:production",
+        auto_remove=True,
+        command=f"./atd-knack-services/services/sr_asset_assign.py -a data-tracker -c view_2362 -s signals",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t1

--- a/dags/atd_knack_data_tracker_street_segment_updater.py
+++ b/dags/atd_knack_data_tracker_street_segment_updater.py
@@ -1,0 +1,67 @@
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.knack import get_date_filter_arg
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiKey",
+    },
+    "AGOL_USERNAME": {
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.username",
+    },
+    "AGOL_PASSWORD": {
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.password",
+    },
+}
+
+with DAG(
+    dag_id=f"atd_knack_data_tracker_street_segment_updater",
+    description="Update street segment records in Data Tracker with feature data from ArcGIS Online",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="45 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=5),
+    tags=["repo:atd-knack-services", "knack", "data-tracker", "agol"],
+    catchup=False,
+) as dag:
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    date_filter_arg = get_date_filter_arg()
+
+    t1 = DockerOperator(
+        task_id="update_street_segments",
+        image="atddocker/atd-knack-services:production",
+        auto_remove=True,
+        command=f"./atd-knack-services/services/knack_street_seg_updater.py -a data-tracker -c view_1198 {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    date_filter_arg >> t1

--- a/dags/atd_knack_tcp_submissions.py
+++ b/dags/atd_knack_tcp_submissions.py
@@ -1,0 +1,94 @@
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration, now
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+from utils.knack import get_date_filter_arg
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack Right of Way (ROW) Portal",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack Right of Way (ROW) Portal",
+        "opfield": f"production.apiKey",
+    },
+    "SOCRATA_API_KEY_ID": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SOCRATA_API_KEY_SECRET": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SOCRATA_APP_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "PGREST_ENDPOINT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.endpoint",
+    },
+    "PGREST_JWT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.jwt",
+    }
+}
+
+
+with DAG(
+    dag_id=f"atd_knack_tcp_submissions",
+    description="Load traffic control plan (TCP) submission from ROW portal to Socrata",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="15 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=5),
+    tags=["repo:atd-knack-services", "knack", "socrata", "data-tracker"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/atd-knack-services:production"
+    app_name = "row"
+    container = "view_483"
+
+    date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="atd_knack_tcp_submissions_to_postgrest",
+        image=docker_image,
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t2 = DockerOperator(
+        task_id="atd_knack_tcp_submissions_to_socrata",
+        image=docker_image,
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        mount_tmp_dir=False,
+    )
+
+    date_filter_arg >> t1 >> t2

--- a/dags/atd_knack_work_orders_markings_contractors.py
+++ b/dags/atd_knack_work_orders_markings_contractors.py
@@ -1,0 +1,125 @@
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.knack import get_date_filter_arg
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack Signs and Markings",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack Signs and Markings",
+        "opfield": f"production.apiKey",
+    },
+    "PGREST_ENDPOINT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.endpoint",
+    },
+    "PGREST_JWT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.jwt",
+    },
+    "SOCRATA_API_KEY_ID": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SOCRATA_API_KEY_SECRET": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SOCRATA_APP_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "AGOL_USERNAME": {
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.username",
+    },
+    "AGOL_PASSWORD": {
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.password",
+    },
+}
+
+
+with DAG(
+    dag_id="atd_knack_work_orders_markings_contractors",
+    description="Load markings contractor work orders records from Knack to Postgrest to AGOL, Socrata",
+    default_args=DEFAULT_ARGS,
+    # runs once at 1130a ct and again at 140pm ct
+    schedule_interval="5 2 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=5),
+    tags=["repo:atd-knack-services", "knack", "socrata", "agol", "signs-markings"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/atd-knack-services:production"
+    app_name = "signs-markings"
+    container = "view_3628"
+
+    date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="atd_knack_markings_contractor_work_orders_to_postgrest",
+        image=docker_image,
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+
+    t2 = DockerOperator(
+        task_id="atd_knack_markings_work_orders_to_agol",
+        image=docker_image,
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t3 = DockerOperator(
+        task_id="atd_knack_markings_contractor_work_orders_agol_build_markings_segment_geometries",
+        image=docker_image,
+        auto_remove=True,
+        command=f'./atd-knack-services/services/agol_build_markings_segment_geometries.py -l markings_jobs  {date_filter_arg}',
+        environment=env_vars,
+        tty=True,
+        mount_tmp_dir=False,
+    )
+
+    t4 = DockerOperator(
+        task_id="atd_knack_markings_contractor_work_orders_to_socrata",
+        image=docker_image,
+        auto_remove=True,
+        command=f'./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}',
+        environment=env_vars,
+        tty=True,
+        mount_tmp_dir=False,
+    )
+
+    date_filter_arg >> t1 >> t2 >> t3 >> t4


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/12904

This takes care of all of the flows in [this folder](https://github.com/cityofaustin/atd-prefect/tree/main/flows/atd-knack-services).

## Associated repo
- atd-knack-services
- atd-prefect

## Testing

Start your local Airflow instance and fire away. No need to be on VPN.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates