### PR TITLE
Sync Moped and Data Tracker projects

### DIFF
--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -32,11 +32,11 @@ REQUIRED_SECRETS = {
         "opitem": "Moped Hasura Admin",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Secret",
     },
-    "KNACK_APP_ID": {
+    "KNACK_DATA_TRACKER_APP_ID": {
         "opitem": "Knack AMD Data Tracker",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.appId",
     },
-    "KNACK_API_KEY": {
+    "KNACK_DATA_TRACKER_API_KEY": {
         "opitem": "Knack AMD Data Tracker",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.apiKey",
     },
@@ -62,7 +62,7 @@ with DAG(
         task_id="data_tracker_sync",
         image=docker_image,
         auto_remove=True,
-        command=f"python data_tracker_sync.py --start {date_filter_arg}",
+        command=f"python data_tracker_sync.py {date_filter_arg}",
         environment=env_vars,
         tty=True,
         force_pull=True,

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -44,7 +44,7 @@ with DAG(
     tags=["repo:atd-moped", "moped", "agol"],
     catchup=False,
 ) as dag:
-    docker_image = "atddocker/atd-moped-etl-arcgis:production"
+    docker_image = "atddocker/atd-moped-etl-data-tracker-sync:production"
 
     date_filter_arg = get_date_filter_arg()
 
@@ -54,7 +54,7 @@ with DAG(
         task_id="data_tracker_sync",
         image=docker_image,
         auto_remove=True,
-        command="python data_tracker_sync.py",
+        command=f"python data_tracker_sync.py --start {date_filter_arg}",
         environment=env_vars,
         tty=True,
         force_pull=True,

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -45,7 +45,7 @@ REQUIRED_SECRETS = {
 
 with DAG(
     dag_id="atd_moped_data_tracker_sync",
-    description="sync Moped projects data to Knack Data Tracker projects table",
+    description="sync Moped project data to Knack Data Tracker projects table",
     default_args=DEFAULT_ARGS,
     schedule_interval="0 6 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=30),
@@ -58,14 +58,11 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    # Run the script in test mode if we're developing locally
-    test_flag = "--test" if DEPLOYMENT_ENVIRONMENT == "development" else ""
-
     t1 = DockerOperator(
         task_id="data_tracker_sync",
         image=docker_image,
         auto_remove=True,
-        command=f"python data_tracker_sync.py --start {date_filter_arg} {test_flag}",
+        command=f"python data_tracker_sync.py --start {date_filter_arg}",
         environment=env_vars,
         tty=True,
         force_pull=True,

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -49,7 +49,7 @@ with DAG(
     default_args=DEFAULT_ARGS,
     schedule_interval="0 6 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=30),
-    tags=["repo:atd-moped", "moped", "agol"],
+    tags=["repo:atd-moped", "moped", "data-tracker", "knack"],
     catchup=False,
 ) as dag:
     docker_image = "atddocker/atd-moped-etl-data-tracker-sync:production"
@@ -58,11 +58,14 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
+    # Run the script in test mode if we're developing locally
+    test_flag = "--test" if DEPLOYMENT_ENVIRONMENT == "development" else ""
+
     t1 = DockerOperator(
         task_id="data_tracker_sync",
         image=docker_image,
         auto_remove=True,
-        command=f"python data_tracker_sync.py --start {date_filter_arg}",
+        command=f"python data_tracker_sync.py --start {date_filter_arg} {test_flag}",
         environment=env_vars,
         tty=True,
         force_pull=True,

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -1,0 +1,64 @@
+# Test locally with: docker compose run --rm airflow-cli dags test atd_moped_data_tracker_sync
+
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+from utils.knack import get_date_filter_arg
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": duration(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "HASURA_ENDPOINT": {
+        "opitem": "Moped Hasura Admin",
+        "opfield": "production.Endpoint",
+    },
+    "HASURA_ADMIN_SECRET": {
+        "opitem": "Moped Hasura Admin",
+        "opfield": "production.Admin Secret",
+    },
+}
+
+
+with DAG(
+    dag_id="atd_moped_data_tracker_sync",
+    description="sync Moped projects data to Knack Data Tracker projects table",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="0 6 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    dagrun_timeout=duration(minutes=30),
+    tags=["repo:atd-moped", "moped", "agol"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/atd-moped-etl-arcgis:production"
+
+    date_filter_arg = get_date_filter_arg()
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="data_tracker_sync",
+        image=docker_image,
+        auto_remove=True,
+        command="python data_tracker_sync.py",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t1

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -47,7 +47,7 @@ with DAG(
     dag_id="atd_moped_data_tracker_sync",
     description="sync Moped project data to Knack Data Tracker projects table",
     default_args=DEFAULT_ARGS,
-    schedule_interval="0 6 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="0 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=30),
     tags=["repo:atd-moped", "moped", "data-tracker", "knack"],
     catchup=False,

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -26,11 +26,19 @@ DEFAULT_ARGS = {
 REQUIRED_SECRETS = {
     "HASURA_ENDPOINT": {
         "opitem": "Moped Hasura Admin",
-        "opfield": "production.Endpoint",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Endpoint",
     },
     "HASURA_ADMIN_SECRET": {
         "opitem": "Moped Hasura Admin",
-        "opfield": "production.Admin Secret",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Secret",
+    },
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.apiKey",
     },
 }
 

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -61,6 +61,7 @@ with DAG(
     t1 = DockerOperator(
         task_id="data_tracker_sync",
         image=docker_image,
+        docker_conn_id="docker_default",
         auto_remove=True,
         command=f"python data_tracker_sync.py {date_filter_arg}",
         environment=env_vars,

--- a/dags/utils/knack.py
+++ b/dags/utils/knack.py
@@ -17,7 +17,7 @@ def get_date_filter_arg(should_replace_monthly=False, **context):
             variable.
 
     Returns:
-        Str or None: and ISO date string or None
+        Str or None: the -d flag and ISO date string or None
     """
     today = now()
     prev_start_date = context.get("prev_start_date_success") or today.isoformat()


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/8536

This PR adds a DAG to run the ETL that adds and updates Moped project data into the Knack Data Tracker `projects` table.

## Associated repo
https://github.com/cityofaustin/atd-moped/pull/1250

## Testing

**Steps to test:**
1. Start the local Airflow stack
2. Find a [staging Moped](https://moped.austinmobility.io/moped/) project and find its matching row in the [projects table of the test Data Tracker app](https://builder.knack.com/atd/test--austin-transportation-data-tracker--30-aug-2022/records/objects/object_201?builder_table_sort=field_3858%7Cdesc) by the Moped project ID. If it doesn't have a matching row in Knack, then this DAG will create it. Note that the project title in Moped matches the **Name** column in the Knack table.
3. Update the title of the Moped project through the staging Moped editor
4. Run the DAG added in this PR
5. You should see the DAG log that it updated at least one record (or created one if your record isn't synced yet). Find your row again in the Knack table, and it should be updated with your new title.
6. All of the staging projects are already synced to the test Knack app linked above as of creation of this PR. You can check out the row in the projects table and compare to the projects in staging Moped.

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates