### PR TITLE
Traffic detectors weekly snapshot DAG

### DIFF
--- a/dags/atd_knack_traffic_detectors_weekly_snapshot.py
+++ b/dags/atd_knack_traffic_detectors_weekly_snapshot.py
@@ -17,7 +17,8 @@ DEFAULT_ARGS = {
     "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
+    "retries": 5,
+    "retry_delay": duration(minutes=5),
     "execution_timeout": duration(minutes=10),
     "on_failure_callback": task_fail_slack_alert,
 }

--- a/dags/atd_knack_traffic_detectors_weekly_snapshot.py
+++ b/dags/atd_knack_traffic_detectors_weekly_snapshot.py
@@ -1,0 +1,120 @@
+# test locally with: docker compose run --rm airflow-cli dags test atd_knack_traffic_detectors_weekly_snapshot
+
+import os
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=10),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiKey",
+    },
+    "SOCRATA_API_KEY_ID": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SOCRATA_API_KEY_SECRET": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SOCRATA_APP_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "PGREST_ENDPOINT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.endpoint",
+    },
+    "PGREST_JWT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.jwt",
+    },
+    "AWS_ACCESS_ID": {
+        "opitem": "Socrata Dataset Backups S3 Bucket",
+        "opfield": "production.AWS Access Key",
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+        "opitem": "Socrata Dataset Backups S3 Bucket",
+        "opfield": "production.AWS Secret Access Key",
+    },
+    "BUCKET": {
+        "opitem": "Socrata Dataset Backups S3 Bucket",
+        "opfield": "production.Bucket",
+    },
+}
+
+
+with DAG(
+    dag_id="atd_knack_traffic_detectors_weekly_snapshot",
+    description="Appends traffic detector assets to a running log in Socrata",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="0 1 * * SUN" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:atd-knack-services", "knack", "socrata"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/atd-knack-services:production"
+    app_name = "data-tracker"
+    container = "view_4274"
+
+    # we always want to append the the complete view contents every time
+    date_filter_arg = "-d 1970-01-01"
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="atd_knack_traffic_detectors_weekly_snapshot_to_postgrest",
+        image=docker_image,
+        docker_conn_id="docker_default",
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t2 = DockerOperator(
+        task_id="atd_knack_traffic_detectors_weekly_snapshot_to_socrata",
+        image=docker_image,
+        docker_conn_id="docker_default",
+        auto_remove=True,
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        mount_tmp_dir=False,
+    )
+
+    t3 = DockerOperator(
+        task_id="atd_knack_traffic_detectors_weekly_snapshot_socrata_backup",
+        image=docker_image,
+        docker_conn_id="docker_default",
+        auto_remove=True,
+        command=f"./atd-knack-services/services/backup_socrata.py -a {app_name} -c {container}",
+        environment=env_vars,
+        tty=True,
+        mount_tmp_dir=False,
+    )
+
+    t1 >> t2 >> t3

--- a/dags/atd_knack_traffic_detectors_weekly_snapshot.py
+++ b/dags/atd_knack_traffic_detectors_weekly_snapshot.py
@@ -70,7 +70,7 @@ with DAG(
     dag_id="atd_knack_traffic_detectors_weekly_snapshot",
     description="Appends traffic detector assets to a running log in Socrata",
     default_args=DEFAULT_ARGS,
-    schedule_interval="0 1 * * SUN" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="0 1 * * MON" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-knack-services", "knack", "socrata"],
     catchup=False,
 ) as dag:


### PR DESCRIPTION
## Associated issues
closes https://github.com/cityofaustin/atd-data-tech/issues/19844

## Associated repo
https://github.com/cityofaustin/atd-knack-services

## Testing

**Steps to test:**
```
docker compose run --rm airflow-cli dags test atd_knack_traffic_detectors_weekly_snapshot
```
**or**

`docker compose up` -> trigger `atd_knack_traffic_detectors_weekly_snapshot` through the UI

Then:

- Check the [dataset](https://datahub.austintexas.gov/Transportation-and-Mobility/Traffic-Detectors-Weekly-Archive/g939-dyvz/about_data), to see if it grows by ~5k records and the `published_date` column should have data from when you triggered it.
- Check the socrata backups [S3 bucket for this dataset](https://us-east-1.console.aws.amazon.com/s3/buckets/atd-socrata-backups?region=us-east-1&bucketType=general&prefix=g939_dyvz/) for a backup csv file for the date that you ran the script.

---
#### Ship list
- [ ] Code reviewed 
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates