### PR TITLE
Cron entry to keep our logs from accumulating.

### DIFF
--- a/toolbox/log-purge/log-purge.cron
+++ b/toolbox/log-purge/log-purge.cron
@@ -1,0 +1,9 @@
+# Cron job to clean up old files and empty directories from /usr/airflow/atd-airflow/logs
+# This will run nightly at 2 AM. The first command removes all files which have a modification
+# time greater than 30 days, and the second command removes all empty directories. Removed
+# files and directories are logged into /var/log which will get rotated by the system.
+
+0 2 * * * find /usr/airflow/atd-airflow/logs -type f -mtime +30 -exec rm -v {} \; \
+>> /var/log/airflow-logs-purge.log && \
+find /usr/airflow/atd-airflow/logs -type d -empty -exec rmdir -v {} \; \
+>> /var/log/airflow-logs-purge.log

--- a/toolbox/log-purge/log-purge.cron
+++ b/toolbox/log-purge/log-purge.cron
@@ -5,5 +5,7 @@
 
 0 2 * * * find /usr/airflow/atd-airflow/logs -type f -mtime +30 -exec rm -v {} \; \
 >> /var/log/airflow-logs-purge.log && \
-find /usr/airflow/atd-airflow/logs -type d -empty -exec rmdir -v {} \; \
+find /usr/airflow/atd-airflow/logs -type d -empty | xargs -I {} rmdir -v {}; \
+>> /var/log/airflow-logs-purge.log  && \
+find /usr/airflow/atd-airflow/logs -type d -empty | xargs -I {} rmdir -v {}; \
 >> /var/log/airflow-logs-purge.log


### PR DESCRIPTION
## Associated issues

This PR intends to close https://github.com/cityofaustin/atd-data-tech/issues/12736.


## Testing

Jump on `atd-data03` and as your own, non-root, user, do the following (but keep an eye on `/home` capacity and the system load because `atd-data03` runs hot):

```bash
mkdir ~/your_test_directory;

rsync -av \ # this gets a representative sample of what logs look like
/usr/airflow/atd-airflow/logs/dag_id=*exec* \
/usr/airflow/atd-airflow/logs/*processor* \
/usr/airflow/atd-airflow/logs/scheduler  \
~/your_test_directory/logs

find ~/your_test_directory/logs -type f -mtime +30 -exec rm -v {} \;
find ~/your_test_directory/logs -type d -empty | xargs -I {} rmdir -v {};
find ~/your_test_directory/logs -type d -empty | xargs -I {} rmdir -v {}; 
```

Note that the empty directory clean-up command runs twice because there are directories holding directories that /become/ empty when the first one runs.

If you're satisfied with how it works, check the file in this PR and make sure you like how this is implemented.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates