### PR TITLE
KITS DMS messages to Knack ETL

### DIFF
--- a/dags/atd_kits_dms_message.py
+++ b/dags/atd_kits_dms_message.py
@@ -1,0 +1,78 @@
+# Test locally with: docker compose run --rm airflow-cli dags test atd_kits_dms_message_pub
+
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration, now
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+from utils.knack import get_date_filter_arg
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.apiKey",
+    },
+    "KITS_SERVER": {
+        "opitem": "KITS Traffic Signal Management System",
+        "opfield": "production.server",
+    },
+    "KITS_DATABSE": {
+        "opitem": "KITS Traffic Signal Management System",
+        "opfield": "production.database",
+    },
+    "KITS_USER": {
+        "opitem": "KITS Traffic Signal Management System",
+        "opfield": "production.username",
+    },
+    "KITS_PASSWORD": {
+        "opitem": "KITS Traffic Signal Management System",
+        "opfield": "production.password",
+    },
+}
+
+
+with DAG(
+    dag_id="atd_kits_dms_message_pub",
+    description="Extract DMS message from KITS database and upload to Data Tracker (Knack).",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="21 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=5),
+    tags=["repo:atd-kits", "knack", "kits", "dms"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/atd-kits:latest"
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="update_knack_dms_message",
+        image=docker_image,
+        auto_remove=True,
+        command="python ./atd-kits/atd-kits/dms_message_pub.py",
+        environment=env_vars,
+        tty=True,
+        # force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t1

--- a/dags/atd_kits_dms_message.py
+++ b/dags/atd_kits_dms_message.py
@@ -60,7 +60,7 @@ with DAG(
     tags=["repo:atd-kits", "knack", "kits", "dms"],
     catchup=False,
 ) as dag:
-    docker_image = "atddocker/atd-kits:latest"
+    docker_image = "atddocker/atd-kits:production"
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
@@ -71,7 +71,7 @@ with DAG(
         command="python ./atd-kits/atd-kits/dms_message_pub.py",
         environment=env_vars,
         tty=True,
-        # force_pull=True,
+        force_pull=True,
         mount_tmp_dir=False,
     )
 


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/13237

## Associated repo
https://github.com/cityofaustin/atd-kits

## Testing

**Steps to test:**

1. You must be on the VPN/City Network to be able to hit the KITS DB.  
2. Clone this Airflow branch from this PR then run it with `docker compose run --rm airflow-cli dags test atd_kits_dms_message_pub` while in the atd-airflow directory.
3. Good chance you'll get a `Updating 0 records in Knack.` because the knack records are already up to date with what's in KITS. You can test updating the knack records by manually editing the `DMS_MESSAGE` field to something else in a few records in the [TEST data tracker app here](https://builder.knack.com/atd/test--austin-transportation-data-tracker--30-aug-2022/records/objects/object_109). Then you should get: `Updating X records in Knack.` in a logs based on how many records you changed.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates