### PR TITLE
Use `data_interval_start` instead of `execution_date` for Slack webhook messages

### DIFF
--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -1,9 +1,18 @@
 from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
+from pendulum import timezone
 
 # This is the Conn Id that we set when creating the connection in the Airflow dashboard
 # in Admin > Connections.
 SLACK_CONN_ID = "slack"
+
+
+def get_central_time_exec_data(context):
+    local_tz = timezone("America/Chicago")
+    execution_date_timestamp = context.get("data_interval_start")
+    central_execution_date = local_tz.convert(execution_date_timestamp).format(
+        "MM/DD/YYYY hh:mm:ss A"
+    )
 
 
 def task_fail_slack_alert_critical(context):
@@ -43,7 +52,7 @@ def task_fail_slack_alert(context):
         task=context.get("task_instance").task_id,
         dag=context.get("task_instance").dag_id,
         ti=context.get("task_instance"),
-        exec_date=context.get("execution_date"),
+        exec_date=context.get("ts"),
         log_url=context.get("task_instance").log_url,
     )
     failed_alert = SlackWebhookOperator(

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -1,6 +1,5 @@
 from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
-from pendulum import timezone
 
 # This is the Conn Id that we set when creating the connection in the Airflow dashboard
 # in Admin > Connections.
@@ -8,6 +7,8 @@ SLACK_CONN_ID = "slack"
 
 
 def get_central_time_exec_data(context):
+    from pendulum import timezone
+
     local_tz = timezone("America/Chicago")
     execution_date_timestamp = context.get("data_interval_start")
     return local_tz.convert(execution_date_timestamp).format("MM/DD/YYYY hh:mm:ss A")

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -10,9 +10,7 @@ SLACK_CONN_ID = "slack"
 def get_central_time_exec_data(context):
     local_tz = timezone("America/Chicago")
     execution_date_timestamp = context.get("data_interval_start")
-    central_execution_date = local_tz.convert(execution_date_timestamp).format(
-        "MM/DD/YYYY hh:mm:ss A"
-    )
+    return local_tz.convert(execution_date_timestamp).format("MM/DD/YYYY hh:mm:ss A")
 
 
 def task_fail_slack_alert_critical(context):
@@ -27,7 +25,7 @@ def task_fail_slack_alert_critical(context):
         task=context.get("task_instance").task_id,
         dag=context.get("task_instance").dag_id,
         ti=context.get("task_instance"),
-        exec_date=context.get("execution_date"),
+        exec_date=get_central_time_exec_data(context),
         log_url=context.get("task_instance").log_url,
     )
     failed_alert = SlackWebhookOperator(
@@ -52,7 +50,7 @@ def task_fail_slack_alert(context):
         task=context.get("task_instance").task_id,
         dag=context.get("task_instance").dag_id,
         ti=context.get("task_instance"),
-        exec_date=context.get("ts"),
+        exec_date=get_central_time_exec_data(context),
         log_url=context.get("task_instance").log_url,
     )
     failed_alert = SlackWebhookOperator(
@@ -77,7 +75,7 @@ def task_success_slack_alert(context):
         task=context.get("task_instance").task_id,
         dag=context.get("task_instance").dag_id,
         ti=context.get("task_instance"),
-        exec_date=context.get("execution_date"),
+        exec_date=get_central_time_exec_data(context),
         log_url=context.get("task_instance").log_url,
     )
     success_alert = SlackWebhookOperator(


### PR DESCRIPTION
## Associated issues
n/a

Fixes `AirflowContextDeprecationWarning: Accessing 'execution_date' from the template is deprecated and will be removed in a future version. Please use 'data_interval_start' or 'logical_date' instead.` and formats the execution time to be in CST and be more readable. If anyone prefers the timestamp format, let me know and I'm happy to change it back.

See: 
- https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/taskflow.html#context
- https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/timezone.html#templates

## Associated repo
n/a

## Testing

**Steps to test:**
1. You can test this locally by commenting out line 42 and then printing `slack_msg` after line 55 and then triggering the Slack webhook test DAG
2. Or, you can set up the webhook locally if you really want to 🚨

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates