### PR TITLE
Incremental updates in Moped > AGOL ETL 

### DIFF
--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -47,7 +47,7 @@ with DAG(
     dag_id="atd_moped_components_to_agol",
     description="publish component record data to ArcGIS Online (AGOL)",
     default_args=DEFAULT_ARGS,
-    schedule_interval="30 22 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=30),
     tags=["repo:atd-moped", "moped", "agol"],
     catchup=False,

--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -48,7 +48,7 @@ with DAG(
     description="publish component record data to ArcGIS Online (AGOL)",
     default_args=DEFAULT_ARGS,
     schedule_interval="*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
-    dagrun_timeout=duration(minutes=30),
+    dagrun_timeout=duration(minutes=5),
     tags=["repo:atd-moped", "moped", "agol"],
     catchup=False,
 ) as dag:

--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -8,6 +8,7 @@ from pendulum import datetime, duration, now
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
+from utils.knack import get_date_filter_arg
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 
@@ -53,13 +54,15 @@ with DAG(
 ) as dag:
     docker_image = "atddocker/atd-moped-etl-arcgis:production"
 
+    date_filter_arg = get_date_filter_arg()
+
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperator(
         task_id="moped_components_to_agol",
         image=docker_image,
         auto_remove=True,
-        command="python components_to_agol.py",
+        command=f"python components_to_agol.py {date_filter_arg}",
         environment=env_vars,
         tty=True,
         force_pull=True,


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/14479

Small PR to update the frequency of this DAG and to pass the `date_filter_arg` to the updated Moped script.

How this works:
1. The updated DockerOperator command pass a `-d` flag with a timestamp with timezone date of the last successful run (looks like `python components_to_agol.py -d 2024-07-01T00:06:16.360805+00:00`)
2. The [script was updated](https://github.com/cityofaustin/atd-moped/pull/1369) to expect this flag and date to determine how far back to look for updated project components

## Associated repo
https://github.com/cityofaustin/atd-moped/pull/1369

## Testing

**Steps to test:**
I could use some feedback on this deploy plan to make sure I'm thinking about this right. 🙏

1. This is an existing DAG so it will have a `prev_start_date_success` ([docs](https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html)) coming from our `get_date_filter_arg` helper when this code deploys.
3. So, to deploy this update which goes from once-a-day full replace (~8-15 min run duration recently) to every 5 min updates of only Moped projects updated since the last successful run (way faster run duration), the only risk is having the first run with the updated schedule go longer than 5 min.
4. I think that the chance is very low especially since we would deploy this updated Airflow code the same day as the Moped code which would mean 1 day of updates in projects from Moped users.
5. If something goes wrong, the script still supports a full replace so we can pause the DAG schedule, wipe the dataset by running the script locally with the full replace option, and then resume the schedule to pick up future Moped project updates.

---
#### Ship list
- [x] Code reviewed 
- [x] Product manager approved
~- [ ] Add note to 1PW secrets moved to API vault and check for duplicates~