### PR TITLE
Update VZ Socrata ETL DAG var names to match the script it runs

### DIFF
--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -26,11 +26,11 @@ REQUIRED_SECRETS = {
         "opitem": "Vision Zero graphql-engine Endpoints",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Key",
     },
-    "SOCRATA_API_KEY_ID": {
+    "SOCRATA_KEY_ID": {
         "opitem": "Socrata Key ID, Secret, and Token",
         "opfield": "socrata.apiKeyId",
     },
-    "SOCRATA_API_KEY_SECRET": {
+    "SOCRATA_KEY_SECRET": {
         "opitem": "Socrata Key ID, Secret, and Token",
         "opfield": "socrata.apiKeySecret",
     },


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12495

Mismatched variable names - here is a fix!

## Associated repo
See testing

## Testing

**Steps to test:**
1. Compare the updated secrets names to [the vars used in the VZ script](https://github.com/cityofaustin/atd-vz-data/blob/3f9a3cc0aa991f00265e0419513c9c81942c061c/atd-etl/socrata_export/socrata_export.py#L27-L28) and make sure that they match up

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
- [ ] ~Add note to 1PW secrets moved to API vault and check for duplicates~