### PR TITLE
Migrate VZ Socrata ETL to Airflow v2

### DIFF
--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -20,12 +20,12 @@ default_args = {
 
 REQUIRED_SECRETS = {
     "HASURA_ENDPOINT": {
-        "opitem": "Vision Zero CRIS Import",
+        "opitem": "Vision Zero graphql-engine Endpoints",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.GraphQL Endpoint",
     },
     "HASURA_ADMIN_KEY": {
-        "opitem": "Vision Zero CRIS Import",
-        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.GraphQL Endpoint key",
+        "opitem": "Vision Zero graphql-engine Endpoints",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Key",
     },
     "SOCRATA_API_KEY_ID": {
         "opitem": "Socrata Key ID, Secret, and Token",
@@ -52,7 +52,7 @@ REQUIRED_SECRETS = {
 with DAG(
     dag_id=f"vz_socrata_export_{DEPLOYMENT_ENVIRONMENT}",
     default_args=default_args,
-    schedule_interval="0 9 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="0 4 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=20),
     tags=["repo:atd-vz-data", "socrata"],
     catchup=False,

--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -53,7 +53,7 @@ with DAG(
     dag_id=f"vz_socrata_export_{DEPLOYMENT_ENVIRONMENT}",
     default_args=default_args,
     schedule_interval="0 9 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
-    dagrun_timeout=duration(minutes=5),
+    dagrun_timeout=duration(minutes=20),
     tags=["repo:atd-vz-data", "socrata"],
     catchup=False,
 ) as dag:

--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -50,7 +50,7 @@ REQUIRED_SECRETS = {
 
 with DAG(
     dag_id=f"vz_socrata_export_{DEPLOYMENT_ENVIRONMENT}",
-    description="Downloads CR3 pdfs from CRIS and uploads to S3",
+    description="Exports Vision Zero crash and people datasets to Socrata from Vision Zero database.",
     default_args=default_args,
     schedule_interval="0 4 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=20),

--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -1,11 +1,11 @@
 import os
 from pendulum import datetime, duration
 
-from airflow.decorators import task
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
 
 from utils.slack_operator import task_fail_slack_alert
+from utils.onepassword import get_env_vars_task
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 
@@ -40,17 +40,17 @@ REQUIRED_SECRETS = {
         "opfield": "socrata.appToken",
     },
     "SOCRATA_DATASET_CRASHES": {
-        "opitem": "Vision Zero CRIS Import",
+        "opitem": "Vision Zero Socrata Export",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.SOCRATA_DATASET_CRASHES",
     },
     "SOCRATA_DATASET_PERSONS": {
-        "opitem": "Vision Zero CRIS Import",
+        "opitem": "Vision Zero Socrata Export",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.SOCRATA_DATASET_PERSONS",
     },
 }
 
 with DAG(
-    dag_id=f"vz-cr3-download_{DEPLOYMENT_ENVIRONMENT}",
+    dag_id=f"vz_socrata_export_{DEPLOYMENT_ENVIRONMENT}",
     default_args=default_args,
     schedule_interval="*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=5),

--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -1,0 +1,72 @@
+import os
+from pendulum import datetime, duration
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+default_args = {
+    "owner": "airflow",
+    "description": "Downloads CR3 pdfs from CRIS and uploads to S3",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "retries": 0,
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "HASURA_ENDPOINT": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.GraphQL Endpoint",
+    },
+    "HASURA_ADMIN_KEY": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.GraphQL Endpoint key",
+    },
+    "SOCRATA_API_KEY_ID": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SOCRATA_API_KEY_SECRET": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SOCRATA_APP_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "SOCRATA_DATASET_CRASHES": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.SOCRATA_DATASET_CRASHES",
+    },
+    "SOCRATA_DATASET_PERSONS": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.SOCRATA_DATASET_PERSONS",
+    },
+}
+
+with DAG(
+    dag_id=f"vz-cr3-download_{DEPLOYMENT_ENVIRONMENT}",
+    default_args=default_args,
+    schedule_interval="*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=5),
+    tags=["repo:atd-vz-data", "socrata"],
+    catchup=False,
+) as dag:
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    DockerOperator(
+        task_id="socrata_export",
+        image=f"atddocker/vz-socrata-export:{DEPLOYMENT_ENVIRONMENT}",
+        api_version="auto",
+        auto_remove=True,
+        command="python socrata_export.py",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )

--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -11,7 +11,6 @@ DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",
-    "description": "Downloads CR3 pdfs from CRIS and uploads to S3",
     "depends_on_past": False,
     "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
     "retries": 0,
@@ -51,6 +50,7 @@ REQUIRED_SECRETS = {
 
 with DAG(
     dag_id=f"vz_socrata_export_{DEPLOYMENT_ENVIRONMENT}",
+    description="Downloads CR3 pdfs from CRIS and uploads to S3",
     default_args=default_args,
     schedule_interval="0 4 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=20),

--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -52,7 +52,7 @@ REQUIRED_SECRETS = {
 with DAG(
     dag_id=f"vz_socrata_export_{DEPLOYMENT_ENVIRONMENT}",
     default_args=default_args,
-    schedule_interval="*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="0 9 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=5),
     tags=["repo:atd-vz-data", "socrata"],
     catchup=False,


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12495

## Associated repo
https://github.com/cityofaustin/atd-vz-data/pull/1258

## Testing

**Steps to test:**

This screenshot shows the script working using the local VZ stack + local Airflow stack, because it is kind of a lot to ask y'all to patch this and the Airflow stack to make this work.

<img width="709" alt="Screenshot 2023-07-19 at 7 50 24 PM" src="https://github.com/cityofaustin/atd-airflow/assets/37249039/a2100d37-c32c-4b64-b565-4f860be3747c">

**If you decide to try to test this locally, please coordinate with @tillyw since it affects the micromobility VZV work that she is working on.** I tested this using my local VZ stack only after carrying out the steps in https://github.com/cityofaustin/atd-vz-data/pull/1252 to make sure this doesn't block that ongoing work.

1. Update the [VZ stack `docker-compose.yaml` on line 16](https://github.com/cityofaustin/atd-vz-data/blob/825362d288087e78a6ec713e422cb33d657062ed/docker-compose.yml#L16) with the following change:
```
- 8084:8080
```
2. This is to avoid the VZ graphql engine and Airflow webserver from colliding ports.
3. Start the local VZ stack and follow the steps in https://github.com/cityofaustin/atd-vz-data/pull/1252 to make sure the micromobility data makes its way into this test dataset.
4. Patch this DAG so that the value of `HASURA_ENDPOINT` is `http://host.docker.internal:8084/v1/graphql`.
5. Run the DAG

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [x] Add note to 1PW secrets moved to API vault and check for duplicates