### PR TITLE
Increase traffic incidents frequency to every 3 minutes

### DIFF
--- a/dags/atd_traffic_incident_reports.py
+++ b/dags/atd_traffic_incident_reports.py
@@ -77,7 +77,7 @@ with DAG(
     dag_id="atd_traffic_incident_reports",
     description="wrapper etl for atd-traffic-incident-reports docker image connects to oracle db and updates postrgrest and socrata with incidents",
     default_args=DEFAULT_ARGS,
-    schedule_interval="*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="*/3 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-traffic-incident-reports", "postgrest", "socrata"],
     catchup=False,
 ) as dag:


### PR DESCRIPTION
Came up during a call with CTM this morning that the view that we are getting incidents from is updated every 3 minutes. Small chance we are missing incidents but probably better to sync these up. 

## Associated issues

## Associated repo

## Testing

**Steps to test:**


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates