### PR TITLE
Add get_date_filter_arg to task flow definition

### DIFF
--- a/dags/atd_bond_reporting.py
+++ b/dags/atd_bond_reporting.py
@@ -6,7 +6,6 @@ from pendulum import datetime, duration, now
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
-from utils.knack import get_date_filter_arg
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 

--- a/dags/atd_executive_dashboard_row_weekly_summary.py
+++ b/dags/atd_executive_dashboard_row_weekly_summary.py
@@ -9,7 +9,6 @@ from pendulum import datetime, duration, now
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
-from utils.knack import get_date_filter_arg
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 

--- a/dags/atd_kits_dms_message.py
+++ b/dags/atd_kits_dms_message.py
@@ -8,7 +8,6 @@ from pendulum import datetime, duration, now
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
-from utils.knack import get_date_filter_arg
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 

--- a/dags/atd_kits_sig_stat_pub.py
+++ b/dags/atd_kits_sig_stat_pub.py
@@ -6,7 +6,6 @@ from pendulum import datetime, duration, now
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
-from utils.knack import get_date_filter_arg
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 

--- a/dags/atd_knack_inventory_transactions.py
+++ b/dags/atd_knack_inventory_transactions.py
@@ -90,4 +90,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t1 >> t2
+    get_date_filter_arg >> t1 >> t2

--- a/dags/atd_knack_purchase_request_copier.py
+++ b/dags/atd_knack_purchase_request_copier.py
@@ -5,7 +5,6 @@ from airflow.operators.docker_operator import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
-from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")

--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -8,7 +8,6 @@ from pendulum import datetime, duration, now
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
-from utils.knack import get_date_filter_arg
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -70,4 +70,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t1
+    get_date_filter_arg >> t1


### PR DESCRIPTION
Two of our DAGs were failing intermittently when the first first task `t1` was run concurrently with `get_date_filter_arg`. Two of our DAGs were missing it in the task flow part.

https://austininnovation.slack.com/archives/C013G4RNJ01/p1708925588292689

## Associated issues
none

## Associated repo
various 

## Testing

**Steps to test:**
Kinda hard to test this as sometimes these DAGs will succeed even without this PR. 

---
#### Ship list
- [x] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates