### PR TITLE
wrong env var name

### DIFF
--- a/dags/atd_parking_data.py
+++ b/dags/atd_parking_data.py
@@ -85,7 +85,7 @@ REQUIRED_SECRETS = {
         "opitem": "Parking Data ETL",
         "opfield": "fiserv.Expected Email Address",
     },
-    "ENCRYPTION_KEY": {
+    "FSRV_ENCRYPTION": {
         "opitem": "Parking Data ETL",
         "opfield": "fiserv.Encryption Key",
     },


### PR DESCRIPTION
Messed the key of this env variable, let's try this again.


## Associated issues

## Associated repo

## Testing

**Steps to test:**


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates