### PR TITLE
Add container prune task

### DIFF
--- a/dags/atd_airflow_docker_image_prune.py
+++ b/dags/atd_airflow_docker_image_prune.py
@@ -40,4 +40,10 @@ with DAG(
         task_id="prune_images",
         bash_command="docker image prune -f",
     )
-    t1
+
+    t2 = BashOperator(
+        task_id="prune_containers",
+        bash_command="docker container prune -f",
+    )
+
+    t1 >> t2


### PR DESCRIPTION
## Associated repo
- atd-airflow

## Testing

1. Spin up your local
2. Run `docker ps -a` to see if you have any stopped containers. You can create a stopped container with pretty much any image you have you on your machine. eg with the `python:3.8-slim` image:

```
$ docker run --name my_container python:3.8-slim /bin/bash -c "exit"
```

3. Trigger the DAG `atd_airflow_docker_image_prune` and observe the container IDs logged in the prune task's output

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates