### PR TITLE
Adjust DAG to use new arguments of metadata populator

### DIFF
--- a/dags/vz_populate_cr3_metadata.py
+++ b/dags/vz_populate_cr3_metadata.py
@@ -11,7 +11,7 @@ default_args = {
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 0,
-    "execution_timeout": duration(minutes=5),
+    "execution_timeout": duration(minutes=50),
     "on_failure_callback": task_fail_slack_alert,
 }
 
@@ -48,7 +48,9 @@ REQUIRED_SECRETS = {
 @dag(
     dag_id="vz-populate-cr3-metadata",
     description="A DAG which populates CR3 metadata in the VZDB",
-    schedule_interval="0 9 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval=(
+        "0 8-12 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+    ),
     catchup=False,
     tags=["repo:atd-vz-data", "vision-zero", "ocr", "cr3"],
     default_args=default_args,
@@ -71,7 +73,10 @@ def populate_cr3_metadata():
         image="atddocker/vz-cr3-metadata-pdfs:production",
         auto_remove=True,
         entrypoint=[
-            "/app/populate_cr3_file_metadata.py -t 5 -a -v"
+            "/app/populate_cr3_file_metadata.py",
+            "-t 20",
+            "-a",
+            "-v",
         ],  # five threads, do all pending actions instead of batching them, and be verbose in logging.
         tty=True,
         force_pull=True,

--- a/dags/vz_populate_cr3_metadata.py
+++ b/dags/vz_populate_cr3_metadata.py
@@ -70,7 +70,9 @@ def populate_cr3_metadata():
         environment=env_vars,
         image="atddocker/vz-cr3-metadata-pdfs:production",
         auto_remove=True,
-        entrypoint=["/app/populate_cr3_file_metadata.py -t 5 -a"],
+        entrypoint=[
+            "/app/populate_cr3_file_metadata.py -t 5 -a -v"
+        ],  # five threads, do all pending actions instead of batching them, and be verbose in logging.
         tty=True,
         force_pull=True,
     )

--- a/dags/vz_populate_cr3_metadata.py
+++ b/dags/vz_populate_cr3_metadata.py
@@ -49,7 +49,7 @@ REQUIRED_SECRETS = {
     dag_id="vz-populate-cr3-metadata",
     description="A DAG which populates CR3 metadata in the VZDB",
     schedule_interval=(
-        "0 8-12 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+        "0 8-17 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
     ),
     catchup=False,
     tags=["repo:atd-vz-data", "vision-zero", "ocr", "cr3"],

--- a/dags/vz_populate_cr3_metadata.py
+++ b/dags/vz_populate_cr3_metadata.py
@@ -48,9 +48,7 @@ REQUIRED_SECRETS = {
 @dag(
     dag_id="vz-populate-cr3-metadata",
     description="A DAG which populates CR3 metadata in the VZDB",
-    schedule_interval="*/5 8-10 * * *"
-    if DEPLOYMENT_ENVIRONMENT == "production"
-    else None,
+    schedule_interval="0 9 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     catchup=False,
     tags=["repo:atd-vz-data", "vision-zero", "ocr", "cr3"],
     default_args=default_args,
@@ -72,7 +70,7 @@ def populate_cr3_metadata():
         environment=env_vars,
         image="atddocker/vz-cr3-metadata-pdfs:production",
         auto_remove=True,
-        entrypoint=["/app/populate_cr3_file_metadata.py"],
+        entrypoint=["/app/populate_cr3_file_metadata.py -t 5 -a"],
         tty=True,
         force_pull=True,
     )

--- a/dags/vz_populate_cr3_metadata.py
+++ b/dags/vz_populate_cr3_metadata.py
@@ -77,7 +77,7 @@ def populate_cr3_metadata():
             "-t 20",
             "-a",
             "-v",
-        ],  # five threads, do all pending actions instead of batching them, and be verbose in logging.
+        ],  # twenty threads, do all pending actions instead of batching them, and be verbose in logging.
         tty=True,
         force_pull=True,
     )


### PR DESCRIPTION
## Associated issues

This PR is part of closing https://github.com/cityofaustin/atd-data-tech/issues/16746.

## Associated repo & PR

[atd-vz-data](https://github.com/cityofaustin/atd-vz-data) and in particular, [this sibling PR](https://github.com/cityofaustin/atd-vz-data/pull/1436).

## Testing
* Spin up your VZ stack, at least enough to get a DB and graphql-engine instance running. 
  * For linux users (or those who are not using docker desktop), you may have to make considerations for the missing `host.docker.internal` hostname used in the DAG's development configuration. 
* Spin up the local airflow stack and execute the DAG.
  * Did it run? 
  * You're looking for a line in the logs similar to: `INFO - Items to process: 0`
* Look at the new schedule and see if you like it.
  * The goal is to get them all processed as soon as reasonable after CR3s are downloaded.
  * It's modified to run in a way that processes all pending operations, instead of doing it batch by batch. Because of this, I'm changing the schedule to run at the top of the hour, from 8AM to noon. To prevent the very unlikely case of it running longer than an hour and getting into the situation to where we have two going at once, I've set the `execution_timeout` to 50 minutes, just in case. 
  * Under this regime, at the top of the next hour after the CR3s are downloaded, we will rapidly get caught up and begin showing those CR3s on the VZE.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates