### PR TITLE
DMS message pub: remove date_filter_arg

### DIFF
--- a/dags/atd_knack_dms.py
+++ b/dags/atd_knack_dms.py
@@ -1,3 +1,5 @@
+# test locally with: docker compose run --rm airflow-cli dags test atd_knack_dms
+
 import os
 
 from airflow.models import DAG
@@ -73,8 +75,6 @@ with DAG(
     app_name = "data-tracker"
     container = "view_1564"
 
-    date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
-
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperator(
@@ -82,7 +82,7 @@ with DAG(
         docker_conn_id="docker_default",
         image=docker_image,
         auto_remove=True,
-        command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
+        command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container}",
         environment=env_vars,
         tty=True,
         force_pull=True,
@@ -94,7 +94,7 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove=True,
-        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}",
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container}",
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,
@@ -105,10 +105,10 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove=True,
-        command=f"./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} {date_filter_arg}",
+        command=f"./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container}",
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,
     )
 
-    date_filter_arg >> t1 >> t2 >> t3
+    t1 >> t2 >> t3

--- a/dags/atd_knack_dms.py
+++ b/dags/atd_knack_dms.py
@@ -7,7 +7,6 @@ from airflow.operators.docker_operator import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
-from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")


### PR DESCRIPTION
Noticed our DMS socrata [dataset](https://data.austintexas.gov/Transportation-and-Mobility/Dynamic-Message-Signs-DMS-/4r2j-b4rx/about_data) was only updating at the beginning of the month. This is because atd-kits does not update the modified date when it updates the data in knack. Since this is only 20 records, I see no problem just updating the whole thing daily.

## Associated issues
n/a
## Associated repos
- https://github.com/cityofaustin/atd-knack-services
- https://github.com/cityofaustin/atd-kits
## Testing

**Steps to test:**
Feel free to run this locally, you won't break anything
> $ docker compose run --rm airflow-cli dags test atd_knack_dms

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates