### PR TITLE
Trail Counters sliding 7 day window

### DIFF
--- a/dags/atd_trail_counters.py
+++ b/dags/atd_trail_counters.py
@@ -42,6 +42,10 @@ REQUIRED_SECRETS = {
         "opitem": "Trail Counters",
         "opfield": "production.Dataset ID",
     },
+    "DEVICE_DATASET": {
+        "opitem": "Trail Counters",
+        "opfield": "production.Device ID",
+    },
 }
 
 with DAG(

--- a/dags/atd_trail_counters.py
+++ b/dags/atd_trail_counters.py
@@ -23,7 +23,7 @@ default_args = {
     "on_failure_callback": task_fail_slack_alert,
 }
 
-docker_image = "atddocker/atd-trail-counters:latest"
+docker_image = "atddocker/atd-trail-counters:production"
 
 REQUIRED_SECRETS = {
     "SO_WEB": {

--- a/dags/atd_trail_counters.py
+++ b/dags/atd_trail_counters.py
@@ -55,7 +55,7 @@ with DAG(
 ) as dag:
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    start = "{{ prev_start_date_success.strftime('%Y-%m-%d') if prev_start_date_success else '1970-01-01'}}"
+    start = "{{ (prev_start_date_success - macros.timedelta(days=7)).strftime('%Y-%m-%d') if prev_start_date_success else '1970-01-01'}}"
     t1 = DockerOperator(
         task_id="trail_counter_data_publish",
         image=docker_image,


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/8642

I noticed that we had only one sensor reporting data to this [dataset](https://datahub.austintexas.gov/Transportation-and-Mobility/Trail-Counters-Daily-Totals/26tt-cp67) after migrating to airflow meanwhile the ecocounter data portal was still reporting data for multiple sensors. I believe this is because that one sensor was reporting data earlier than the others? So I'm adding a one week sliding window for our data instead of just 24h and hoping we catch the update.

## Associated repo
https://github.com/cityofaustin/atd-trail-counter-data

## Testing

**Steps to test:**
1. `docker compose run --rm airflow-cli dags test atd_trail_counters`
2. Verify you get data from multiple sensors like `22 records found for Shoal Creek Trail & 9th St - Urban Trail`

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates