### PR TITLE
Port atd-finance-data to Airflow

### DIFF
--- a/dags/atd_finance_data_fdus.py
+++ b/dags/atd_finance_data_fdus.py
@@ -1,0 +1,162 @@
+# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_task_orders
+
+import os
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=60),  # some queries are very slow
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+# Data tracker Knack app secrets
+DATA_TRACKER_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": "production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": "production.apiKey",
+    },
+}
+
+# Finance purchasing Knack app secrets
+FINANCE_PURCHASING_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack Finance and Purchasing",
+        "opfield": "production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack Finance and Purchasing",
+        "opfield": "production.apiKey",
+    },
+}
+
+OTHER_SECRETS = {
+    "USER": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Username",
+    },
+    "PASSWORD": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Password",
+    },
+    "HOST": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Host",
+    },
+    "PORT": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Port",
+    },
+    "SERVICE": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Service",
+    },
+    "BUCKET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Bucket",
+    },
+    "BUCKET_NAME": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Bucket",
+    },
+    "AWS_ACCESS_KEY_ID": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Access ID",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Secret Access Key",
+    },
+    "AWS_ACCESS_ID": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Access ID",
+    },
+    "AWS_PASS": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Secret Access Key",
+    },
+    "TASK_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Task Dataset ID",
+    },
+    "FDU_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.FDU Dataset ID",
+    },
+    "DEPT_UNITS_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Department Units Dataset ID",
+    },
+    "SO_USER": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SO_PASS": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SO_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "SO_WEB": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.endpoint",
+    },
+}
+
+# Combine env vars to create one for each Knack app
+DATA_TRACKER_SECRETS.update(OTHER_SECRETS)
+FINANCE_PURCHASING_SECRETS.update(OTHER_SECRETS)
+
+with DAG(
+    dag_id="atd_finance_data_fdus",
+    description="Gets Finance data from a database, places it in an S3 bucket, then moves it along to Knack and socrata.",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="33 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:atd-finance-data", "knack", "data-tracker", "socrata"],
+    catchup=False,
+) as dag:
+    data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
+    finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="task_orders_to_s3",
+        image="atddocker/atd-finance-data:production",
+        auto_remove=True,
+        command="python upload_to_s3.py fdus",
+        environment=data_tracker_env,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t2 = DockerOperator(
+        task_id="task_orders_to_finance_purchasing",
+        image="atddocker/atd-finance-data:production",
+        auto_remove=True,
+        command="python s3_to_socrata.py --dataset fdus",
+        environment=finance_purchasing_env,
+        tty=True,
+        force_pull=False,
+        mount_tmp_dir=False,
+    )
+
+    t1 >> t2

--- a/dags/atd_finance_data_fdus.py
+++ b/dags/atd_finance_data_fdus.py
@@ -138,7 +138,7 @@ with DAG(
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
     t1 = DockerOperator(
-        task_id="task_orders_to_s3",
+        task_id="fdus_to_s3",
         image="atddocker/atd-finance-data:production",
         auto_remove=True,
         command="python upload_to_s3.py fdus",
@@ -149,7 +149,7 @@ with DAG(
     )
 
     t2 = DockerOperator(
-        task_id="task_orders_to_finance_purchasing",
+        task_id="fdus_to_socrata",
         image="atddocker/atd-finance-data:production",
         auto_remove=True,
         command="python s3_to_socrata.py --dataset fdus",

--- a/dags/atd_finance_data_fdus.py
+++ b/dags/atd_finance_data_fdus.py
@@ -1,4 +1,4 @@
-# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_task_orders
+# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_fdus
 
 import os
 
@@ -72,23 +72,11 @@ OTHER_SECRETS = {
         "opitem": "atd-finance-data",
         "opfield": "production.Bucket",
     },
-    "BUCKET_NAME": {
-        "opitem": "atd-finance-data",
-        "opfield": "production.Bucket",
-    },
     "AWS_ACCESS_KEY_ID": {
         "opitem": "atd-finance-data",
         "opfield": "production.Access ID",
     },
     "AWS_SECRET_ACCESS_KEY": {
-        "opitem": "atd-finance-data",
-        "opfield": "production.Secret Access Key",
-    },
-    "AWS_ACCESS_ID": {
-        "opitem": "atd-finance-data",
-        "opfield": "production.Access ID",
-    },
-    "AWS_PASS": {
         "opitem": "atd-finance-data",
         "opfield": "production.Secret Access Key",
     },
@@ -103,6 +91,10 @@ OTHER_SECRETS = {
     "DEPT_UNITS_DATASET": {
         "opitem": "atd-finance-data",
         "opfield": "production.Department Units Dataset ID",
+    },
+    "SUBPROJECTS_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Subprojects Dataset ID",
     },
     "SO_USER": {
         "opitem": "Socrata Key ID, Secret, and Token",

--- a/dags/atd_finance_data_master_agreements.py
+++ b/dags/atd_finance_data_master_agreements.py
@@ -1,4 +1,4 @@
-# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_task_orders
+# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_master_agreements
 
 import os
 
@@ -72,23 +72,11 @@ OTHER_SECRETS = {
         "opitem": "atd-finance-data",
         "opfield": "production.Bucket",
     },
-    "BUCKET_NAME": {
-        "opitem": "atd-finance-data",
-        "opfield": "production.Bucket",
-    },
     "AWS_ACCESS_KEY_ID": {
         "opitem": "atd-finance-data",
         "opfield": "production.Access ID",
     },
     "AWS_SECRET_ACCESS_KEY": {
-        "opitem": "atd-finance-data",
-        "opfield": "production.Secret Access Key",
-    },
-    "AWS_ACCESS_ID": {
-        "opitem": "atd-finance-data",
-        "opfield": "production.Access ID",
-    },
-    "AWS_PASS": {
         "opitem": "atd-finance-data",
         "opfield": "production.Secret Access Key",
     },
@@ -103,6 +91,10 @@ OTHER_SECRETS = {
     "DEPT_UNITS_DATASET": {
         "opitem": "atd-finance-data",
         "opfield": "production.Department Units Dataset ID",
+    },
+    "SUBPROJECTS_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Subprojects Dataset ID",
     },
     "SO_USER": {
         "opitem": "Socrata Key ID, Secret, and Token",

--- a/dags/atd_finance_data_master_agreements.py
+++ b/dags/atd_finance_data_master_agreements.py
@@ -138,7 +138,7 @@ with DAG(
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
     t1 = DockerOperator(
-        task_id="task_orders_to_s3",
+        task_id="master_agreements_to_s3",
         image="atddocker/atd-finance-data:production",
         auto_remove=True,
         command="python upload_to_s3.py master_agreements",

--- a/dags/atd_finance_data_master_agreements.py
+++ b/dags/atd_finance_data_master_agreements.py
@@ -1,0 +1,151 @@
+# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_task_orders
+
+import os
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=60),  # some queries are very slow
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+# Data tracker Knack app secrets
+DATA_TRACKER_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": "production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": "production.apiKey",
+    },
+}
+
+# Finance purchasing Knack app secrets
+FINANCE_PURCHASING_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack Finance and Purchasing",
+        "opfield": "production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack Finance and Purchasing",
+        "opfield": "production.apiKey",
+    },
+}
+
+OTHER_SECRETS = {
+    "USER": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Username",
+    },
+    "PASSWORD": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Password",
+    },
+    "HOST": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Host",
+    },
+    "PORT": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Port",
+    },
+    "SERVICE": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Service",
+    },
+    "BUCKET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Bucket",
+    },
+    "BUCKET_NAME": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Bucket",
+    },
+    "AWS_ACCESS_KEY_ID": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Access ID",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Secret Access Key",
+    },
+    "AWS_ACCESS_ID": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Access ID",
+    },
+    "AWS_PASS": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Secret Access Key",
+    },
+    "TASK_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Task Dataset ID",
+    },
+    "FDU_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.FDU Dataset ID",
+    },
+    "DEPT_UNITS_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Department Units Dataset ID",
+    },
+    "SO_USER": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SO_PASS": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SO_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "SO_WEB": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.endpoint",
+    },
+}
+
+# Combine env vars to create one for each Knack app
+DATA_TRACKER_SECRETS.update(OTHER_SECRETS)
+FINANCE_PURCHASING_SECRETS.update(OTHER_SECRETS)
+
+with DAG(
+    dag_id="atd_finance_data_master_agreements",
+    description="Gets Finance data from a database, places it in an S3 bucket, then moves it along to Knack and socrata.",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="28 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:atd-finance-data", "knack", "data-tracker", "socrata"],
+    catchup=False,
+) as dag:
+    data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
+    finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="task_orders_to_s3",
+        image="atddocker/atd-finance-data:production",
+        auto_remove=True,
+        command="python upload_to_s3.py master_agreements",
+        environment=data_tracker_env,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t1

--- a/dags/atd_finance_data_objects.py
+++ b/dags/atd_finance_data_objects.py
@@ -1,0 +1,151 @@
+# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_task_orders
+
+import os
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=60),  # some queries are very slow
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+# Data tracker Knack app secrets
+DATA_TRACKER_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": "production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": "production.apiKey",
+    },
+}
+
+# Finance purchasing Knack app secrets
+FINANCE_PURCHASING_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack Finance and Purchasing",
+        "opfield": "production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack Finance and Purchasing",
+        "opfield": "production.apiKey",
+    },
+}
+
+OTHER_SECRETS = {
+    "USER": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Username",
+    },
+    "PASSWORD": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Password",
+    },
+    "HOST": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Host",
+    },
+    "PORT": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Port",
+    },
+    "SERVICE": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Service",
+    },
+    "BUCKET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Bucket",
+    },
+    "BUCKET_NAME": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Bucket",
+    },
+    "AWS_ACCESS_KEY_ID": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Access ID",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Secret Access Key",
+    },
+    "AWS_ACCESS_ID": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Access ID",
+    },
+    "AWS_PASS": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Secret Access Key",
+    },
+    "TASK_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Task Dataset ID",
+    },
+    "FDU_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.FDU Dataset ID",
+    },
+    "DEPT_UNITS_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Department Units Dataset ID",
+    },
+    "SO_USER": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SO_PASS": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SO_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "SO_WEB": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.endpoint",
+    },
+}
+
+# Combine env vars to create one for each Knack app
+DATA_TRACKER_SECRETS.update(OTHER_SECRETS)
+FINANCE_PURCHASING_SECRETS.update(OTHER_SECRETS)
+
+with DAG(
+    dag_id="atd_finance_data_objects",
+    description="Gets Finance data from a database, places it in an S3 bucket, then moves it along to Knack and socrata.",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="23 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:atd-finance-data", "knack", "data-tracker", "socrata"],
+    catchup=False,
+) as dag:
+    data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
+    finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="task_orders_to_s3",
+        image="atddocker/atd-finance-data:production",
+        auto_remove=True,
+        command="python upload_to_s3.py objects",
+        environment=data_tracker_env,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t1

--- a/dags/atd_finance_data_objects.py
+++ b/dags/atd_finance_data_objects.py
@@ -138,7 +138,7 @@ with DAG(
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
     t1 = DockerOperator(
-        task_id="task_orders_to_s3",
+        task_id="objects_to_s3",
         image="atddocker/atd-finance-data:production",
         auto_remove=True,
         command="python upload_to_s3.py objects",

--- a/dags/atd_finance_data_task_orders.py
+++ b/dags/atd_finance_data_task_orders.py
@@ -171,7 +171,7 @@ with DAG(
     )
 
     t4 = DockerOperator(
-        task_id="task_orders_to_finance_purchasing",
+        task_id="task_orders_to_socrata",
         image="atddocker/atd-finance-data:production",
         auto_remove=True,
         command="python s3_to_socrata.py --dataset task_orders",

--- a/dags/atd_finance_data_task_orders.py
+++ b/dags/atd_finance_data_task_orders.py
@@ -1,4 +1,4 @@
-# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_task_orders
+# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_subprojects
 
 import os
 
@@ -72,23 +72,11 @@ OTHER_SECRETS = {
         "opitem": "atd-finance-data",
         "opfield": "production.Bucket",
     },
-    "BUCKET_NAME": {
-        "opitem": "atd-finance-data",
-        "opfield": "production.Bucket",
-    },
     "AWS_ACCESS_KEY_ID": {
         "opitem": "atd-finance-data",
         "opfield": "production.Access ID",
     },
     "AWS_SECRET_ACCESS_KEY": {
-        "opitem": "atd-finance-data",
-        "opfield": "production.Secret Access Key",
-    },
-    "AWS_ACCESS_ID": {
-        "opitem": "atd-finance-data",
-        "opfield": "production.Access ID",
-    },
-    "AWS_PASS": {
         "opitem": "atd-finance-data",
         "opfield": "production.Secret Access Key",
     },
@@ -103,6 +91,10 @@ OTHER_SECRETS = {
     "DEPT_UNITS_DATASET": {
         "opitem": "atd-finance-data",
         "opfield": "production.Department Units Dataset ID",
+    },
+    "SUBPROJECTS_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Subprojects Dataset ID",
     },
     "SO_USER": {
         "opitem": "Socrata Key ID, Secret, and Token",
@@ -130,7 +122,7 @@ with DAG(
     dag_id="atd_finance_data_task_orders",
     description="Gets Finance data from a database, places it in an S3 bucket, then moves it along to Knack and socrata.",
     default_args=DEFAULT_ARGS,
-    schedule_interval="13 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="38 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-finance-data", "knack", "data-tracker", "socrata"],
     catchup=False,
 ) as dag:

--- a/dags/atd_finance_data_task_orders.py
+++ b/dags/atd_finance_data_task_orders.py
@@ -1,0 +1,184 @@
+# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_task_orders
+
+import os
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=60),  # some queries are very slow
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+# Data tracker Knack app secrets
+DATA_TRACKER_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": "production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": "production.apiKey",
+    },
+}
+
+# Finance purchasing Knack app secrets
+FINANCE_PURCHASING_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack Finance and Purchasing",
+        "opfield": "production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack Finance and Purchasing",
+        "opfield": "production.apiKey",
+    },
+}
+
+OTHER_SECRETS = {
+    "USER": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Username",
+    },
+    "PASSWORD": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Password",
+    },
+    "HOST": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Host",
+    },
+    "PORT": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Port",
+    },
+    "SERVICE": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Service",
+    },
+    "BUCKET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Bucket",
+    },
+    "BUCKET_NAME": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Bucket",
+    },
+    "AWS_ACCESS_KEY_ID": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Access ID",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Secret Access Key",
+    },
+    "AWS_ACCESS_ID": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Access ID",
+    },
+    "AWS_PASS": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Secret Access Key",
+    },
+    "TASK_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Task Dataset ID",
+    },
+    "FDU_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.FDU Dataset ID",
+    },
+    "DEPT_UNITS_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Department Units Dataset ID",
+    },
+    "SO_USER": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SO_PASS": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SO_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "SO_WEB": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.endpoint",
+    },
+}
+
+# Combine env vars to create one for each Knack app
+DATA_TRACKER_SECRETS.update(OTHER_SECRETS)
+FINANCE_PURCHASING_SECRETS.update(OTHER_SECRETS)
+
+with DAG(
+    dag_id="atd_finance_data_task_orders",
+    description="Gets Finance data from a database, places it in an S3 bucket, then moves it along to Knack and socrata.",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="13 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:atd-finance-data", "knack", "data-tracker", "socrata"],
+    catchup=False,
+) as dag:
+    data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
+    finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="task_orders_to_s3",
+        image="atddocker/atd-finance-data:production",
+        auto_remove=True,
+        command="python upload_to_s3.py task_orders",
+        environment=data_tracker_env,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t2 = DockerOperator(
+        task_id="task_orders_to_data_tracker",
+        image="atddocker/atd-finance-data:production",
+        auto_remove=True,
+        command="python s3_to_knack.py task_orders data-tracker",
+        environment=data_tracker_env,
+        tty=True,
+        force_pull=False,
+        mount_tmp_dir=False,
+    )
+
+    t3 = DockerOperator(
+        task_id="task_orders_to_finance_purchasing",
+        image="atddocker/atd-finance-data:production",
+        auto_remove=True,
+        command="python s3_to_knack.py task_orders finance-purchasing",
+        environment=finance_purchasing_env,
+        tty=True,
+        force_pull=False,
+        mount_tmp_dir=False,
+    )
+
+    t4 = DockerOperator(
+        task_id="task_orders_to_finance_purchasing",
+        image="atddocker/atd-finance-data:production",
+        auto_remove=True,
+        command="python s3_to_socrata.py --dataset task_orders",
+        environment=finance_purchasing_env,
+        tty=True,
+        force_pull=False,
+        mount_tmp_dir=False,
+    )
+
+    t1 >> t2 >> t3 >> t4

--- a/dags/atd_finance_data_units.py
+++ b/dags/atd_finance_data_units.py
@@ -1,0 +1,173 @@
+# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_task_orders
+
+import os
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=60),  # some queries are very slow
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+# Data tracker Knack app secrets
+DATA_TRACKER_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": "production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": "production.apiKey",
+    },
+}
+
+# Finance purchasing Knack app secrets
+FINANCE_PURCHASING_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack Finance and Purchasing",
+        "opfield": "production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack Finance and Purchasing",
+        "opfield": "production.apiKey",
+    },
+}
+
+OTHER_SECRETS = {
+    "USER": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Username",
+    },
+    "PASSWORD": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Password",
+    },
+    "HOST": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Host",
+    },
+    "PORT": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Port",
+    },
+    "SERVICE": {
+        "opitem": "Finance Data Warehouse Oracle DB",
+        "opfield": "production.Service",
+    },
+    "BUCKET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Bucket",
+    },
+    "BUCKET_NAME": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Bucket",
+    },
+    "AWS_ACCESS_KEY_ID": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Access ID",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Secret Access Key",
+    },
+    "AWS_ACCESS_ID": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Access ID",
+    },
+    "AWS_PASS": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Secret Access Key",
+    },
+    "TASK_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Task Dataset ID",
+    },
+    "FDU_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.FDU Dataset ID",
+    },
+    "DEPT_UNITS_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Department Units Dataset ID",
+    },
+    "SO_USER": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SO_PASS": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SO_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "SO_WEB": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.endpoint",
+    },
+}
+
+# Combine env vars to create one for each Knack app
+DATA_TRACKER_SECRETS.update(OTHER_SECRETS)
+FINANCE_PURCHASING_SECRETS.update(OTHER_SECRETS)
+
+with DAG(
+    dag_id="atd_finance_data_units",
+    description="Gets Finance data from a database, places it in an S3 bucket, then moves it along to Knack and socrata.",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="18 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:atd-finance-data", "knack", "data-tracker", "socrata"],
+    catchup=False,
+) as dag:
+    data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
+    finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="task_orders_to_s3",
+        image="atddocker/atd-finance-data:production",
+        auto_remove=True,
+        command="python upload_to_s3.py units",
+        environment=data_tracker_env,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t2 = DockerOperator(
+        task_id="task_orders_to_data_tracker",
+        image="atddocker/atd-finance-data:production",
+        auto_remove=True,
+        command="python s3_to_knack.py units data-tracker",
+        environment=data_tracker_env,
+        tty=True,
+        force_pull=False,
+        mount_tmp_dir=False,
+    )
+
+    t3 = DockerOperator(
+        task_id="task_orders_to_finance_purchasing",
+        image="atddocker/atd-finance-data:production",
+        auto_remove=True,
+        command="python s3_to_socrata.py --dataset dept_units",
+        environment=finance_purchasing_env,
+        tty=True,
+        force_pull=False,
+        mount_tmp_dir=False,
+    )
+
+    t1 >> t2 >> t3

--- a/dags/atd_finance_data_units.py
+++ b/dags/atd_finance_data_units.py
@@ -1,4 +1,4 @@
-# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_task_orders
+# test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_units
 
 import os
 
@@ -72,23 +72,11 @@ OTHER_SECRETS = {
         "opitem": "atd-finance-data",
         "opfield": "production.Bucket",
     },
-    "BUCKET_NAME": {
-        "opitem": "atd-finance-data",
-        "opfield": "production.Bucket",
-    },
     "AWS_ACCESS_KEY_ID": {
         "opitem": "atd-finance-data",
         "opfield": "production.Access ID",
     },
     "AWS_SECRET_ACCESS_KEY": {
-        "opitem": "atd-finance-data",
-        "opfield": "production.Secret Access Key",
-    },
-    "AWS_ACCESS_ID": {
-        "opitem": "atd-finance-data",
-        "opfield": "production.Access ID",
-    },
-    "AWS_PASS": {
         "opitem": "atd-finance-data",
         "opfield": "production.Secret Access Key",
     },
@@ -103,6 +91,10 @@ OTHER_SECRETS = {
     "DEPT_UNITS_DATASET": {
         "opitem": "atd-finance-data",
         "opfield": "production.Department Units Dataset ID",
+    },
+    "SUBPROJECTS_DATASET": {
+        "opitem": "atd-finance-data",
+        "opfield": "production.Subprojects Dataset ID",
     },
     "SO_USER": {
         "opitem": "Socrata Key ID, Secret, and Token",

--- a/dags/atd_finance_data_units.py
+++ b/dags/atd_finance_data_units.py
@@ -138,7 +138,7 @@ with DAG(
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
     t1 = DockerOperator(
-        task_id="task_orders_to_s3",
+        task_id="units_orders_to_s3",
         image="atddocker/atd-finance-data:production",
         auto_remove=True,
         command="python upload_to_s3.py units",
@@ -149,7 +149,7 @@ with DAG(
     )
 
     t2 = DockerOperator(
-        task_id="task_orders_to_data_tracker",
+        task_id="units_to_data_tracker",
         image="atddocker/atd-finance-data:production",
         auto_remove=True,
         command="python s3_to_knack.py units data-tracker",
@@ -160,7 +160,7 @@ with DAG(
     )
 
     t3 = DockerOperator(
-        task_id="task_orders_to_finance_purchasing",
+        task_id="units_to_socrata",
         image="atddocker/atd-finance-data:production",
         auto_remove=True,
         command="python s3_to_socrata.py --dataset dept_units",


### PR DESCRIPTION
Moving this [prefect flow](https://github.com/cityofaustin/atd-prefect/blob/main/flows/atd-finance-data/finance_data_to_s3.py) to airflow 2. I created a separate DAG for each type of data rather than making one giant DAG. Schedule is offset by 5 minutes per dataset.

## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12376

## Associated repo
https://github.com/cityofaustin/atd-finance-data

## Testing

**Steps to test:**
1. Checkout this branch
2. Feel free to test any of these with the command at the top of the file or using the airflow UI

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates