### PR TITLE
Update CR3 download script

### DIFF
--- a/dags/utils/onepassword.py
+++ b/dags/utils/onepassword.py
@@ -51,7 +51,7 @@ def get_item_by_title(entry_name):
     execution_timeout=duration(seconds=30),
 )
 def get_env_vars_task(required_secrets):
-    """This is a wrapper around `load_dict` so that it can be 
+    """This is a wrapper around `load_dict` so that it can be
     imported as an airflow task.
 
     Args:
@@ -62,3 +62,18 @@ def get_env_vars_task(required_secrets):
         dict: a dict with one key/val per secret
     """
     return load_dict(required_secrets)
+
+
+@task(
+    task_id="get_item_last_update_date",
+    multiple_outputs=True,
+    execution_timeout=duration(seconds=30),
+)
+def get_item_last_update_date(entry_name):
+    """Return a specific item's last update date
+
+    Keyword arguments:
+    entry_name -- string value of the 1Password entry name in the vault
+    """
+    updated_at_datetime = get_item_by_title(entry_name).updated_at
+    return {"updated_at": updated_at_datetime}

--- a/dags/utils/onepassword.py
+++ b/dags/utils/onepassword.py
@@ -76,4 +76,4 @@ def get_item_last_update_date(entry_name):
     entry_name -- string value of the 1Password entry name in the vault
     """
     updated_at_datetime = get_item_by_title(entry_name).updated_at
-    return {"updated_at": updated_at_datetime}
+    return {"updated_at_datetime": updated_at_datetime}

--- a/dags/utils/time.py
+++ b/dags/utils/time.py
@@ -1,0 +1,24 @@
+from airflow.decorators import task
+from pendulum import now, parse
+
+
+@task(
+    task_id="get_previous_run_date",
+    multiple_outputs=True,
+)
+def get_previous_run_date(**context):
+    """Task to return the last successful run date in UTC datetime format.
+
+    Args:
+        context (dict): Airflow task context, which contains the prev_start_date_success
+            variable.
+
+    Returns:
+        Dict: dict containing the last run datetime and other future formats
+    """
+    last_run_datetime = context.get("prev_start_date_success") or parse("1970-01-01")
+
+    return {
+        "last_run_datetime": last_run_datetime,
+        # add other formats here
+    }

--- a/dags/vz_cr3_download.py
+++ b/dags/vz_cr3_download.py
@@ -1,0 +1,56 @@
+import os
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+default_args = {
+    "owner": "airflow",
+    "description": "Downloads CR3 pdfs from CRIS and uploads to S3",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "retries": 0,
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {}
+
+with DAG(
+    dag_id=f"vz-cr3-download",
+    default_args=default_args,
+    schedule_interval=None,
+    dagrun_timeout=duration(minutes=5),
+    tags=["repo:atd-vz-data", "cris", "s3", "cr3"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/"
+
+    @task(
+        task_id="get_env_vars",
+        execution_timeout=duration(seconds=30),
+    )
+    def get_env_vars():
+        from utils.onepassword import load_dict
+
+        return load_dict(REQUIRED_SECRETS)
+
+    env_vars = get_env_vars()
+
+    t1 = DockerOperator(
+        task_id="vz_cr3_download",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command="",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t1

--- a/dags/vz_cr3_download.py
+++ b/dags/vz_cr3_download.py
@@ -8,6 +8,7 @@ from pendulum import datetime, duration, now, parse
 
 from utils.onepassword import get_env_vars_task, get_item_last_update_date
 from utils.slack_operator import task_fail_slack_alert, task_success_slack_alert
+from utils.time import get_previous_run_date
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 
@@ -61,14 +62,15 @@ REQUIRED_SECRETS = {
 with DAG(
     dag_id=f"vz-cr3-download",
     default_args=default_args,
-    schedule_interval="*/5 * * * *",
+    schedule_interval="*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=5),
     tags=["repo:atd-vz-data", "cris", "s3", "cr3"],
     catchup=False,
 ) as dag:
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    updated_at_dict = get_item_last_update_date(COOKIE_1PW_ENTRY)
+    last_run = get_previous_run_date()
+    updated_at = get_item_last_update_date(COOKIE_1PW_ENTRY)
 
     branch_true = DockerOperator(
         task_id="vz_cr3_download",
@@ -86,17 +88,17 @@ with DAG(
     branch_false = DummyOperator(task_id="skip_vz_cr3_download")
 
     @task.branch(task_id="choose_branch")
-    def choose_branch(updated_at):
-        minutes_ago_utc = now() - duration(minutes=5)
-        updated_at_utc = updated_at
-
-        if updated_at_utc > minutes_ago_utc:
+    def choose_branch(updated_at, last_run):
+        if updated_at > last_run:
             print("Downloading CR3 pdfs")
             return ["vz_cr3_download"]
         else:
             print("Cookie entry not updated - skipping CR3 pdf downloads")
             return ["skip_vz_cr3_download"]
 
-    choose_branch = choose_branch(updated_at=updated_at_dict["updated_at"])
+    choose_branch = choose_branch(
+        updated_at=updated_at["updated_at_datetime"],
+        last_run=last_run["last_run_datetime"],
+    )
 
     choose_branch >> [branch_true, branch_false]

--- a/dags/vz_cr3_download.py
+++ b/dags/vz_cr3_download.py
@@ -24,12 +24,12 @@ COOKIE_1PW_ENTRY = "CRIS CR3 Download Cookie"
 
 REQUIRED_SECRETS = {
     "HASURA_ENDPOINT": {
-        "opitem": "Vision Zero CRIS Import",
+        "opitem": "Vision Zero graphql-engine Endpoints",
         "opfield": "production.GraphQL Endpoint",
     },
     "HASURA_ADMIN_KEY": {
-        "opitem": "Vision Zero CRIS Import",
-        "opfield": "production.GraphQL Endpoint key",
+        "opitem": "Vision Zero graphql-engine Endpoints",
+        "opfield": "production.Admin Key",
     },
     "AWS_ACCESS_KEY_ID": {
         "opitem": "CR3 Download IAM Access Key and Secret",

--- a/dags/vz_cr3_download.py
+++ b/dags/vz_cr3_download.py
@@ -18,7 +18,40 @@ default_args = {
     "on_failure_callback": task_fail_slack_alert,
 }
 
-REQUIRED_SECRETS = {}
+REQUIRED_SECRETS = {
+    "HASURA_ENDPOINT": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": "production.GraphQL Endpoint",
+    },
+    "HASURA_ADMIN_KEY": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": "production.GraphQL Endpoint key",
+    },
+    "AWS_ACCESS_KEY_ID": {
+        "opitem": "CR3 Download IAM Access Key and Secret",
+        "opfield": "production.accessKeyId",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "opitem": "CR3 Download IAM Access Key and Secret",
+        "opfield": "production.accessSecret",
+    },
+    "AWS_DEFAULT_REGION": {
+        "opitem": "CR3 Download IAM Access Key and Secret",
+        "opfield": "production.awsDefaultRegion",
+    },
+    "ATD_CRIS_CR3_URL": {
+        "opitem": "CRIS CR3 Download",
+        "opfield": "production.ATD_CRIS_CR3_URL",
+    },
+    "AWS_CRIS_CR3_DOWNLOAD_PATH": {
+        "opitem": "CRIS CR3 Download",
+        "opfield": "production.AWS_CRIS_CR3_DOWNLOAD_PATH",
+    },
+    "AWS_CRIS_CR3_BUCKET_NAME": {
+        "opitem": "CRIS CR3 Download",
+        "opfield": "production.AWS_CRIS_CR3_BUCKET_NAME",
+    },
+}
 
 with DAG(
     dag_id=f"vz-cr3-download",

--- a/dags/vz_cr3_download.py
+++ b/dags/vz_cr3_download.py
@@ -14,7 +14,6 @@ DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",
-    "description": "Downloads CR3 pdfs from CRIS and uploads to S3",
     "depends_on_past": False,
     "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
     "retries": 0,
@@ -60,7 +59,8 @@ REQUIRED_SECRETS = {
 
 
 with DAG(
-    dag_id=f"vz-cr3-download",
+    dag_id="vz-cr3-download",
+    description="Downloads CR3 pdfs from CRIS and uploads to S3",
     default_args=default_args,
     schedule_interval="*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=5),

--- a/dags/vz_cr3_download.py
+++ b/dags/vz_cr3_download.py
@@ -47,10 +47,6 @@ REQUIRED_SECRETS = {
         "opitem": "CRIS CR3 Download",
         "opfield": "production.ATD_CRIS_CR3_URL",
     },
-    "AWS_CRIS_CR3_DOWNLOAD_PATH": {
-        "opitem": "CRIS CR3 Download",
-        "opfield": "production.AWS_CRIS_CR3_DOWNLOAD_PATH",
-    },
     "AWS_CRIS_CR3_BUCKET_NAME": {
         "opitem": "CRIS CR3 Download",
         "opfield": "production.AWS_CRIS_CR3_BUCKET_NAME",
@@ -76,10 +72,10 @@ with DAG(
 
     branch_true = DockerOperator(
         task_id="vz_cr3_download",
-        image=f"atddocker/atd-vz-etl:{DEPLOYMENT_ENVIRONMENT}",
+        image=f"atddocker/vz-cr3-download:{DEPLOYMENT_ENVIRONMENT}",
         api_version="auto",
         auto_remove=True,
-        command="python process_cris_cr3.py",
+        command="python cr3_download.py",
         environment=env_vars,
         tty=True,
         force_pull=True,

--- a/dags/vz_cr3_download.py
+++ b/dags/vz_cr3_download.py
@@ -66,32 +66,28 @@ with DAG(
 
     updated_at_dict = get_item_last_update_date("CRIS CR3 Download")
 
-    # 1PW returns 2023-07-11T22:32:58Z
-    @task(task_id="download_cr3", execution_timeout=duration(seconds=30))
-    def print_message(updated_at):
+    # t1 = DockerOperator(
+    #     task_id="vz_cr3_download",
+    #     # image=docker_image,
+    #     image="vz_etl",
+    #     api_version="auto",
+    #     auto_remove=True,
+    #     command="",
+    #     environment=env_vars,
+    #     tty=True,
+    #     force_pull=True,
+    #     mount_tmp_dir=False,
+    # )
+
+    @task.branch
+    def choose_branch(updated_at):
         minutes_ago_utc = now() - duration(minutes=5)
         updated_at_utc = updated_at
 
         if updated_at_utc > minutes_ago_utc:
             print("Download CR3")
+            # return ["t1"]
         else:
-            print("Don't download CR3")
+            print("Cookie entry not updated - skipping CR3 download")
 
-    t1 = print_message(updated_at=updated_at_dict["updated_at"])
-
-    t1 = DockerOperator(
-        task_id="vz_cr3_download",
-        # image=docker_image,
-        image="vz_etl",
-        api_version="auto",
-        auto_remove=True,
-        command="",
-        environment=env_vars,
-        tty=True,
-        force_pull=True,
-        mount_tmp_dir=False,
-    )
-
-    # t1
-
-    # t1
+    choose_branch(updated_at=updated_at_dict["updated_at"])

--- a/dags/vz_cr3_download.py
+++ b/dags/vz_cr3_download.py
@@ -3,8 +3,9 @@ import os
 from airflow.decorators import task
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
-from pendulum import datetime, duration
+from pendulum import datetime, duration, now, parse
 
+from utils.onepassword import get_env_vars_task, get_item_last_update_date
 from utils.slack_operator import task_fail_slack_alert
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
@@ -61,31 +62,36 @@ with DAG(
     tags=["repo:atd-vz-data", "cris", "s3", "cr3"],
     catchup=False,
 ) as dag:
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    @task(
-        task_id="get_env_vars",
-        execution_timeout=duration(seconds=30),
+    updated_at_dict = get_item_last_update_date("CRIS CR3 Download")
+
+    # 1PW returns 2023-07-11T22:32:58Z
+    @task(task_id="download_cr3", execution_timeout=duration(seconds=30))
+    def print_message(updated_at):
+        minutes_ago_utc = now() - duration(minutes=5)
+        updated_at_utc = updated_at
+
+        if updated_at_utc > minutes_ago_utc:
+            print("Download CR3")
+        else:
+            print("Don't download CR3")
+
+    t1 = print_message(updated_at=updated_at_dict["updated_at"])
+
+    t1 = DockerOperator(
+        task_id="vz_cr3_download",
+        # image=docker_image,
+        image="vz_etl",
+        api_version="auto",
+        auto_remove=True,
+        command="",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
     )
-    def get_env_vars():
-        from utils.onepassword import load_dict
 
-        return load_dict(REQUIRED_SECRETS)
-
-    env_vars = get_env_vars()
-
-    print(env_vars)
-
-    # t1 = DockerOperator(
-    #     task_id="vz_cr3_download",
-    #     # image=docker_image,
-    #     image="vz_etl",
-    #     api_version="auto",
-    #     auto_remove=True,
-    #     command="",
-    #     environment=env_vars,
-    #     tty=True,
-    #     force_pull=True,
-    #     mount_tmp_dir=False,
-    # )
+    # t1
 
     # t1

--- a/dags/vz_cr3_download.py
+++ b/dags/vz_cr3_download.py
@@ -61,7 +61,6 @@ with DAG(
     tags=["repo:atd-vz-data", "cris", "s3", "cr3"],
     catchup=False,
 ) as dag:
-    docker_image = "atddocker/"
 
     @task(
         task_id="get_env_vars",
@@ -74,16 +73,19 @@ with DAG(
 
     env_vars = get_env_vars()
 
-    t1 = DockerOperator(
-        task_id="vz_cr3_download",
-        image=docker_image,
-        api_version="auto",
-        auto_remove=True,
-        command="",
-        environment=env_vars,
-        tty=True,
-        force_pull=True,
-        mount_tmp_dir=False,
-    )
+    print(env_vars)
 
-    t1
+    # t1 = DockerOperator(
+    #     task_id="vz_cr3_download",
+    #     # image=docker_image,
+    #     image="vz_etl",
+    #     api_version="auto",
+    #     auto_remove=True,
+    #     command="",
+    #     environment=env_vars,
+    #     tty=True,
+    #     force_pull=True,
+    #     mount_tmp_dir=False,
+    # )
+
+    # t1


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12849

This has the changes that I showed in dev sync, and I'm open to all thoughts on this. I'm seeing a few ways to go here and we can always make multiple ways possible. Here is what some of those would look like:
- Having the DAG run routinely to watch a 1PW cookie entry for changes
   - Go through the steps to get the cookie (we have to think about how long a session would live)
   - Update the cookie entry in 1Password
   - wait for the DAG to see the update, run, and see a success alert to the Airflow slack channel
- Manually run from the Airflow dashboard with a parameter
   - Go through the steps to get the cookie
   - Get on the VPN and login to the Airflow v2 dashboard
   - Run the DAG manually and feed the cookie in a parameter
- Same as the last one but update the cookie 1Password entry and then manually run it instead of using an Airflow parameter

## Associated repo
https://github.com/cityofaustin/atd-vz-data/pull/1254

## Testing

**Steps to test:**
I pushed a [`development` tag to DockerHub](https://hub.docker.com/layers/atddocker/vz-cr3-download/development/images/sha256-b8cc0ec5f337c372fa5ed46ae91d6a827900c11d48371735b12e24fb9d4b9d2f?context=repo) that has the code changes in the VZ PR linked above.

Spin up the local stack and trigger the `vz-cr3-download` DAG. It will skip the `vz_cr3_download` task. Update the `CRIS CR3 Download Cookie` 1PW entry and trigger it again. You should see the modified date shown in 1PW update. It should run the `vz_cr3_download` task and log that there are no pdfs to download (unless you run it in the morning before the designated CRIS downloader runs the current process).

If you want to go the extra mile, you can: 
- find an older crash record without serious injuries or fatalities (we don't want to disrupt VZ team efforts)
- carefully, [SSH tunnel and connect to the production database](https://app.gitbook.com/o/-LzDQOVGhTudbKRDGpUA/s/-MIQvl_rKnZ_-wHRdp4J/dev-guides/how-tos/how-to-connect-to-the-rds-instance#2.-open-the-tunnel) and update the one crash record's `cr3_stored_flag` column from `Y` to `N` (i tested this with crash id `16302089`)
- run the script and it will log one pdf download from CRIS and upload to S3

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates