### PR TITLE
Increase VZ Socrata DAG timeout

### DIFF
--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -53,7 +53,7 @@ with DAG(
     description="Exports Vision Zero crash and people datasets to Socrata from Vision Zero database.",
     default_args=default_args,
     schedule_interval="0 4 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
-    dagrun_timeout=duration(minutes=20),
+    dagrun_timeout=duration(minutes=40),
     tags=["repo:atd-vz-data", "socrata"],
     catchup=False,
 ) as dag:

--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -13,7 +13,7 @@ default_args = {
     "owner": "airflow",
     "depends_on_past": False,
     "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
-    "retries": 0,
+    "retries": 2,
     "on_failure_callback": task_fail_slack_alert,
 }
 


### PR DESCRIPTION
## Associated issues
n/a

This ETL is taking longer than expected in Airflow v2 so I'm doubling the timeout. It also received a 500 from Socrata so I added a couple of retries. Open to any other suggestions! This was a really solid ETL in v1 so I'm hoping that this just bad luck this week.

## Associated repo

## Testing

**Steps to test:**
1. Not much to test here. The ETL ran successfully - it just took longer than expected.

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates