### PR TITLE
Remove unneeded bond reporting tasks

### DIFF
--- a/dags/atd_bond_reporting.py
+++ b/dags/atd_bond_reporting.py
@@ -133,34 +133,6 @@ with DAG(
     )
 
     t3 = DockerOperator(
-        task_id="microstrategy_report_fdu_expenses_quarterly",
-        image=docker_image,
-        docker_conn_id="docker_default",
-        auto_remove=True,
-        command='python atd-bond-reporting/microstrategy_to_s3.py -r "FDU Expenses by Quarter"',
-        environment=env_vars,
-        tty=True,
-        force_pull=False,
-        mount_tmp_dir=False,
-        retries=3,
-        retry_delay=duration(seconds=60),
-    )
-
-    t4 = DockerOperator(
-        task_id="microstrategy_report_2020_bond_metadata",
-        image=docker_image,
-        docker_conn_id="docker_default",
-        auto_remove=True,
-        command='python atd-bond-reporting/microstrategy_to_s3.py -r "2020 Division Group and Unit"',
-        environment=env_vars,
-        tty=True,
-        force_pull=False,
-        mount_tmp_dir=False,
-        retries=3,
-        retry_delay=duration(seconds=60),
-    )
-
-    t5 = DockerOperator(
         task_id="bond_data_to_postgres",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -174,7 +146,7 @@ with DAG(
         retry_delay=duration(seconds=60),
     )
 
-    t6 = DockerOperator(
+    t4 = DockerOperator(
         task_id="bond_data_processing",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -188,18 +160,5 @@ with DAG(
         retry_delay=duration(seconds=60),
     )
 
-    t7 = DockerOperator(
-        task_id="bond_quarterly_data_processing",
-        image=docker_image,
-        docker_conn_id="docker_default",
-        auto_remove=True,
-        command="python atd-bond-reporting/quarterly_reporting.py",
-        environment=env_vars,
-        tty=True,
-        force_pull=False,
-        mount_tmp_dir=False,
-        retries=3,
-        retry_delay=duration(seconds=60),
-    )
 
-    t1 >> t2 >> t3 >> t4 >> t5 >> t6 >> t7
+    t1 >> t2 >> t3 >> t4

--- a/dags/atd_bond_reporting.py
+++ b/dags/atd_bond_reporting.py
@@ -1,3 +1,5 @@
+# test locally with: docker compose run --rm airflow-cli dags test atd_bond_reporting
+
 import os
 
 from airflow.models import DAG


### PR DESCRIPTION
[related atd-bond-reporting PR](https://github.com/cityofaustin/atd-bond-reporting/pull/10)

No one is using the quarterly reporting data, so I'm removing these task! I'm working on a PR that will get this cleaned up in the repo as well.

## Associated issues

## Associated repo
https://github.com/cityofaustin/atd-bond-reporting

## Testing

**Steps to test:**
I tested it I promise, but if you want to check:
```
$ docker compose run --rm airflow-cli dags test atd_bond_reporting
```

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates