### PR TITLE
Microstrategy Revenue/Expenses Orchestration 

### DIFF
--- a/dags/atd_executive_dashboard_expenses_revenue.py
+++ b/dags/atd_executive_dashboard_expenses_revenue.py
@@ -112,7 +112,7 @@ with DAG(
         command=f"python finance-reports/mstro_reports_to_socrata.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
+        force_pull=False,
     )
 
     t1 >> t2

--- a/dags/atd_executive_dashboard_expenses_revenue.py
+++ b/dags/atd_executive_dashboard_expenses_revenue.py
@@ -1,0 +1,118 @@
+# test locally with: docker compose run --rm airflow-cli dags test atd_executive_dashboard_expenses_revenue
+
+import os
+
+from datetime import datetime, timedelta
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 12, 1),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+docker_image = "atddocker/atd-executive-dashboard:production"
+
+REQUIRED_SECRETS = {
+    "SO_WEB": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.endpoint",
+    },
+    "SO_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "SO_SECRET": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SO_KEY": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "EXP_DATASET": {
+        "opitem": "Executive Dashboard",
+        "opfield": "datasets.Expenses",
+    },
+    "REV_DATASET": {
+        "opitem": "Executive Dashboard",
+        "opfield": "datasets.Revenue",
+    },
+    "BUCKET_NAME": {
+        "opitem": "Executive Dashboard",
+        "opfield": "s3.Bucket",
+    },
+    "AWS_ACCESS_KEY": {
+        "opitem": "Executive Dashboard",
+        "opfield": "s3.AWS Access Key",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "opitem": "Executive Dashboard",
+        "opfield": "s3.AWS Secret Access Key",
+    },
+    "BASE_URL": {
+        "opitem": "Microstrategy API",
+        "opfield": "shared.Base URL",
+    },
+    "PROJECT_ID": {
+        "opitem": "Microstrategy API",
+        "opfield": "shared.Project ID",
+    },
+    "MSTRO_USERNAME": {
+        "opitem": "Microstrategy API",
+        "opfield": "shared.Username",
+    },
+    "MSTRO_PASSWORD": {
+        "opitem": "Microstrategy API",
+        "opfield": "shared.Password",
+    },
+}
+
+with DAG(
+    dag_id="atd_executive_dashboard_expenses_revenue",
+    description="Downloads two Microstrategy Reports for Expenses and Revenue. \
+    Places the results as a CSV in a S3 bucket. \
+    Then publishes the data to a Socrata dataset",
+    default_args=default_args,
+    schedule_interval="00 11 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=timedelta(minutes=120),
+    tags=["repo:atd-executive-dashboard", "socrata", "microstrategy"],
+    catchup=False,
+) as dag:
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="download_microstrategy_reports",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f"python finance-reports/rev_exp_report_to_s3.py",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+    )
+
+    t2 = DockerOperator(
+        task_id="update_socrata",
+        image=docker_image,
+        api_version="auto",
+        auto_remove=True,
+        command=f"python finance-reports/mstro_reports_to_socrata.py",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+    )
+
+    t1 >> t2


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/12775

## Associated repo
https://github.com/cityofaustin/atd-executive-dashboard

## Testing

**Steps to test:**
1. Git checkout this branch
2. `docker compose run --rm airflow-cli dags test atd_executive_dashboard_expenses_revenue`
---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates