### PR TITLE
Parking data - Add Encryption Key Secret

### DIFF
--- a/dags/atd_parking_data.py
+++ b/dags/atd_parking_data.py
@@ -85,6 +85,10 @@ REQUIRED_SECRETS = {
         "opitem": "Parking Data ETL",
         "opfield": "fiserv.Expected Email Address",
     },
+    "ENCRYPTION_KEY": {
+        "opitem": "Parking Data ETL",
+        "opfield": "fiserv.Encryption Key",
+    },
     # AWS S3
     "AWS_ACCESS_ID": {
         "opitem": "Parking Data ETL",


### PR DESCRIPTION
Forgot to add this new secret. It's the password for our CSV attachments from Fiserv. Only way to test this is if we have an unprocessed email in our s3 bucket. 



## Associated issues

## Associated repo

## Testing

**Steps to test:**


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates