### PR TITLE
Automate population of CR3 metadata in VZDB

### DIFF
--- a/dags/vz_populate_cr3_metadata.py
+++ b/dags/vz_populate_cr3_metadata.py
@@ -1,5 +1,5 @@
 import os
-from pendulum import datetime
+from pendulum import datetime, duration
 from airflow.decorators import dag, task
 from airflow.operators.docker_operator import DockerOperator
 from utils.slack_operator import task_fail_slack_alert
@@ -34,6 +34,14 @@ REQUIRED_SECRETS = {
         "opitem": "Vision Zero graphql-engine Endpoints",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Key",
     },
+    "AWS_ACCESS_KEY_ID": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AWS Access key",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AWS Secret key",
+    },
 }
 
 
@@ -55,7 +63,11 @@ def populate_cr3_metadata():
     def get_env_vars():
         from utils.onepassword import load_dict
 
-        return load_dict(REQUIRED_SECRETS)
+        answers = load_dict(REQUIRED_SECRETS)
+        print(answers)
+        return answers
+
+        # return load_dict(REQUIRED_SECRETS)
 
     env_vars = get_env_vars()
 
@@ -64,7 +76,7 @@ def populate_cr3_metadata():
         environment=env_vars,
         image="atddocker/vz-cr3-metadata-pdfs:production",
         auto_remove=True,
-        #entrypoint=["/entrypoint.sh"],
+        entrypoint=["/app/populate_cr3_file_metadata.py"],
         #command=["ems"],
         tty=True,
         force_pull=True,

--- a/dags/vz_populate_cr3_metadata.py
+++ b/dags/vz_populate_cr3_metadata.py
@@ -1,0 +1,74 @@
+import os
+from pendulum import datetime
+from airflow.decorators import dag, task
+from airflow.operators.docker_operator import DockerOperator
+from utils.slack_operator import task_fail_slack_alert
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2019, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+REQUIRED_SECRETS = {
+    "AWS_BUCKET_NAME": {
+        "opitem": "Vision Zero CR3 Metadata Extraction",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AWS Bucket for CR3s",
+    },
+    "AWS_BUCKET_ENVIRONMENT": {
+        "opitem": "Vision Zero CR3 Metadata Extraction",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AWS S3 Path for CR3s",
+    },
+    "HASURA_ENDPOINT": {
+        "opitem": "Vision Zero graphql-engine Endpoints",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.GraphQL Endpoint",
+    },
+    "HASURA_ADMIN_KEY": {
+        "opitem": "Vision Zero graphql-engine Endpoints",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Key",
+    },
+}
+
+
+@dag(
+    dag_id="vz-populate-cr3-metadata",
+    description="A DAG which populates CR3 metadata in the VZDB",
+    schedule_interval="*/5 8-10 * * *"
+    if DEPLOYMENT_ENVIRONMENT == "production"
+    else None,
+    catchup=False,
+    tags=["repo:atd-vz-data", "vision-zero", "ocr", "cr3"],
+    default_args=default_args,
+)
+def populate_cr3_metadata():
+    @task(
+        task_id="get_env_vars",
+        execution_timeout=duration(seconds=30),
+    )
+    def get_env_vars():
+        from utils.onepassword import load_dict
+
+        return load_dict(REQUIRED_SECRETS)
+
+    env_vars = get_env_vars()
+
+    DockerOperator(
+        task_id="run_cr3_metadata_population",
+        environment=env_vars,
+        image="atddocker/vz-cr3-metadata-pdfs:production",
+        auto_remove=True,
+        #entrypoint=["/entrypoint.sh"],
+        #command=["ems"],
+        tty=True,
+        force_pull=True,
+    )
+
+
+populate_cr3_metadata()

--- a/dags/vz_populate_cr3_metadata.py
+++ b/dags/vz_populate_cr3_metadata.py
@@ -62,12 +62,7 @@ def populate_cr3_metadata():
     )
     def get_env_vars():
         from utils.onepassword import load_dict
-
-        answers = load_dict(REQUIRED_SECRETS)
-        print(answers)
-        return answers
-
-        # return load_dict(REQUIRED_SECRETS)
+        return load_dict(REQUIRED_SECRETS)
 
     env_vars = get_env_vars()
 

--- a/dags/vz_populate_cr3_metadata.py
+++ b/dags/vz_populate_cr3_metadata.py
@@ -62,6 +62,7 @@ def populate_cr3_metadata():
     )
     def get_env_vars():
         from utils.onepassword import load_dict
+
         return load_dict(REQUIRED_SECRETS)
 
     env_vars = get_env_vars()
@@ -72,7 +73,6 @@ def populate_cr3_metadata():
         image="atddocker/vz-cr3-metadata-pdfs:production",
         auto_remove=True,
         entrypoint=["/app/populate_cr3_file_metadata.py"],
-        #command=["ems"],
         tty=True,
         force_pull=True,
     )


### PR DESCRIPTION
## Associated issues

This work is a continuation of the work here: https://github.com/cityofaustin/atd-data-tech/issues/14899. 

## Associated repo

The Vision Zero Stack at `atd-vz-data`

## Testing

1) Spin up the VZDB and populate it with a replication of production's data.
2) Spin up the airflow stack and trigger the DAG `vz-populate-cr3-metadata`
3) Before, after, and during, try this command to quantify the number of un-metadata bearing crashes there:

```sql
select count(*)
from atd_txdot_crashes 
where cr3_file_metadata is null
```

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates