### PR TITLE
Make webserver.base_url configurable via environment file with suitable default for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ The stack is composed of:
 
 ## Table of Contents
 
-
 - [Getting Started](#getting-started)
   - [Developing a new DAG](#developing-a-new-dag)
   - [Tags](#tags)

--- a/README.md
+++ b/README.md
@@ -14,17 +14,21 @@ The stack is composed of:
 
 ## Table of Contents
 
-- [Getting Started](#getting-started)
-  - [Developing a new DAG](#developing-a-new-dag)
-  - [Tags](#tags)
-  - [Moving to production](#moving-to-production)
-- [Utilities](#utilities)
-  - [1Password utility](#1password-utility)
-  - [Slack operator utility](#slack-operator-utility)
-- [Useful Commands](#useful-commands)
-- [Updating the stack](#updating-the-stack)
-- [HAProxy and SSL](#haproxy-and-ssl)
-  - [HAProxy operation](#haproxy-operation)
+- [DTS Airflow](#dts-airflow)
+  - [Table of Contents](#table-of-contents)
+  - [Getting Started](#getting-started)
+    - [Developing a new DAG](#developing-a-new-dag)
+    - [Tags](#tags)
+    - [Moving to production](#moving-to-production)
+  - [Utilities](#utilities)
+    - [1Password utility](#1password-utility)
+    - [Slack operator utility](#slack-operator-utility)
+  - [Useful Commands](#useful-commands)
+  - [Updating the stack](#updating-the-stack)
+      - [Update Process](#update-process)
+  - [HAProxy and SSL](#haproxy-and-ssl)
+    - [HAProxy operation](#haproxy-operation)
+  - [Ideas](#ideas)
 
 ## Getting Started
 
@@ -40,6 +44,7 @@ _AIRFLOW_WWW_USER_PASSWORD=<Pick your initial admin password here>
 AIRFLOW_PROJ_DIR=<The absolute path of your Airflow repository checkout>
 # this fernet key is for testing purposes only
 _AIRFLOW__CORE__FERNET_KEY=PTkIRwL-c46jgnaohlkkXfVikC-roKa95ipXfqST7JM=
+_AIRFLOW__WEBSERVER__BASE_URL=http://localhost:8080
 OP_API_TOKEN=<Get from 1Password entry named "Connect Server: Production Access Token: API Accessible Secrets">
 OP_CONNECT=<Get from 1Password entry named "Endpoint for 1Password Connect Server API">
 OP_VAULT_ID=<Get from 1Password entry named "Vault ID of API Accessible Secrets vault">

--- a/README.md
+++ b/README.md
@@ -14,21 +14,18 @@ The stack is composed of:
 
 ## Table of Contents
 
-- [DTS Airflow](#dts-airflow)
-  - [Table of Contents](#table-of-contents)
-  - [Getting Started](#getting-started)
-    - [Developing a new DAG](#developing-a-new-dag)
-    - [Tags](#tags)
-    - [Moving to production](#moving-to-production)
-  - [Utilities](#utilities)
-    - [1Password utility](#1password-utility)
-    - [Slack operator utility](#slack-operator-utility)
-  - [Useful Commands](#useful-commands)
-  - [Updating the stack](#updating-the-stack)
-      - [Update Process](#update-process)
-  - [HAProxy and SSL](#haproxy-and-ssl)
-    - [HAProxy operation](#haproxy-operation)
-  - [Ideas](#ideas)
+
+- [Getting Started](#getting-started)
+  - [Developing a new DAG](#developing-a-new-dag)
+  - [Tags](#tags)
+  - [Moving to production](#moving-to-production)
+- [Utilities](#utilities)
+  - [1Password utility](#1password-utility)
+  - [Slack operator utility](#slack-operator-utility)
+- [Useful Commands](#useful-commands)
+- [Updating the stack](#updating-the-stack)
+- [HAProxy and SSL](#haproxy-and-ssl)
+  - [HAProxy operation](#haproxy-operation)
 
 ## Getting Started
 

--- a/airflow.cfg
+++ b/airflow.cfg
@@ -536,7 +536,7 @@ default_hive_mapred_queue =
 # The base url of your website as airflow cannot guess what domain or
 # cname you are using. This is used in automated emails that
 # airflow sends to point links to the right web server
-base_url = http://localhost:8080
+base_url =
 
 # Default timezone to display all dates in the UI, can be UTC, system, or
 # any IANA timezone string (e.g. Europe/Amsterdam). If left empty the

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -6,10 +6,6 @@ from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperato
 # in Admin > Connections.
 SLACK_CONN_ID = "slack"
 
-def handle_production_url(log_url):
-    if os.getenv('ENVIRONMENT') == 'production':
-        log_url = log_url.replace('http://localhost:8080', 'https://airflow.austinmobility.io')
-    return log_url
 
 def task_fail_slack_alert_critical(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
@@ -24,7 +20,7 @@ def task_fail_slack_alert_critical(context):
         dag=context.get("task_instance").dag_id,
         ti=context.get("task_instance"),
         exec_date=context.get("execution_date"),
-        log_url=handle_production_url(context.get("task_instance").log_url),
+        log_url=context.get("task_instance").log_url,
     )
     failed_alert = SlackWebhookOperator(
         task_id="slack_critical_failure",
@@ -38,6 +34,9 @@ def task_fail_slack_alert_critical(context):
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
+    log_url = context.get("task_instance").log_url
+    if os.getenv('ENVIRONMENT') == 'production':
+        log_url = log_url.replace('http://localhost:8080', 'https://airflow.austinmobility.io')
     slack_msg = """
             :red_circle: Task Failed. 
             *Task*: {task}  
@@ -49,7 +48,7 @@ def task_fail_slack_alert(context):
         dag=context.get("task_instance").dag_id,
         ti=context.get("task_instance"),
         exec_date=context.get("execution_date"),
-        log_url=handle_production_url(context.get("task_instance").log_url),
+        log_url=log_url,
     )
 
     failed_alert = SlackWebhookOperator(
@@ -75,7 +74,7 @@ def task_success_slack_alert(context):
         dag=context.get("task_instance").dag_id,
         ti=context.get("task_instance"),
         exec_date=context.get("execution_date"),
-        log_url=handle_production_url(context.get("task_instance").log_url),
+        log_url=context.get("task_instance").log_url,
     )
     success_alert = SlackWebhookOperator(
         task_id="slack_success",

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -1,3 +1,4 @@
+import os
 from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 
@@ -33,6 +34,9 @@ def task_fail_slack_alert_critical(context):
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
+    log_url = context.get("task_instance").log_url
+    if os.getenv('ENVIRONMENT') == 'production':
+        log_url = log_url.replace('http://localhost:8080', 'https://airflow.austinmobility.io')
     slack_msg = """
             :red_circle: Task Failed. 
             *Task*: {task}  
@@ -44,8 +48,9 @@ def task_fail_slack_alert(context):
         dag=context.get("task_instance").dag_id,
         ti=context.get("task_instance"),
         exec_date=context.get("execution_date"),
-        log_url=context.get("task_instance").log_url,
+        log_url=log_url
     )
+
     failed_alert = SlackWebhookOperator(
         task_id="slack_failure",
         http_conn_id="slack",

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -48,7 +48,7 @@ def task_fail_slack_alert(context):
         dag=context.get("task_instance").dag_id,
         ti=context.get("task_instance"),
         exec_date=context.get("execution_date"),
-        log_url=log_url
+        log_url=log_url,
     )
 
     failed_alert = SlackWebhookOperator(

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -48,7 +48,7 @@ def task_fail_slack_alert(context):
         dag=context.get("task_instance").dag_id,
         ti=context.get("task_instance"),
         exec_date=context.get("execution_date"),
-        log_url=log_url,
+        log_url=log_url
     )
 
     failed_alert = SlackWebhookOperator(

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -1,4 +1,3 @@
-import os
 from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 
@@ -34,9 +33,6 @@ def task_fail_slack_alert_critical(context):
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
-    log_url = context.get("task_instance").log_url
-    if os.getenv('ENVIRONMENT') == 'production':
-        log_url = log_url.replace('http://localhost:8080', 'https://airflow.austinmobility.io')
     slack_msg = """
             :red_circle: Task Failed. 
             *Task*: {task}  
@@ -48,9 +44,8 @@ def task_fail_slack_alert(context):
         dag=context.get("task_instance").dag_id,
         ti=context.get("task_instance"),
         exec_date=context.get("execution_date"),
-        log_url=log_url
+        log_url=context.get("task_instance").log_url,
     )
-
     failed_alert = SlackWebhookOperator(
         task_id="slack_failure",
         http_conn_id="slack",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ x-airflow-common: &airflow-common
   image: atddocker/atd-airflow:production
   environment: &airflow-common-env
     AIRFLOW__CORE__FERNET_KEY: ${_AIRFLOW__CORE__FERNET_KEY}
+    AIRFLOW__WEBSERVER__BASE_URL: ${_AIRFLOW__WEBSERVER__BASE_URL:-http://defaultvalue:8080}
     # You need to explictly allow .env vars into the airflow containers's environments here
     OP_API_TOKEN: ${OP_API_TOKEN}
     OP_CONNECT: ${OP_CONNECT}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ x-airflow-common: &airflow-common
   image: atddocker/atd-airflow:production
   environment: &airflow-common-env
     AIRFLOW__CORE__FERNET_KEY: ${_AIRFLOW__CORE__FERNET_KEY}
-    AIRFLOW__WEBSERVER__BASE_URL: ${_AIRFLOW__WEBSERVER__BASE_URL:-http://defaultvalue:8080}
+    AIRFLOW__WEBSERVER__BASE_URL: ${_AIRFLOW__WEBSERVER__BASE_URL:-http://localhost:8080}
     # You need to explictly allow .env vars into the airflow containers's environments here
     OP_API_TOKEN: ${OP_API_TOKEN}
     OP_CONNECT: ${OP_CONNECT}


### PR DESCRIPTION
This PR makes the webserver.base_url configuration value for airflow settable in the environment file. If it's not set, a suitable value for local development will be used.

Please see this [conversation](https://austininnovation.slack.com/archives/C013G4RNJ01/p1689690216401759?thread_ts=1689689445.887899&cid=C013G4RNJ01). Thanks to @johnclary and @chiaberry for the idea!

The approach above was inspected, and then a different, final solution was arrived at on advice from @johnclary in slack PMs. Thank you!

---
#### Ship list
- [ ] Code reviewed 
