### PR TITLE
Backup airflow DB to S3 via dag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM apache/airflow:2.6.1
 
 USER root
 RUN apt-get update
-RUN apt-get install -y aptitude magic-wormhole vim black
+RUN apt-get install -y aptitude magic-wormhole vim black awscli
 
 USER ${AIRFLOW_UID}
 COPY requirements.txt /opt/airflow/requirements.txt

--- a/dags/airflow-database-backup.py
+++ b/dags/airflow-database-backup.py
@@ -1,0 +1,63 @@
+import os
+from pendulum import datetime, duration
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.bash_operator import BashOperator
+
+from datetime import datetime as vanilla_datetime
+
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+default_args = {
+    "owner": "airflow",
+    "description": "Backup, compress and store airflow pg_dump in S3",
+    "depends_on_past": False,
+    "start_date": datetime(2019, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=30),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "AWS_ACCESS_KEY_ID": {
+        "opitem": "AWS atd-airflow IAM user API credentials",
+        "opfield": "production.access key",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "opitem": "AWS atd-airflow IAM user API credentials",
+        "opfield": "production.secret key",
+    }, 
+}
+
+with DAG(
+    dag_id=f"airflow_db_backup_{DEPLOYMENT_ENVIRONMENT}",
+    default_args=default_args,
+    # 3:00 AM central
+    schedule_interval="0 3 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:atd-airflow", "backup"],
+    catchup=False,
+) as dag:
+
+    @task()
+    def get_env_vars():
+        from utils.onepassword import load_dict
+        return load_dict(REQUIRED_SECRETS)
+
+    @task()
+    def add_todays_date_to_dict(secrets):
+        secrets["current_date"] = vanilla_datetime.today().strftime('%Y-%m-%d')
+        return secrets
+
+    env_vars = get_env_vars()
+    env_vars = add_todays_date_to_dict(env_vars)
+
+    BashOperator(
+      task_id="backup_airflow_db",
+      env=env_vars,
+      bash_command=f"docker exec -i atd-airflow-postgres-1 pg_dump -U airflow airflow | bzip2 -9 | AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY aws s3 cp - s3://atd-airflow/$current_date_airflow-db-backup.bz2"
+    )

--- a/dags/airflow-database-backup.py
+++ b/dags/airflow-database-backup.py
@@ -59,5 +59,5 @@ with DAG(
     BashOperator(
       task_id="backup_airflow_db",
       env=env_vars,
-      bash_command=f"docker exec -i atd-airflow-postgres-1 pg_dump -U airflow airflow | bzip2 -9 | AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY aws s3 cp - s3://atd-airflow/$current_date_airflow-db-backup.bz2"
+      bash_command=f"docker exec -i atd-airflow-postgres-1 pg_dump -U airflow airflow | bzip2 -9 | AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY aws s3 cp - s3://atd-airflow/$current_date/airflow-db-backup.bz2"
     )


### PR DESCRIPTION
## Associated issues

This PR intends to close https://github.com/cityofaustin/atd-data-tech/issues/12347.

## Associated repo

Airflow

## Testing

This PR requires a new package to be installed in the airflow images, so to test this locally, modify your docker-compose.yaml file to build from `.` and build some local images for testing. This will happen via CI when merged into production. I think, also, because the DAG is entirely self contained and there's no docker reliance or anything like that -- the eyeball test may be appropriate here. 

**Steps to test:**

Normal routine - spin up local airflow and give it a whirl. 

## S3 Lifecycle Rules

I've added this lifecycle rule to the `atd-airflow` backup bucket. After 180 days, all files in the bucket are auto-deleted. Backups are only going to last 180 days. 

Also, if a backup is overwritten, we'll keep all versions until the 180 days, but after a month, we'll only keep up to 5. This is a much less important part of the rule.

![image](https://github.com/cityofaustin/atd-airflow/assets/3653206/2e656c68-eb0c-41d6-af2f-9eec77a33172)


---

#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates