### PR TITLE
Stop running the VZ Socrata export on sunday + monday mornings

### DIFF
--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -85,7 +85,8 @@ with DAG(
     dag_id="vz-socrata-export",
     description="Exports Vision Zero crash and people datasets to Socrata from Vision Zero database.",
     default_args=DEFAULT_ARGS,
-    schedule_interval="0 4 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    # do not run on sunday and monday mornings to give VZ team time to QA records imported over weekend
+    schedule_interval="0 4 * * 2-6" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     start_date=datetime(2024, 8, 1, tz="America/Chicago"),
     tags=["vision-zero", "cris", "repo:atd-vz-data", "socrata"],
 ) as dag:


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/20579

## Associated repo

* vision-zero


The ETL sequence is currently set so that the Socrata export happens at 4am local and the CRIS import runs at 5am, so QA'd data gets published, then new data gets imported.

With this change, data will not be published on Sunday and Monday mornings, giving VZ team a chance ti review the newly imported data before it's published.

Crontab guru: [`0 4 * * 2-6`](https://crontab.guru/#0_4_*_*_2-6)

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
