### PR TITLE
Add params to Moped to AGOL DAG

### DIFF
--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -63,6 +63,7 @@ def get_args(params, **context):
         Str: the -d flag and ISO date string or full replace arg.
     """
     full_replace = bool(params["full_replace"])
+
     if full_replace == False:
         prev_start_date = context.get("prev_start_date_success") or parse("1970-01-01")
         return f"-d {prev_start_date.isoformat()}"
@@ -73,6 +74,7 @@ def get_args(params, **context):
 @task.branch(task_id="branch")
 def branch(params):
     """Task to determine whether to fully replace dataset or not based on web server input.
+    See https://airflow.apache.org/docs/apache-airflow/2.9.0/core-concepts/dags.html#branching
     See https://airflow.apache.org/docs/apache-airflow/2.9.0/core-concepts/params.html.
 
     Args:
@@ -118,7 +120,7 @@ with DAG(
         tty=True,
         force_pull=True,
         mount_tmp_dir=False,
-        execution_timeout=duration(minutes=15),
+        execution_timeout=duration(minutes=30),
     )
 
     incremental = DockerOperator(

--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -46,6 +46,8 @@ REQUIRED_SECRETS = {
 }
 
 
+# TODO: Make this is string param so that we can just pass any arguments to the script as an override
+# TODO: Handle null or empty string when no param is passed
 @task(
     task_id="get_args",
 )
@@ -63,11 +65,13 @@ with DAG(
     dag_id="atd_moped_components_to_agol",
     description="publish component record data to ArcGIS Online (AGOL)",
     default_args=DEFAULT_ARGS,
-    schedule_interval="*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    # schedule_interval="*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="*/1 * * * *",
     dagrun_timeout=duration(minutes=5),
     tags=["repo:atd-moped", "moped", "agol"],
     catchup=False,
     params={"full_replace": Param(False, type="boolean")},
+    max_active_runs=1,
 ) as dag:
     # docker_image = "atddocker/atd-moped-etl-arcgis:production"
     docker_image = "ubuntu:latest"
@@ -93,7 +97,7 @@ with DAG(
         task_id="moped_components_to_agol",
         image=docker_image,
         auto_remove=True,
-        command=f"echo {args}",
+        command=f"sleep 2m",
         # environment=env_vars,
         tty=True,
         force_pull=True,

--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -4,7 +4,6 @@ import os
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
-from airflow.operators.bash_operator import BashOperator
 from airflow.decorators import task
 from airflow.models import Param
 from pendulum import datetime, duration, now, parse
@@ -46,67 +45,56 @@ REQUIRED_SECRETS = {
 }
 
 
-# TODO: Make this is string param so that we can just pass any arguments to the script as an override
-# TODO: Handle null or empty string when no param is passed
 @task(
     task_id="get_args",
 )
-def get_args(full_replace_param, **context):
-    full_replace = full_replace_param == "True"
+def get_args(arg_override, **context):
+    """Task to get a date filter based on previous success date. If there
+    is no prev success date, today's date is returned. If arg_override is provided,
+    it will be returned instead of the date filter.
 
-    if full_replace:
-        return "-f"
-    else:
+    Args:
+        arg_override (string): if provided, the arg string will be used instead of the date filter
+        in the Python script invocation.
+        context (dict): Airflow task context, which contains the prev_start_date_success
+            variable.
+
+    Returns:
+        Str: the -d flag and ISO date string or script argument override string.
+    """
+    if arg_override == "":
         prev_start_date = context.get("prev_start_date_success") or parse("1970-01-01")
         return f"-d {prev_start_date.isoformat()}"
+    else:
+        return arg_override
 
 
 with DAG(
     dag_id="atd_moped_components_to_agol",
     description="publish component record data to ArcGIS Online (AGOL)",
     default_args=DEFAULT_ARGS,
-    # schedule_interval="*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
-    schedule_interval="*/1 * * * *",
+    schedule_interval="*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=5),
     tags=["repo:atd-moped", "moped", "agol"],
     catchup=False,
-    params={"full_replace": Param(False, type="boolean")},
-    max_active_runs=1,
+    params={"arg_override": Param(default="", type="string")},
+    max_active_runs=1,  # Block schedule while DAG with params is triggered
 ) as dag:
-    # docker_image = "atddocker/atd-moped-etl-arcgis:production"
-    docker_image = "ubuntu:latest"
+    docker_image = "atddocker/atd-moped-etl-arcgis:production"
 
-    # date_filter_arg = get_date_filter_arg()
-    args = get_args("{{ params.full_replace }}")
-    # args = get_args(params=dag.params)
+    args = get_args("{{ params.arg_override }}")
 
-    # env_vars = get_env_vars_task(REQUIRED_SECRETS)
-
-    # t1 = DockerOperator(
-    #     task_id="moped_components_to_agol",
-    #     image=docker_image,
-    #     auto_remove=True,
-    #     command=f"python components_to_agol.py {date_filter_arg}",
-    #     environment=env_vars,
-    #     tty=True,
-    #     force_pull=True,
-    #     mount_tmp_dir=False,
-    # )
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperator(
         task_id="moped_components_to_agol",
         image=docker_image,
         auto_remove=True,
-        command=f"sleep 2m",
-        # environment=env_vars,
+        command=f"python components_to_agol.py {args}",
+        environment=env_vars,
         tty=True,
         force_pull=True,
         mount_tmp_dir=False,
     )
-
-    # t1 = BashOperator(
-    #     task_id="test_param",
-    #     bash_command='echo "{{params.full_replace}}"',
-    # )
 
     args >> t1

--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -6,11 +6,10 @@ from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
 from airflow.decorators import task
 from airflow.models import Param
-from pendulum import datetime, duration, now, parse
+from pendulum import datetime, duration, parse
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
-from utils.knack import get_date_filter_arg
 
 DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/18469

This PR adds a new DAG parameter to control the flow of the DAG to be either incremental (current behavior) or a full data replacement (new and currently only possible with a local run). This will help us execute a full replacement to backfill new fields in the AGOL dataset when we add them in the future.

I tried and failed to use the parameter to dynamically set the execution timeout parameter in the DockerOperator task, and, the more that I read, it felt like I was use the wrong tool for the problem. Open to all feedback on the implementation since we haven't used branching before.

Here are some links:
- https://airflow.apache.org/docs/apache-airflow/2.9.0/core-concepts/dags.html#branching
- And what i read about passing data at runtime: 
   - Xcom https://www.astronomer.io/docs/learn/airflow-passing-data-between-tasks 
   - Similar issue that i ran into https://stackoverflow.com/questions/64235496/format-jinja-template-as-int-in-operator-parameter-in-airflow
      - I even tried writing awkward code using [Jinja templating](https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html) like `execution_timeout=duration(minutes=int("{{ 30 if params.full_replace else 5 }}")` which Airflow wouldn't accept as a working DAG since the logic inside the string doesn't resolve until runtime so it sees a long string that is an invalid argument for `int()`

## Associated repo
https://github.com/cityofaustin/atd-moped/tree/main/moped-etl/arcgis

## Testing

**Steps to test:**
1. To test, you will have to disable the production DAG before proceeding. You will also need to fully complete these steps to make sure the dataset remains complete. After completing the steps, turn the production DAG back on to make sure we continue to pick up updated Moped components. It will take about 15 minutes.
2. Start up your local Airflow stack and then go to this DAG in the dashboard. Click the Play button to trigger a run, and you will see a new toggle labeled `full_replace`. Keep the radio toggled off and press the **Trigger** button.
3. You should see `Starting sync. Finding projects updated since <timestamp> and replacing components data...` logged and 
4. Next, trigger the run with the `full_replace` radio toggled on. This run takes much longer and fully replaces ~5600 points features, ~6200 line features, and then the combined ~11800 features to three AGOL layers.
5. You should see `Starting sync. Replacing all projects' components data...` logged.
6. After it is complete, please turn the production schedule back on. Thanks!

**Note:** The DAG defaults to `full_replace = False` so, when scheduled, the DAG will run incrementally, and a manually trigger full replace will interrupt the schedule, run the full replace, and revert to incremental runs afterwards. The scheduled when I tested locally looked like:
<img width="420" alt="Screenshot 2024-08-26 at 3 33 23 PM" src="https://github.com/user-attachments/assets/34306805-4784-4e5d-85f6-31f10e002f5a">


---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates