### PR TITLE
ROW Queries changing trigger rule

### DIFF
--- a/dags/atd_executive_dashboard_row_weekly_summary.py
+++ b/dags/atd_executive_dashboard_row_weekly_summary.py
@@ -114,6 +114,7 @@ with DAG(
         mount_tmp_dir=False,
         retries=3,
         retry_delay=duration(seconds=60),
+        trigger_rule="all_done",
     )
 
     t2 = DockerOperator(
@@ -127,6 +128,7 @@ with DAG(
         mount_tmp_dir=False,
         retries=3,
         retry_delay=duration(seconds=60),
+        trigger_rule="all_done",
     )
 
     t3 = DockerOperator(
@@ -140,6 +142,7 @@ with DAG(
         mount_tmp_dir=False,
         retries=3,
         retry_delay=duration(seconds=60),
+        trigger_rule="all_done",
     )
 
     t4 = DockerOperator(
@@ -153,6 +156,7 @@ with DAG(
         mount_tmp_dir=False,
         retries=3,
         retry_delay=duration(seconds=60),
+        trigger_rule="all_done",
     )
 
     t5 = DockerOperator(
@@ -166,6 +170,7 @@ with DAG(
         mount_tmp_dir=False,
         retries=3,
         retry_delay=duration(seconds=60),
+        trigger_rule="all_done",
     )
 
     t6 = DockerOperator(
@@ -179,6 +184,7 @@ with DAG(
         mount_tmp_dir=False,
         retries=3,
         retry_delay=duration(seconds=60),
+        trigger_rule="all_done",
     )
 
     t7 = DockerOperator(
@@ -192,6 +198,7 @@ with DAG(
         mount_tmp_dir=False,
         retries=3,
         retry_delay=duration(seconds=60),
+        trigger_rule="all_done",
     )
 
     t1 >> t2 >> t3 >> t4 >> t5 >> t6 >> t7


### PR DESCRIPTION
## Associated issues
@johnclary suggested to change the [trigger rule](https://airflow.apache.org/docs/apache-airflow/1.10.10/concepts.html#trigger-rules) for these DAGs so they run regardless if the upstream tasks were successful or not. This could handle the case that we could have one query fail to run and we will still want the others to try.

I've changed the trigger rule from `all_success`(default) to `all_done` which triggers the DAG if all parents are done with their execution. That way we still trigger the DAG if things fail but also should not bomb the AMANDA database. 

## Associated repo
https://github.com/cityofaustin/atd-executive-dashboard

## Testing

**Steps to test:**
Easy way to test this is to not connect to the VPN and try to trigger this DAG. The first `get_env_vars` task should succeed if your 1pass secrets are set locally. The `amanda_` and `ex_permits_issued` tasks should fail but after the three retries are exhausted, the DAG should continue on to the remaining tasks.

I'm not sure how best to test the slack notifications, but I assume it will notify each time a task comes up 🟥 (failed). This could create a lot of noise but I'm not sure if there's a way around that? [Callbacks docs](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/callbacks.html)

Right-most column is what I get when applying these trigger rules:
<img width="308" alt="Screenshot 2024-01-08 at 11 17 15 AM" src="https://github.com/cityofaustin/atd-airflow/assets/30810522/67074a58-99c3-41bf-89f8-098dd6946f03">

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates