### PR TITLE
Add narrative extraction to CRIS import DAG

### DIFF
--- a/dags/vz_cris_import.py
+++ b/dags/vz_cris_import.py
@@ -11,6 +11,7 @@ results:
 - staging: use <bucket-name>/staging/inbox and staging hasura cluster
 - dev: use <bucket-name>/dev/inbox and localhost hasura cluster
 """
+
 import os
 from pendulum import datetime, duration
 
@@ -33,32 +34,32 @@ else:
 
 
 REQUIRED_SECRETS = {
-    "ENV": {
-        "opitem": "Vision Zero CRIS Import - v2",
-        "opfield": f"{secrets_env_prefix}.env",
+    "BUCKET_ENV": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": f"{secrets_env_prefix}.BUCKET_ENV",
     },
     "AWS_ACCESS_KEY_ID": {
-        "opitem": "Vision Zero CRIS Import - v2",
+        "opitem": "Vision Zero CRIS Import",
         "opfield": f"common.AWS_ACCESS_KEY_ID",
     },
     "AWS_SECRET_ACCESS_KEY": {
-        "opitem": "Vision Zero CRIS Import - v2",
+        "opitem": "Vision Zero CRIS Import",
         "opfield": f"common.AWS_SECRET_ACCESS_KEY",
     },
     "BUCKET_NAME": {
-        "opitem": "Vision Zero CRIS Import - v2",
+        "opitem": "Vision Zero CRIS Import",
         "opfield": f"common.BUCKET_NAME",
     },
     "EXTRACT_PASSWORD": {
-        "opitem": "Vision Zero CRIS Import - v2",
+        "opitem": "Vision Zero CRIS Import",
         "opfield": f"common.EXTRACT_PASSWORD",
     },
     "HASURA_GRAPHQL_ENDPOINT": {
-        "opitem": "Vision Zero CRIS Import - v2",
+        "opitem": "Vision Zero CRIS Import",
         "opfield": f"{secrets_env_prefix}.HASURA_GRAPHQL_ENDPOINT",
     },
     "HASURA_GRAPHQL_ADMIN_SECRET": {
-        "opitem": "Vision Zero CRIS Import - v2",
+        "opitem": "Vision Zero CRIS Import",
         "opfield": f"{secrets_env_prefix}.HASURA_GRAPHQL_ADMIN_SECRET",
     },
 }
@@ -98,4 +99,15 @@ with DAG(
         force_pull=True,
     )
 
-    cris_import
+    ocr_crash_narratives = DockerOperator(
+        task_id="ocr_crash_narratives",
+        docker_conn_id="docker_default",
+        image=docker_image,
+        command=f"./cr3_ocr_narrative.py --workers 2",
+        environment=env_vars,
+        auto_remove=True,
+        tty=True,
+        force_pull=True,
+    )
+
+    cris_import >> ocr_crash_narratives


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/19204

This PR deploys the OCR narrative extraction ETL that shipped via https://github.com/cityofaustin/vision-zero/pull/1568.

## Associated repo
- `vision-zero`

## Testing

1. Get on VPN so that you can talk to the 1pass connect server
2. Start your local VZ stack with a fresh replica
3. Start your local airflow stack
4. Head to the `atd-vision-zero` bucket in AWS S3 and move `extract_2023_20240823135638635_99726_20240920_HAYSTRAVISWILLIAMSON.zip` from `/dev/cris_extracts/archive` into `/dev/cris_extracts/inbox`.

With the AWS CLI:

```shell
aws s3 mv s3://atd-vision-zero/dev/cris_extracts/archive/extract_2023_20240823135638635_99726_20240920_HAYSTRAVISWILLIAMSON.zip s3://atd-vision-zero/dev/cris_extracts/inbox/
```

or the console:

<img width="1052" alt="Screenshot 2024-10-04 at 9 57 21 AM" src="https://github.com/user-attachments/assets/481ee61d-9980-45e9-aa59-5fa431aa51e2">

5. Trigger the DAG: `vz-cris-import`

6. Use the Airflow UI to inspect the logs of the `ocr_crash_narratives` task. Grab a CRIS crash ID from the logs and checkout the OCR'd narrative in your local DB:

```sql
select investigator_narrative from crashes where cris_crash_id = 20379816;
```

7. ✨Bonus points✨ Move the extract zip you just processed back into the inbox from the archive, and trigger the DAG again. This time, the OCR task will not find any records that need to be processed and it will finish immediately. 
---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates