### PR TITLE
Backing up active ROW permits log

### DIFF
--- a/dags/atd_executive_dashboard_row_active_permits_logging.py
+++ b/dags/atd_executive_dashboard_row_active_permits_logging.py
@@ -140,6 +140,7 @@ with DAG(
     t1 = DockerOperator(
         task_id="active_permits_logging",
         image=docker_image,
+        docker_conn_id="docker_default",
         auto_remove=True,
         command=f"python active_permits_logging.py",
         environment=env_vars,
@@ -153,6 +154,7 @@ with DAG(
     t2 = DockerOperator(
         task_id="backup_active_permits",
         image=docker_image_2,
+        docker_conn_id="docker_default",
         auto_remove=True,
         command=f"./atd-knack-services/services/backup_socrata.py --dataset {dataset_id}",
         environment=env_vars_2,

--- a/dags/atd_executive_dashboard_row_active_permits_logging.py
+++ b/dags/atd_executive_dashboard_row_active_permits_logging.py
@@ -1,5 +1,8 @@
+# test locally with: docker compose run --rm airflow-cli dags test atd_executive_dashboard_row_active_permits_logging
+
 import os
 
+from airflow.decorators import task
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
 from pendulum import datetime, duration, now
@@ -88,6 +91,36 @@ REQUIRED_SECRETS = {
     },
 }
 
+SECRETS_SOCRATA_BACKUP = {
+    "SOCRATA_API_KEY_ID": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SOCRATA_API_KEY_SECRET": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SOCRATA_APP_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "AWS_ACCESS_ID": {
+        "opitem": "Socrata Dataset Backups S3 Bucket",
+        "opfield": "production.AWS Access Key",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "opitem": "Socrata Dataset Backups S3 Bucket",
+        "opfield": "production.AWS Secret Access Key",
+    },
+    "BUCKET": {
+        "opitem": "Socrata Dataset Backups S3 Bucket",
+        "opfield": "production.Bucket",
+    },
+}
+
+@task
+def get_dataset_id(env_vars):
+    return env_vars['ACTIVE_DATASET']
 
 with DAG(
     dag_id="atd_executive_dashboard_row_active_permits_logging",
@@ -98,8 +131,11 @@ with DAG(
     catchup=False,
 ) as dag:
     docker_image = "atddocker/atd-executive-dashboard:production"
+    docker_image_2 = "atddocker/atd-knack-services:production"
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
+    env_vars_2 = get_env_vars_task(SECRETS_SOCRATA_BACKUP)
+    dataset_id = get_dataset_id(env_vars)
 
     t1 = DockerOperator(
         task_id="active_permits_logging",
@@ -114,4 +150,16 @@ with DAG(
         retry_delay=duration(seconds=60),
     )
 
-    t1
+    t2 = DockerOperator(
+        task_id="backup_active_permits",
+        image=docker_image_2,
+        auto_remove=True,
+        command=f"./atd-knack-services/services/backup_socrata.py --dataset {dataset_id}",
+        environment=env_vars_2,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+
+    t1 >> t2


### PR DESCRIPTION
Remembered this [dataset](https://data.austintexas.gov/Transportation-and-Mobility/ATD-Right-of-Way-Active-Permits/hyc6-zz9w/about_data) is not being backed up which just has running log of snapshots in time of active ROW permits retrieved from AMANDA.
## Associated issues

## Associated repo

## Testing

**Steps to test:**
Trigger this DAG and check for `INFO - backup_active_permits ran successfully!` 



---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates