### PR TITLE
Set default docker hub connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ _AIRFLOW__WEBSERVER__BASE_URL=http://localhost:8080
 OP_API_TOKEN=<Get from 1Password entry named "Connect Server: Production Access Token: API Accessible Secrets">
 OP_CONNECT=<Get from 1Password entry named "Endpoint for 1Password Connect Server API">
 OP_VAULT_ID=<Get from 1Password entry named "Vault ID of API Accessible Secrets vault">
+DOCKER_HUB_USERNAME=<Get from 1Password entry named "Docker Hub">
+DOCKER_HUB_TOKEN=<A docker hub access token assigned to specifically to you>
 ```
 
 3. Start the Docker the stack (optionlly use the `-d` flag to run containers in the background):

--- a/dags/atd_knack_dms.py
+++ b/dags/atd_knack_dms.py
@@ -79,6 +79,7 @@ with DAG(
 
     t1 = DockerOperator(
         task_id="atd_knack_dms_to_postgrest",
+        docker_conn_id="docker_default",
         image=docker_image,
         auto_remove=True,
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
@@ -91,6 +92,7 @@ with DAG(
     t2 = DockerOperator(
         task_id="atd_knack_dms_to_socrata",
         image=docker_image,
+        docker_conn_id="docker_default",
         auto_remove=True,
         command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
@@ -101,6 +103,7 @@ with DAG(
     t3 = DockerOperator(
         task_id="atd_knack_dms_to_agol",
         image=docker_image,
+        docker_conn_id="docker_default",
         auto_remove=True,
         command=f"./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -106,8 +106,6 @@ services:
       retries: 5
       start_period: 30s
     restart: always
-    environment:
-      AIRFLOW_CONN_DOCKER_DEFAULT: "docker://${DOCKER_HUB_USERNAME}:${DOCKER_HUB_TOKEN}@https%3A%2F%2Findex.docker.io%2Fv1%2F:80"
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ x-airflow-common: &airflow-common
     FLOWER_AUTH_USERNAME: ${_AIRFLOW_WWW_USER_USERNAME}
     FLOWER_AUTH_PASSWORD: ${_AIRFLOW_WWW_USER_PASSWORD}
     AIRFLOW_CHECKOUT_PATH: ${AIRFLOW_PROJ_DIR}
+    AIRFLOW_CONN_DOCKER_DEFAULT: "docker://${DOCKER_HUB_USERNAME}:${DOCKER_HUB_TOKEN}@https%3A%2F%2Findex.docker.io%2Fv1%2F:80"
     # Quiet SQLAlchemy warnings
     SQLALCHEMY_SILENCE_UBER_WARNING: 1
 
@@ -105,6 +106,8 @@ services:
       retries: 5
       start_period: 30s
     restart: always
+    environment:
+      AIRFLOW_CONN_DOCKER_DEFAULT: "docker://${DOCKER_HUB_USERNAME}:${DOCKER_HUB_TOKEN}@https%3A%2F%2Findex.docker.io%2Fv1%2F:80"
     depends_on:
       <<: *airflow-common-depends-on
       airflow-init:


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/13654

This PR adds a default Docker Hub connection to our Airflow stack. The connection can be referenced by `DockerOperator` tasks to mitigate rate limiting or to use a private Docker image.

## Associated repo
- atd-airflow

## Testing

It's hard to verify the connection is in place, because, per the [Airflow docs](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html):

> Connections defined in environment variables will not show up in the Airflow UI or using airflow connections list.

So the trick to testing this is:
1. Use the Docker Hub credentials in 1password to login to hub.docker.com. 
2. From the top-right menu, go to **Account Settings** then navigate to **Security** via the left vertical nav.
3. Create a read-only access token for yourself called `<first-name>-<last-name>-local-dev`
4. Add the `DOCKER_HUB_USERNAME` and `DOCKER_HUB_TOKEN` values to your `env` file. Note that you should set the `DOCKER_HUB_USERNAME` to our Docker username, not the name of your access token.
5. Remove the knack services image from your system (or skip this step if you don't have a copy)

```
$ docker image rmi atddocker/atd-knack-services:production
```

6. Start Airflow and trigger the `atd_knack_dms ` DAG. You can observe in the task logs that the `atd-knack-services` DAG has been pulled.
7. From the access tokens page in the Docker Hub, refresh the page and locate your access token in the list of tokens. It should be near the top of the token list and have have a "Last used" date that matches the timestamp when you triggered the DAG.


<img width="1102" alt="Screenshot 2023-09-05 at 12 02 23 PM" src="https://github.com/cityofaustin/atd-airflow/assets/14793120/08102dd3-e12a-4dc3-bccd-6c07302b1089">

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates