### PR TITLE
PR in two fixes which have been made in situ in production; fix knack utility and cron job definition

### DIFF
--- a/dags/utils/knack.py
+++ b/dags/utils/knack.py
@@ -21,9 +21,7 @@ def get_date_filter_arg(should_replace_monthly=False, **context):
     """
 
     today = now()
-    prev_start_date = (
-        context.get("prev_start_date_success").isoformat() or today.isoformat()
-    )
+    prev_start_date = context.get("prev_start_date_success") or today
 
     if should_replace_monthly and today.day == 1:
         return ""

--- a/dags/utils/knack.py
+++ b/dags/utils/knack.py
@@ -1,5 +1,5 @@
 from airflow.decorators import task
-from pendulum import now
+from pendulum import now, parse, DateTime
 
 
 @task(
@@ -20,7 +20,19 @@ def get_date_filter_arg(should_replace_monthly=False, **context):
         Str or None: the -d flag and ISO date string or None
     """
     today = now()
-    prev_start_date = context.get("prev_start_date_success") or today.isoformat()
+    prev_start_date = context.get("prev_start_date_success")
+
+    if isinstance(prev_start_date, DateTime):
+        prev_start_date = prev_start_date.isoformat()
+    elif prev_start_date:
+        try:
+            prev_start_date = parse(prev_start_date).isoformat()
+        except ValueError:
+            prev_start_date = today.isoformat()
+    else:
+        prev_start_date = today.isoformat()
+
     if should_replace_monthly and today.day == 1:
         return ""
+
     return f"-d {prev_start_date}"

--- a/dags/utils/knack.py
+++ b/dags/utils/knack.py
@@ -19,18 +19,11 @@ def get_date_filter_arg(should_replace_monthly=False, **context):
     Returns:
         Str or None: the -d flag and ISO date string or None
     """
-    today = now()
-    prev_start_date = context.get("prev_start_date_success")
 
-    if isinstance(prev_start_date, DateTime):
-        prev_start_date = prev_start_date.isoformat()
-    elif prev_start_date:
-        try:
-            prev_start_date = parse(prev_start_date).isoformat()
-        except ValueError:
-            prev_start_date = today.isoformat()
-    else:
-        prev_start_date = today.isoformat()
+    today = now()
+    prev_start_date = (
+        context.get("prev_start_date_success").isoformat() or today.isoformat()
+    )
 
     if should_replace_monthly and today.day == 1:
         return ""

--- a/dags/utils/knack.py
+++ b/dags/utils/knack.py
@@ -28,4 +28,4 @@ def get_date_filter_arg(should_replace_monthly=False, **context):
     if should_replace_monthly and today.day == 1:
         return ""
 
-    return f"-d {prev_start_date}"
+    return f"-d {prev_start_date.isoformat()}"

--- a/dags/utils/knack.py
+++ b/dags/utils/knack.py
@@ -1,5 +1,5 @@
 from airflow.decorators import task
-from pendulum import now, parse, DateTime
+from pendulum import now
 
 
 @task(

--- a/toolbox/log-purge/log-purge.cron
+++ b/toolbox/log-purge/log-purge.cron
@@ -3,7 +3,7 @@
 # time greater than 30 days, and the second command removes all empty directories. Removed
 # files and directories are logged into /var/log which will get rotated by the system.
 
-0 2 * * * find /usr/airflow/atd-airflow/logs -type f -mtime +30 -exec rm -v {} \; \
+0 2 * * * root find /usr/airflow/atd-airflow/logs -type f -mtime +30 -exec rm -v {} \; \
 >> /var/log/airflow-logs-purge.log && \
 find /usr/airflow/atd-airflow/logs -type d -empty | xargs -I {} rmdir -v {}; \
 >> /var/log/airflow-logs-purge.log  && \


### PR DESCRIPTION
## Associated issues

/none/

These changes are in production already. I had promised to PR this in last sprint, and I forgot. I found the outstanding changes again last night, so here we are -- better late than never! Sorry for the delay on delivering this PR to y'all.

## Background for `dags/utils/knack.py`

Through a very informative and interesting conversation with @johnclary, the root cause of this situation was identified, and we're able to revert back to this ever-so-slightly changed code.

## Background for `toolbox/log-purge/log-purge.cron`

At some point in the recent past, we discovered that our cron job definition was malformed because it was to be used in the `/etc` definitions of jobs, where the user has to be specified for the daemon to know who to run the job as. We had used the format you use in `crontab -e` which intrinsically knows that the user to use is "you."

## Associated repo

`atd-airflow`

## Testing

These are in production, and have been for a few weeks, so we genuinely get this one for free.


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates