### PR TITLE
Airflow stack update to v2.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM apache/airflow:2.9.0
 
 USER root
 RUN apt-get update
-RUN apt-get install -y aptitude magic-wormhole vim black awscli
+RUN apt-get install -y aptitude magic-wormhole vim black awscli gosu
 
 USER ${AIRFLOW_UID}
 COPY requirements.txt /opt/airflow/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.6.1
+FROM apache/airflow:2.9.0
 
 USER root
 RUN apt-get update

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,6 @@
 # https://airflow.apache.org/docs/apache-airflow/2.6.1/docker-compose.yaml
 # and documented here:
 # https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html#running-airflow-in-docker
-version: "3.8"
 x-airflow-common: &airflow-common
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml


### PR DESCRIPTION
## TLDR

This was super easy. I browsed the major feature changes on the READMEs of the releases since our initial install, and nothing jumped out at me. I was able to make the update work with only one tweak -- installing `gosu`. 

## Associated issues

This PR intends to close https://github.com/cityofaustin/atd-data-tech/issues/16921.

## Associated repo

[atd-airflow](https://github.com/cityofaustin/atd-airflow)

## New feature

### Cluster Activity and Health page

<img width="1264" alt="image" src="https://github.com/cityofaustin/atd-airflow/assets/3653206/770a4d0e-af2a-478b-a788-52df621d68a7">


## Testing

* Checkout this branch
* Edit [this line](https://github.com/cityofaustin/atd-airflow/blob/airflow-update-2.9.0/docker-compose.yaml#L9) to something like `  image: atddocker/atd-airflow:testing`, noting the tag you choose. It can be anything, this won't get pushed anywhere.
* Build the new airflow image with the following command, making sure to use the same tag you chose.
```bash
docker build -t atddocker/atd-airflow:testing .
```
* Fire up airflow like normal with `docker compose up`, and this terminal becomes the logs to watch while you test. 
* Visit your [local airflow instance](http://localhost:8080/home?status=all)
* Verify the version is `2.9.0` in the footer
* And test anything and everything you want to - everything is in bounds.
  * One DAG I felt fine about firing up off over and over is the `maximo_geo_emergency_mgmt_email_parser_development` one.
* ⚠️ Don't forget to undo the change you made to your docker compose file.
---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates