### PR TITLE
Migrate Knack <> Banner DAG from Prefect to Airflow

### DIFF
--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -46,7 +46,7 @@ with DAG(
     dag_id=f"atd_knack_banner",
     description="Update knack HR app based on records in Banner and CTM",
     default_args=DEFAULT_ARGS,
-    schedule_interval="45 8 * * *" if DEPLOYMENT_ENVIRONMENT == "prod" else None,
+    schedule_interval="45 7 * * *" if DEPLOYMENT_ENVIRONMENT == "prod" else None,
     dagrun_timeout=duration(minutes=30),
     tags=["repo:atd-knack-banner", "knack"],
     catchup=False,

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -64,7 +64,6 @@ with DAG(
         tty=True,
         force_pull=True,
         mount_tmp_dir=False,
-        network_mode="host",
     )
 
     update_employees

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -1,0 +1,70 @@
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from airflow.decorators import task
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+
+REQUIRED_SECRETS = {
+    "BANNER_URL": {
+        "opitem": "HRD Banner API",
+        "opfield": f"production.endpoint",
+    },
+    "BANNER_API_KEY": {
+        "opitem": "HRD Banner API",
+        "opfield": f"production.apiKey",
+    },
+    "KNACK_APP_ID": {
+        "opitem": "Knack Human Resources (HR)",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack Human Resources (HR)",
+        "opfield": f"production.apiKey",
+    },
+}
+
+
+with DAG(
+    dag_id=f"atd_knack_banner",
+    description="Update knack HR app based on records in Banner and CTM",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="45 8 * * *" if DEPLOYMENT_ENVIRONMENT == "prod" else None,
+    dagrun_timeout=duration(minutes=30),
+    tags=["repo:atd-knack-banner", "knack"],
+    catchup=False,
+) as dag:
+    docker_image = f"atddocker/atd-knack-banner:production"
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    update_employees = DockerOperator(
+        task_id="update_employees",
+        image=docker_image,
+        auto_remove=True,
+        command=f"./atd-knack-banner/update_employees.py",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+        network_mode="bridge",
+    )
+
+    update_employees

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -46,7 +46,7 @@ with DAG(
     dag_id=f"atd_knack_banner",
     description="Update knack HR app based on records in Banner and CTM",
     default_args=DEFAULT_ARGS,
-    schedule_interval="45 7 * * *" if DEPLOYMENT_ENVIRONMENT == "prod" else None,
+    schedule_interval="45 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=30),
     tags=["repo:atd-knack-banner", "knack"],
     catchup=False,
@@ -64,7 +64,7 @@ with DAG(
         tty=True,
         force_pull=True,
         mount_tmp_dir=False,
-        network_mode="bridge",
+        network_mode="host",
     )
 
     update_employees


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/13084

## Associated repo
- [atd-knack-banner](https://github.com/cityofaustin/atd-knack-banner)

## Testing
- Once [this PR](https://github.com/cityofaustin/atd-knack-banner/pull/13) is merged, you can test this locally by getting on VPN and triggering the DAG.

I think this will still fail because of a data quality issue discussed [here](https://austininnovation.slack.com/archives/C026ZRP1TH8/p1691425344344869). But the DAG should run and report an error related to a duplicate email address in Knack.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates