### PR TITLE
Use the `docker_conn_id` directive for the CRIS import

### DIFF
--- a/dags/vz_cris_import.py
+++ b/dags/vz_cris_import.py
@@ -20,6 +20,7 @@ def cris_import():
     DockerOperator(
         task_id="run_cris_import",
         environment=dict(os.environ),
+        docker_conn_id="docker_default",
         image="atddocker/vz-cris-import:production",
         auto_remove=True,
         tty=True,


### PR DESCRIPTION
## Associated issues

None. This failed on Saturday with one of those errors we've seen when the COA IP has hit the API limit at docker hub for unauthenticated users. You can see the error [here](https://airflow.austinmobility.io/dags/vz-cris-import/grid?dag_run_id=scheduled__2024-03-29T12:00:00+00:00&task_id=run_cris_import&tab=logs).

## Associated repo

`atd-vz-data`

## Testing

This is hard to test because you need the COA network to be getting throttled by Docker Hub. I'd be comfortable with a code review. 

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates