### PR TITLE
Adjust timing for VZ OCR ETL

### DIFF
--- a/dags/vz_cr3_extract_ocr_narrative.py
+++ b/dags/vz_cr3_extract_ocr_narrative.py
@@ -17,7 +17,7 @@ default_args = {
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 0,
-    "execution_timeout": duration(minutes=5),
+    "execution_timeout": duration(minutes=20),
     "on_failure_callback": task_fail_slack_alert,
 }
 

--- a/dags/vz_cr3_extract_ocr_narrative.py
+++ b/dags/vz_cr3_extract_ocr_narrative.py
@@ -40,16 +40,15 @@ REQUIRED_SECRETS = {
     },
 }
 
+# fmt: off
 with DAG(
     dag_id=f"vz_cr3_ocr_narrative_extract_{DEPLOYMENT_ENVIRONMENT}",
     default_args=default_args,
-    # Every 5 minutes, at 8A, 9A, and 10A
-    schedule_interval="*/20 * * * *"
-    if DEPLOYMENT_ENVIRONMENT == "production"
-    else None,
+    schedule_interval="*/20 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-vz-data", "vision-zero"],
     catchup=False,
 ) as dag:
+# fmt: on
 
     @task(
         task_id="get_env_vars",

--- a/dags/vz_cr3_extract_ocr_narrative.py
+++ b/dags/vz_cr3_extract_ocr_narrative.py
@@ -29,7 +29,7 @@ REQUIRED_SECRETS = {
     "HASURA_ADMIN_KEY": {
         "opitem": "Vision Zero CRIS Import",
         "opfield": "production.GraphQL Endpoint key",
-    }, 
+    },
     "AWS_ACCESS_KEY_ID": {
         "opitem": "Vision Zero CRIS Import",
         "opfield": "production.AWS Access key",
@@ -37,7 +37,7 @@ REQUIRED_SECRETS = {
     "AWS_SECRET_ACCESS_KEY": {
         "opitem": "Vision Zero CRIS Import",
         "opfield": "production.AWS Secret key",
-    }
+    },
 }
 
 with DAG(
@@ -50,16 +50,18 @@ with DAG(
     tags=["repo:atd-vz-data", "vision-zero"],
     catchup=False,
 ) as dag:
+
     @task(
         task_id="get_env_vars",
         execution_timeout=duration(seconds=30),
     )
     def get_env_vars():
         from utils.onepassword import load_dict
+
         return load_dict(REQUIRED_SECRETS)
 
     env_vars = get_env_vars()
-    
+
     DockerOperator(
         task_id="ocr_narrative_extract",
         image="atddocker/atd-vz-cr3-extract:production",

--- a/dags/vz_cr3_extract_ocr_narrative.py
+++ b/dags/vz_cr3_extract_ocr_narrative.py
@@ -44,7 +44,9 @@ with DAG(
     dag_id=f"vz_cr3_ocr_narrative_extract_{DEPLOYMENT_ENVIRONMENT}",
     default_args=default_args,
     # Every 5 minutes, at 8A, 9A, and 10A
-    schedule_interval="*/5 8-10 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="*/20 * * * *"
+    if DEPLOYMENT_ENVIRONMENT == "production"
+    else None,
     tags=["repo:atd-vz-data", "vision-zero"],
     catchup=False,
 ) as dag:


### PR DESCRIPTION
## Associated issues

This PR is tangentially related to https://github.com/cityofaustin/atd-data-tech/issues/14899. It concerns tuning the timing around the ETL so that it is able to complete full batches of OCR and diagram extraction per execution. 

## Associated repo

`atd-vz-data`

## Testing

* Spin up local airflow and see that the script compiles. You won't see the schedule in local airflow, but please take a close look at it in the diff to see if it correctly schedules the DAG every 20 minutes, all day. 
* Look closely that the DAG is set to not timeout until 20 minutes into a task's execution.

### Associated data

<img width="1160" alt="image" src="https://github.com/cityofaustin/atd-airflow/assets/3653206/dec55cc4-aac8-4621-8c24-44e62ba43046">

This is data03 trucking along overnight under the timing regime set forth in this PR as it back-processes a large number of CR3s.

---

#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates