### PR TITLE
Create DAG to send SR activities from Knack to 311 CSR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,7 @@ venv.bak/
 
 # Misc
 *.pem
+*.cert
 .DS_Store
 logs/*
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ venv.bak/
 
 # Misc
 *.pem
+*.cert
 .DS_Store
 logs/*
 *.swp

--- a/certs/knack/README.md
+++ b/certs/knack/README.md
@@ -1,0 +1,4 @@
+# Knack self-signed SSL certificate and key stored here
+This directory is available to the docker-compose stack as a named volume. See the volumne definition in docker-compose.yaml for more details.
+
+The certificate stored here as `esb.cert` and `esb.pem` is used as a self-signed certificate for communication with the Enterprise Service Bus (ESB) for the 311 CSR integration.

--- a/dags/atd_knack_esb_311.py
+++ b/dags/atd_knack_esb_311.py
@@ -58,7 +58,7 @@ with DAG(
     dag_id=f"atd_knack_esb_311",
     description="Publishes 311 SR activities from Knack to 311 CSR via the CTM ESB",
     default_args=DEFAULT_ARGS,
-    schedule_interval="*/7 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="1-59/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-knack-311", "311", "knack", "esb"],
     catchup=False,
 ) as dag:

--- a/dags/atd_knack_esb_311.py
+++ b/dags/atd_knack_esb_311.py
@@ -59,7 +59,7 @@ with DAG(
     description="Publishes 311 SR activities from Knack to 311 CSR via the CTM ESB",
     default_args=DEFAULT_ARGS,
     schedule_interval="*/7 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
-    tags=["repo:atd-kits", "socrata", "kits"],
+    tags=["repo:atd-knack-311", "311", "knack", "esb"],
     catchup=False,
 ) as dag:
     env_vars_data_tracker = get_env_vars_task(REQUIRED_SECRETS_DATA_TRACKER)

--- a/dags/atd_knack_esb_311.py
+++ b/dags/atd_knack_esb_311.py
@@ -1,0 +1,91 @@
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration, now
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DOCKER_IMAGE ="atddocker/atd-knack-311:production"
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS_DATA_TRACKER = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiKey",
+    },
+    "ESB_ENDPOINT": {
+        "opitem": "CTM Enterprise Service Bus - ESB - 311 Interface",
+        "opfield": f"production.endpoint",
+    }
+}
+
+REQUIRED_SECRETS_SIGNS_MARKIGNS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack Signs and Markings",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack Signs and Markings",
+        "opfield": f"production.apiKey",
+    },
+    "ESB_ENDPOINT": {
+        "opitem": "CTM Enterprise Service Bus - ESB - 311 Interface",
+        "opfield": f"production.endpoint",
+    }
+}
+
+with DAG(
+    dag_id=f"atd_knack_esb_311",
+    description="Publishes 311 SR activities from Knack to 311 CSR via the CTM ESB",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="*/7 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:atd-kits", "socrata", "kits"],
+    catchup=False,
+) as dag:
+
+    env_vars_data_tracker = get_env_vars_task(REQUIRED_SECRETS_DATA_TRACKER)
+    env_vars_signs_markings = get_env_vars_task(REQUIRED_SECRETS_SIGNS_MARKIGNS)
+
+    t1 = DockerOperator(
+        task_id="knack_amd_data_tracker_activities_to_311",
+        image=DOCKER_IMAGE,
+        auto_remove=True,
+        command="./python send_knack_messages_to_esb.py data-tracker",
+        environment=env_vars_data_tracker,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+        network_mode="bridge",
+    )
+
+    t2 = DockerOperator(
+        task_id="knack_amd_signs_markings_activities_to_311",
+        image=DOCKER_IMAGE,
+        auto_remove=True,
+        command="./python send_knack_messages_to_esb.py signs-markings",
+        environment=env_vars_signs_markings,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+        network_mode="bridge",
+    )
+
+    t1 >> t2

--- a/dags/atd_knack_esb_311.py
+++ b/dags/atd_knack_esb_311.py
@@ -73,39 +73,11 @@ with DAG(
         type="volume"
     )
 
-    # t1 = DockerOperator(
-    #     task_id="knack_amd_data_tracker_activities_to_311",
-    #     image=DOCKER_IMAGE,
-    #     auto_remove=True,
-    #     command="./atd-knack-311/send_knack_messages_to_esb.py data-tracker",
-    #     environment=env_vars_data_tracker,
-    #     tty=True,
-    #     force_pull=True,
-    #     mount_tmp_dir=False,
-    #     network_mode="bridge",
-    #     mounts=[cert_mount]
-    # )
-
-    # t2 = DockerOperator(
-    #     task_id="knack_amd_signs_markings_activities_to_311",
-    #     image=DOCKER_IMAGE,
-    #     auto_remove=True,
-    #     command="./atd-knack-311/send_knack_messages_to_esb.py signs-markings",
-    #     environment=env_vars_signs_markings,
-    #     tty=True,
-    #     force_pull=True,
-    #     mount_tmp_dir=False,
-    #     network_mode="bridge",
-    #     mounts=[cert_mount]
-    # )
-
-    # t1 >> t2
-
     t1 = DockerOperator(
         task_id="knack_amd_data_tracker_activities_to_311",
         image=DOCKER_IMAGE,
         auto_remove=True,
-        command="sleep 300",
+        command="./atd-knack-311/send_knack_messages_to_esb.py data-tracker",
         environment=env_vars_data_tracker,
         tty=True,
         force_pull=True,
@@ -114,4 +86,17 @@ with DAG(
         mounts=[cert_mount]
     )
 
-    t1
+    t2 = DockerOperator(
+        task_id="knack_amd_signs_markings_activities_to_311",
+        image=DOCKER_IMAGE,
+        auto_remove=True,
+        command="./atd-knack-311/send_knack_messages_to_esb.py signs-markings",
+        environment=env_vars_signs_markings,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+        network_mode="bridge",
+        mounts=[cert_mount]
+    )
+
+    t1 >> t2

--- a/dags/atd_knack_esb_311.py
+++ b/dags/atd_knack_esb_311.py
@@ -66,18 +66,46 @@ with DAG(
     env_vars_signs_markings = get_env_vars_task(REQUIRED_SECRETS_SIGNS_MARKIGNS)
 
     # the self-signed certificate and key must be stored within the airflow project directory
-    # accoriding to the path specified in the docker compose volumne definition
+    # according to the path specified in the docker compose volumne definition
     cert_mount =  Mount(
         source="atd-airflow_knack-certs", 
         target="/app/atd-knack-311/certs",
         type="volume"
     )
 
+    # t1 = DockerOperator(
+    #     task_id="knack_amd_data_tracker_activities_to_311",
+    #     image=DOCKER_IMAGE,
+    #     auto_remove=True,
+    #     command="./atd-knack-311/send_knack_messages_to_esb.py data-tracker",
+    #     environment=env_vars_data_tracker,
+    #     tty=True,
+    #     force_pull=True,
+    #     mount_tmp_dir=False,
+    #     network_mode="bridge",
+    #     mounts=[cert_mount]
+    # )
+
+    # t2 = DockerOperator(
+    #     task_id="knack_amd_signs_markings_activities_to_311",
+    #     image=DOCKER_IMAGE,
+    #     auto_remove=True,
+    #     command="./atd-knack-311/send_knack_messages_to_esb.py signs-markings",
+    #     environment=env_vars_signs_markings,
+    #     tty=True,
+    #     force_pull=True,
+    #     mount_tmp_dir=False,
+    #     network_mode="bridge",
+    #     mounts=[cert_mount]
+    # )
+
+    # t1 >> t2
+
     t1 = DockerOperator(
         task_id="knack_amd_data_tracker_activities_to_311",
         image=DOCKER_IMAGE,
         auto_remove=True,
-        command="./atd-knack-311/send_knack_messages_to_esb.py data-tracker",
+        command="sleep 300",
         environment=env_vars_data_tracker,
         tty=True,
         force_pull=True,
@@ -86,17 +114,4 @@ with DAG(
         mounts=[cert_mount]
     )
 
-    t2 = DockerOperator(
-        task_id="knack_amd_signs_markings_activities_to_311",
-        image=DOCKER_IMAGE,
-        auto_remove=True,
-        command="./atd-knack-311/send_knack_messages_to_esb.py signs-markings",
-        environment=env_vars_signs_markings,
-        tty=True,
-        force_pull=True,
-        mount_tmp_dir=False,
-        network_mode="bridge",
-        mounts=[cert_mount]
-    )
-
-    t1 >> t2
+    t1

--- a/dags/atd_knack_esb_311.py
+++ b/dags/atd_knack_esb_311.py
@@ -38,7 +38,7 @@ REQUIRED_SECRETS_DATA_TRACKER = {
     }
 }
 
-REQUIRED_SECRETS_SIGNS_MARKIGNS = {
+REQUIRED_SECRETS_SIGNS_MARKINGS = {
     "KNACK_APP_ID": {
         "opitem": "Knack Signs and Markings",
         "opfield": f"production.appId",
@@ -63,7 +63,7 @@ with DAG(
     catchup=False,
 ) as dag:
     env_vars_data_tracker = get_env_vars_task(REQUIRED_SECRETS_DATA_TRACKER)
-    env_vars_signs_markings = get_env_vars_task(REQUIRED_SECRETS_SIGNS_MARKIGNS)
+    env_vars_signs_markings = get_env_vars_task(REQUIRED_SECRETS_SIGNS_MARKINGS)
 
     # the self-signed certificate and key must be stored within the airflow project directory
     # according to the path specified in the docker compose volumne definition

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,7 @@ x-airflow-common: &airflow-common
     - ${AIRFLOW_PROJ_DIR}/plugins:/opt/airflow/plugins
     - ${AIRFLOW_PROJ_DIR}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR}/airflow.cfg:/opt/airflow/airflow.cfg
+    - knack-certs:/opt/airflow/certs/knack
     - /var/run/docker.sock:/var/run/docker.sock
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on: &airflow-common-depends-on

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -258,6 +258,13 @@ services:
       <<: *airflow-common-depends-on
       airflow-init:
         condition: service_completed_successfully
-# postgres db data persisted here
 volumes:
+  # postgres db data persisted here
   postgres-db-volume:
+  # volume for Knack SSL certs which will be mounted to DockerOperator tasks for 311 integration
+  knack-certs:
+    driver: local
+    driver_opts:
+      type: 'none'
+      o: 'bind'
+      device: ${AIRFLOW_PROJ_DIR}/certs/knack


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/11175

## Associated repo
- `atd-knack-311`

## Testing

**Steps to test:**
This branch is deployed on our production server, you can observe the run history of this DAG.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates