### PR TITLE
Fix cost-of-service reporting into Knack from AMANDA DAG / specify correct python binary in `$PATH`

### DIFF
--- a/dags/atd_cost_of_service_fees.py
+++ b/dags/atd_cost_of_service_fees.py
@@ -68,10 +68,11 @@ with DAG(
         task_id="atd_cost_of_service_fees_to_knack",
         image="atddocker/atd-cost-of-service:production",
         auto_remove=True,
-        command="python knack_load_fees.py",
+        command="python3 knack_load_fees.py",
         network_mode="bridge",
         environment=env_vars,
         tty=True,
+        docker_conn_id="docker_default",
         force_pull=True,
         mount_tmp_dir=False,
     )


### PR DESCRIPTION
## Intent

With the recent reworking of our docker image that we use for Amanda connectivity, the python interpreter in the path changed from `python` to `python3`, and this PR adjusts the DAG to call the right interpreter. Additionally, it now specifies the docker hub credentials to use explicitly. 

## Associated issues

This PR is associated to https://github.com/cityofaustin/atd-data-tech/issues/15372 and is a sibling to https://github.com/cityofaustin/atd-cost-of-service-reporting/pull/7. 

## Associated repo

[atd-cost-of-service-reporting](https://github.com/cityofaustin/atd-cost-of-service-reporting)

## Testing

### Local
* Get on the COA network / VPN
* Spin up your airflow instance
* Run this DAG
* Did it run successfully?

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates