### PR TITLE
amd preventative maintenance dag

### DIFF
--- a/dags/atd_knack_amd_preventative_maintenance.py
+++ b/dags/atd_knack_amd_preventative_maintenance.py
@@ -1,0 +1,98 @@
+# test locally with: docker compose run --rm airflow-cli dags test atd_knack_amd_pm
+
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration, now
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+from utils.knack import get_date_filter_arg
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=15),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiKey",
+    },
+    "SOCRATA_API_KEY_ID": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SOCRATA_API_KEY_SECRET": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SOCRATA_APP_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "PGREST_ENDPOINT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.endpoint",
+    },
+    "PGREST_JWT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.jwt",
+    },
+}
+
+
+with DAG(
+    dag_id=f"atd_knack_amd_pm",
+    description="Load preventative maintenance work order (view_3887) records from Knack to Postgrest and Socrata",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="15 4 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:atd-knack-services", "knack", "socrata", "data-tracker"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/atd-knack-services:production"
+    app_name = "data-tracker"
+    container = "view_3887"
+
+    date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="atd_knack_amd_pm_to_postgrest",
+        image=docker_image,
+        docker_conn_id="docker_default",
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t2 = DockerOperator(
+        task_id="atd_knack_amd_pm_to_socrata",
+        image=docker_image,
+        docker_conn_id="docker_default",
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        mount_tmp_dir=False,
+    )
+
+
+    date_filter_arg >> t1 >> t2


### PR DESCRIPTION
## Associated issues
fixes https://github.com/cityofaustin/atd-data-tech/issues/16840

## Associated repo
https://github.com/cityofaustin/atd-knack-services/tree/production

## Testing

**Steps to test:**
1. If you are on arm64 architecture you have to manually pull the latest docker image for atd-knack-services, this will be fixed in [16596](https://github.com/cityofaustin/atd-data-tech/issues/16596).

`$ docker pull atddocker/atd-knack-services:production --platform linux/x86_64/v8` 

2. Then trigger the dag, my favorite way is:

`$ docker compose run --rm airflow-cli dags test atd_knack_amd_pm `

3. Check that it ran successfully

> {dag.py:3691} INFO - > atd_knack_amd_pm_to_socrata ran successfully

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates