### PR TITLE
ETL DAG ports from Airflow V1 for VZ location & CR3 maintenance

### DIFF
--- a/dags/atd_visionzero_cr3_process_missing_pdfs.py
+++ b/dags/atd_visionzero_cr3_process_missing_pdfs.py
@@ -53,7 +53,7 @@ with DAG(
     tags=["repo:atd_vz_data", "vision-zero", "cr3", "pdf"],
     catchup=False,
 ) as dag:
-    docker_image = "atddocker/vz-pdf-maintenance:latest"
+    docker_image = "atddocker/vz-pdf-maintenance:production"
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 

--- a/dags/atd_visionzero_cr3_process_missing_pdfs.py
+++ b/dags/atd_visionzero_cr3_process_missing_pdfs.py
@@ -53,7 +53,7 @@ with DAG(
     tags=["repo:atd_vz_data", "vision-zero", "cr3", "pdf"],
     catchup=False,
 ) as dag:
-    docker_image = "atddocker/process_missing_cr3_pdfs:production"
+    docker_image = "atddocker/vz-process-missing-cr3-pdfs:production"
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 

--- a/dags/atd_visionzero_cr3_process_missing_pdfs.py
+++ b/dags/atd_visionzero_cr3_process_missing_pdfs.py
@@ -5,7 +5,6 @@ from airflow.operators.docker_operator import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
-from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")

--- a/dags/atd_visionzero_cr3_process_missing_pdfs.py
+++ b/dags/atd_visionzero_cr3_process_missing_pdfs.py
@@ -43,7 +43,7 @@ REQUIRED_SECRETS = {
 }
 
 with DAG(
-    dag_id="vision_zero_process_missing_pdfs",
+    dag_id="vz_process_missing_pdfs",
     description="Execute housekeeping routine manage missing or malformed CR3 PDFs",
     default_args=DEFAULT_ARGS,
     schedule_interval="*/30 * * * *"

--- a/dags/atd_visionzero_cr3_process_missing_pdfs.py
+++ b/dags/atd_visionzero_cr3_process_missing_pdfs.py
@@ -1,0 +1,82 @@
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.knack import get_date_filter_arg
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+# secrets atd_visionzero_hasura_sql_production
+
+REQUIRED_SECRETS = {
+    "HASURA_ENDPOINT": {
+        "opitem": "Vision Zero graphql-engine Endpoints",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Query Endpoint",
+    },
+    "HASURA_ADMIN_KEY": {
+        "opitem": "Vision Zero graphql-engine Endpoints",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Key",
+    }, 
+    "AWS_BUCKET_NAME": {
+        "opitem": "CRIS CR3 Download",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AWS_CRIS_CR3_BUCKET_NAME",
+    },
+    "AWS_BUCKET_ENVIRONMENT": {
+        "opitem": "CRIS CR3 Download",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AWS_CRIS_CR3_BUCKET_PATH_ENVIRONMENT",
+    }
+}
+
+with DAG(
+    dag_id="vision_zero_process_missing_pdfs",
+    description="Execute housekeeping routine manage missing or malformed CR3 PDFs",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="*/30 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=15),
+    tags=["repo:atd_vz_data", "vision-zero", "cr3", "pdf"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/vz-pdf-maintenance:latest"
+
+    date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    cr3_temp_record_remove_pdf = DockerOperator(
+        task_id="cr3_temp_record_remove_pdf",
+        image=docker_image,
+        auto_remove=True,
+        command="python scripts/atd_vzd_cr3_temp_record_remove_pdf.py",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    cr3_scan_pdf_records = DockerOperator(
+        task_id="cr3_scan_pdf_records",
+        image=docker_image,
+        auto_remove=True,
+        command="python scripts/atd_vzd_cr3_scan_pdf_records.py",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+
+cr3_temp_record_remove_pdf >> cr3_scan_pdf_records

--- a/dags/atd_visionzero_cr3_process_missing_pdfs.py
+++ b/dags/atd_visionzero_cr3_process_missing_pdfs.py
@@ -53,7 +53,7 @@ with DAG(
     tags=["repo:atd_vz_data", "vision-zero", "cr3", "pdf"],
     catchup=False,
 ) as dag:
-    docker_image = "atddocker/vz-pdf-maintenance:production"
+    docker_image = "atddocker/process_missing_cr3_pdfs:production"
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 

--- a/dags/atd_visionzero_cr3_process_missing_pdfs.py
+++ b/dags/atd_visionzero_cr3_process_missing_pdfs.py
@@ -31,7 +31,7 @@ REQUIRED_SECRETS = {
     "HASURA_ADMIN_KEY": {
         "opitem": "Vision Zero graphql-engine Endpoints",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Key",
-    }, 
+    },
     "AWS_BUCKET_NAME": {
         "opitem": "CRIS CR3 Download",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AWS_CRIS_CR3_BUCKET_NAME",
@@ -39,14 +39,16 @@ REQUIRED_SECRETS = {
     "AWS_BUCKET_ENVIRONMENT": {
         "opitem": "CRIS CR3 Download",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AWS_CRIS_CR3_BUCKET_PATH_ENVIRONMENT",
-    }
+    },
 }
 
 with DAG(
     dag_id="vision_zero_process_missing_pdfs",
     description="Execute housekeeping routine manage missing or malformed CR3 PDFs",
     default_args=DEFAULT_ARGS,
-    schedule_interval="*/30 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="*/30 * * * *"
+    if DEPLOYMENT_ENVIRONMENT == "production"
+    else None,
     dagrun_timeout=duration(minutes=15),
     tags=["repo:atd_vz_data", "vision-zero", "cr3", "pdf"],
     catchup=False,

--- a/dags/atd_visionzero_cr3_process_missing_pdfs.py
+++ b/dags/atd_visionzero_cr3_process_missing_pdfs.py
@@ -55,7 +55,6 @@ with DAG(
 ) as dag:
     docker_image = "atddocker/vz-pdf-maintenance:latest"
 
-    date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     cr3_temp_record_remove_pdf = DockerOperator(

--- a/dags/atd_visionzero_cr3_process_missing_pdfs.py
+++ b/dags/atd_visionzero_cr3_process_missing_pdfs.py
@@ -33,11 +33,11 @@ REQUIRED_SECRETS = {
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Key",
     },
     "AWS_BUCKET_NAME": {
-        "opitem": "CRIS CR3 Download",
+        "opitem": "Vision Zero CRIS CR3 Download",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AWS_CRIS_CR3_BUCKET_NAME",
     },
     "AWS_BUCKET_ENVIRONMENT": {
-        "opitem": "CRIS CR3 Download",
+        "opitem": "Vision Zero CRIS CR3 Download",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AWS_CRIS_CR3_BUCKET_PATH_ENVIRONMENT",
     },
 }

--- a/dags/atd_visionzero_reassociate_missing_locations.py
+++ b/dags/atd_visionzero_reassociate_missing_locations.py
@@ -1,0 +1,76 @@
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.knack import get_date_filter_arg
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+# secrets atd_visionzero_hasura_sql_production
+
+REQUIRED_SECRETS = {
+    "HASURA_ENDPOINT": {
+        "opitem": "Vision Zero graphql-engine Endpoints",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Query Endpoint",
+    },
+    "HASURA_ADMIN_KEY": {
+        "opitem": "Vision Zero graphql-engine Endpoints",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Key",
+    }, 
+}
+
+with DAG(
+    dag_id="vision-zero-reassociate-missing-locations",
+    description="Execute housekeeping routine to associate VZ Polygons and Crashes together",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="0 3 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=15),
+    tags=["repo:atd-vz-data", "vision-zero", "polygons", "crashes"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/vz-location-associations:latest"
+
+    date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    # This process will find the locations for CR3 crashes that do not have one but
+    # fall into a location and they are not mainlanes.
+    update_cr3_locations = DockerOperator(
+        task_id="update_cr3_locations",
+        image=docker_image,
+        auto_remove=True,
+        command="python scripts/atd_vzd_update_cr3_locations.py",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+
+    # This process will find the locations for Non-CR3 crashes that do not have one but
+    # fall into a location and they are not mainlanes.
+    update_non_cr3_locations = DockerOperator(
+        task_id="update_cr3_locations",
+        image=docker_image,
+        auto_remove=True,
+        command="python scripts/atd_vzd_update_noncr3_locations.py",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )

--- a/dags/atd_visionzero_reassociate_missing_locations.py
+++ b/dags/atd_visionzero_reassociate_missing_locations.py
@@ -99,3 +99,16 @@ with DAG(
         force_pull=True,
         mount_tmp_dir=False,
     )
+
+    reassociate_wrong_locations = DockerOperator(
+        task_id="reassociate_wrong_locations",
+        image=docker_image,
+        auto_remove=True,
+        command="python scripts/atd_vzd_reassociate_wrong_locations.py",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+update_cr3_locations >> update_noncr3_locations >> dissociate_cr3 >> dissociate_noncr3 >> reassociate_wrong_locations

--- a/dags/atd_visionzero_reassociate_missing_locations.py
+++ b/dags/atd_visionzero_reassociate_missing_locations.py
@@ -5,7 +5,6 @@ from airflow.operators.docker_operator import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
-from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
@@ -43,7 +42,6 @@ with DAG(
 ) as dag:
     docker_image = "atddocker/vz-location-associations:production"
 
-    date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     # This process will find the locations for CR3 crashes that do not have one but

--- a/dags/atd_visionzero_reassociate_missing_locations.py
+++ b/dags/atd_visionzero_reassociate_missing_locations.py
@@ -41,7 +41,7 @@ with DAG(
     tags=["repo:atd_vz_data", "vision-zero", "polygons", "crashes"],
     catchup=False,
 ) as dag:
-    docker_image = "atddocker/vz-location-associations:latest"
+    docker_image = "atddocker/vz-location-associations:production"
 
     date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
     env_vars = get_env_vars_task(REQUIRED_SECRETS)

--- a/dags/atd_visionzero_reassociate_missing_locations.py
+++ b/dags/atd_visionzero_reassociate_missing_locations.py
@@ -65,7 +65,7 @@ with DAG(
     # This process will find the locations for Non-CR3 crashes that do not have one but
     # fall into a location and they are not mainlanes.
     update_non_cr3_locations = DockerOperator(
-        task_id="update_cr3_locations",
+        task_id="update_noncr3_locations",
         image=docker_image,
         auto_remove=True,
         command="python scripts/atd_vzd_update_noncr3_locations.py",

--- a/dags/atd_visionzero_reassociate_missing_locations.py
+++ b/dags/atd_visionzero_reassociate_missing_locations.py
@@ -33,7 +33,7 @@ REQUIRED_SECRETS = {
 }
 
 with DAG(
-    dag_id="vision_zero_reassociate_missing_locations",
+    dag_id="vz_reassociate_missing_locations",
     description="Execute housekeeping routine to associate VZ Polygons and Crashes together",
     default_args=DEFAULT_ARGS,
     schedule_interval="0 3 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,

--- a/dags/atd_visionzero_reassociate_missing_locations.py
+++ b/dags/atd_visionzero_reassociate_missing_locations.py
@@ -21,8 +21,6 @@ DEFAULT_ARGS = {
     "on_failure_callback": task_fail_slack_alert,
 }
 
-# secrets atd_visionzero_hasura_sql_production
-
 REQUIRED_SECRETS = {
     "HASURA_ENDPOINT": {
         "opitem": "Vision Zero graphql-engine Endpoints",

--- a/dags/atd_visionzero_reassociate_missing_locations.py
+++ b/dags/atd_visionzero_reassociate_missing_locations.py
@@ -66,7 +66,7 @@ with DAG(
         command="python scripts/atd_vzd_update_noncr3_locations.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
+        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -78,7 +78,7 @@ with DAG(
         command="python scripts/atd_vzd_dissociate_cr3_mainlanes.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
+        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -90,7 +90,7 @@ with DAG(
         command="python scripts/atd_vzd_dissociate_noncr3_mainlanes.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
+        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -101,7 +101,7 @@ with DAG(
         command="python scripts/atd_vzd_reassociate_wrong_locations.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
+        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_visionzero_reassociate_missing_locations.py
+++ b/dags/atd_visionzero_reassociate_missing_locations.py
@@ -29,7 +29,7 @@ REQUIRED_SECRETS = {
     "HASURA_ADMIN_KEY": {
         "opitem": "Vision Zero graphql-engine Endpoints",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Key",
-    }, 
+    },
 }
 
 with DAG(
@@ -59,7 +59,6 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-
     # This process will find the locations for Non-CR3 crashes that do not have one but
     # fall into a location and they are not mainlanes.
     update_noncr3_locations = DockerOperator(
@@ -85,7 +84,6 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-
     # This process will remove the location for Non-CR3 crashes that are main-lanes.
     dissociate_noncr3 = DockerOperator(
         task_id="dissociate_noncr3",
@@ -109,4 +107,10 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-update_cr3_locations >> update_noncr3_locations >> dissociate_cr3 >> dissociate_noncr3 >> reassociate_wrong_locations
+(
+    update_cr3_locations
+    >> update_noncr3_locations
+    >> dissociate_cr3
+    >> dissociate_noncr3
+    >> reassociate_wrong_locations
+)


### PR DESCRIPTION
## Associated issues

This PR puts a couple more check marks on: https://github.com/cityofaustin/atd-data-tech/issues/12860

Sibling PR: https://github.com/cityofaustin/atd-vz-data/pull/1257

## Associated repo

`atd-vz-data`

## Testing

* Configure your local VZ `graphql-engine` service to listen on port `8084` if needed
* Spin up local VZDB & local `graphql-engine`
* Spin up local airflow
* Trigger `vision_zero_process_missing_pdfs`
* Trigger `vision_zero_reassociate_missing_locations`

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [x] Add note to 1PW secrets moved to API vault and check for duplicates