### PR TITLE
temporarily turn off full replace for knack signals

### DIFF
--- a/dags/atd_knack_signals.py
+++ b/dags/atd_knack_signals.py
@@ -73,7 +73,7 @@ with DAG(
     app_name = "data-tracker"
     container = "view_197"
 
-    date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
+    date_filter_arg = get_date_filter_arg(should_replace_monthly=False)
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/15525, sorta

## Associated repo

## Testing

turning off the full replace flag for the rest of today, since its already done a full replace and this runs every 5 min


---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates