### PR TITLE
Add ZenHub API secret to Service Bot DAG

### DIFF
--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -65,6 +65,7 @@ with DAG(
     DockerOperator(
         task_id="github_to_dts_portal",
         image=docker_image,
+        docker_conn_id="docker_default",
         api_version="auto",
         auto_remove=True,
         command="./atd-service-bot/gh_index_issues_to_dts_portal.py",

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -36,6 +36,10 @@ REQUIRED_SECRETS = {
         "opitem": "Github Access Token Service Bot",
         "opfield": ".password",
     },
+    "ZENHUB_ACCESS_TOKEN": {
+        "opitem": "Zenhub Access Token",
+        "opfield": ".password",
+    },
 }
 
 with DAG(

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -45,7 +45,7 @@ REQUIRED_SECRETS = {
 with DAG(
     dag_id=f"atd_service_bot_issues_to_dts_portal_{DEPLOYMENT_ENVIRONMENT}",
     default_args=default_args,
-    schedule_interval="0 5 * * *",
+    schedule_interval="0 5 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-service-bot", "knack", "github"],
     catchup=False,
 ) as dag:

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -45,17 +45,19 @@ with DAG(
     tags=["repo:atd-service-bot", "knack", "github"],
     catchup=False,
 ) as dag:
+
     @task(
         task_id="get_env_vars",
         execution_timeout=duration(seconds=30),
     )
     def get_env_vars():
         from utils.onepassword import load_dict
+
         env_vars = load_dict(REQUIRED_SECRETS)
         return env_vars
-    
+
     env_vars = get_env_vars()
-    
+
     DockerOperator(
         task_id="github_to_dts_portal",
         image=docker_image,


### PR DESCRIPTION
## Associated issues

This PR is associated with [issue 15878](https://github.com/cityofaustin/atd-data-tech/issues/15878) and `atd-service-bot` [PR 64](https://github.com/cityofaustin/atd-service-bot/pull/64).

## Associated repo

[atd-service-bot](https://github.com/cityofaustin/atd-service-bot)

## Testing

**Steps to test:**

* ✅ If you want to test that the changes to this DAG are non-breaking, you can spin up the local stack and start it up via the airflow UI. It will be providing the new environment variable to the docker container, but the `:production` tag doesn't use it yet.

* ❌ Testing with the updated ETL image is trickier, because the changes in [PR 64](https://github.com/cityofaustin/atd-service-bot/pull/64) depend on a column in Knack that I don't believe exists in the development Knack app. 

I hope this works - please let me know if we need more on this testing. Thanks!


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates