### PR TITLE
Secondary Signals ETL

### DIFF
--- a/dags/atd_knack_secondary_signals.py
+++ b/dags/atd_knack_secondary_signals.py
@@ -1,0 +1,58 @@
+# test locally with: docker compose run --rm airflow-cli dags test atd_knack_secondary_signals
+
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiKey",
+    },
+}
+
+with DAG(
+    dag_id="atd_knack_secondary_signals",
+    description="Update traffic signal records with secondary signal relationships.",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="25 2 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=60),
+    tags=["repo:atd-knack-services", "knack", "data-tracker"],
+    catchup=False,
+) as dag:
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="update_secondary_signals",
+        image="atddocker/atd-knack-services:production",
+        auto_remove=True,
+        command=f"./atd-knack-services/services/secondary_signals_updater.py -a data-tracker -c view_197",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t1

--- a/dags/atd_knack_secondary_signals.py
+++ b/dags/atd_knack_secondary_signals.py
@@ -18,7 +18,7 @@ DEFAULT_ARGS = {
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 0,
-    "retry_delay": duration(minutes=5),
+    "execution_timeout": duration(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }
 
@@ -38,7 +38,6 @@ with DAG(
     description="Update traffic signal records with secondary signal relationships.",
     default_args=DEFAULT_ARGS,
     schedule_interval="25 2 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
-    dagrun_timeout=duration(minutes=60),
     tags=["repo:atd-knack-services", "knack", "data-tracker"],
     catchup=False,
 ) as dag:


### PR DESCRIPTION
Migrating another [data-deploy ETL](https://github.com/cityofaustin/atd-data-deploy/pull/99) to airflow.

## Associated issues

## Associated repo
[atd-knack-services](https://github.com/cityofaustin/atd-knack-services/)

## Testing

**Steps to test:**
1. Checkout this branch
2. `docker compose run --rm airflow-cli dags test atd_knack_secondary_signals`
3. Check in the logs that it successfully ran, most likely with:
```
INFO - ./atd-knack-services/services/secondary_signals_updater.py.INFO: No changes detected in Knack, doing nothing.
``` 
These updates are rare, so it's hard to test actually reassigning the secondary signals.  

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates