### PR TITLE
Update Schedule for atd_knack_inventory_items_nightly_snapshot.py

### DIFF
--- a/dags/atd_knack_inventory_items_nightly_snapshot.py
+++ b/dags/atd_knack_inventory_items_nightly_snapshot.py
@@ -56,7 +56,7 @@ with DAG(
     dag_id="atd_knack_inventory_items_nightly_snapshot",
     description="Appends inventory item counts to running log in Socrata",
     default_args=DEFAULT_ARGS,
-    schedule_interval="13 4 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="13 23 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=5),
     tags=["repo:atd-knack-services", "knack", "socrata"],
     catchup=False,


### PR DESCRIPTION
Ronnie wants this ETL to run EOD (like how it used to), but it's running at 4AM. I guess Airflow v1 was in UTC, while now we're in local time?

Old 
<img width="319" alt="Screenshot 2023-08-10 at 9 26 35 AM" src="https://github.com/cityofaustin/atd-airflow/assets/30810522/6207fcb5-ff3f-4743-a055-cf4bcb25cb88">

Since July 17
<img width="266" alt="Screenshot 2023-08-10 at 9 26 59 AM" src="https://github.com/cityofaustin/atd-airflow/assets/30810522/a7d5871e-47d8-44fd-97e5-deecf87f21e0">


## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/13318

## Associated repo
[atd-knack-services](https://github.com/cityofaustin/atd-knack-services)

## Testing
None needed, just changing the schedule.

**Steps to test:**


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates