### PR TITLE
Deploy DAG to refresh location crashes

### DIFF
--- a/dags/vz_refresh_location_crashes.py
+++ b/dags/vz_refresh_location_crashes.py
@@ -1,0 +1,74 @@
+"""
+This DAG refreshes the location_crashes_view in the Vision Zero database
+"""
+
+import os
+from pendulum import datetime, duration
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+
+DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT")
+secrets_env_prefix = None
+
+if DEPLOYMENT_ENVIRONMENT == "production":
+    secrets_env_prefix = "prod"
+elif DEPLOYMENT_ENVIRONMENT == "staging":
+    secrets_env_prefix = "staging"
+else:
+    secrets_env_prefix = "dev"
+
+
+REQUIRED_SECRETS = {
+    "HASURA_GRAPHQL_ENDPOINT": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": f"{secrets_env_prefix}.HASURA_GRAPHQL_SCHEMA_API_ENDPOINT",
+    },
+    "HASURA_GRAPHQL_ADMIN_SECRET": {
+        "opitem": "Vision Zero CRIS Import",
+        "opfield": f"{secrets_env_prefix}.HASURA_GRAPHQL_ADMIN_SECRET",
+    },
+}
+
+
+docker_image = f"atddocker/vz-run-sql:{'production' if DEPLOYMENT_ENVIRONMENT == 'production' else 'development'}"
+
+
+DEFAULT_ARGS = {
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 2,
+    "execution_timeout": duration(minutes=60),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+
+with DAG(
+    catchup=False,
+    dag_id="vz-location-crashes-refresh",
+    description="Refreshes the materialized view: location_crashes_view ",
+    default_args=DEFAULT_ARGS,
+    # do not run on sunday and monday mornings to give VZ team time to QA records imported over weekend
+    schedule_interval="0 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    start_date=datetime(2024, 8, 1, tz="America/Chicago"),
+    tags=["vision-zero", "repo:vision-zero"],
+) as dag:
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    refresh_location_crashes = DockerOperator(
+        task_id="refresh_location_crashes",
+        docker_conn_id="docker_default",
+        image=docker_image,
+        command=f"./run_sql.py -c refresh_location_crashes",
+        environment=env_vars,
+        auto_remove=True,
+        tty=True,
+        force_pull=True,
+    )
+
+    refresh_location_crashes

--- a/dags/vz_refresh_location_crashes.py
+++ b/dags/vz_refresh_location_crashes.py
@@ -53,7 +53,6 @@ with DAG(
     dag_id="vz-location-crashes-refresh",
     description="Refreshes the materialized view: location_crashes_view ",
     default_args=DEFAULT_ARGS,
-    # do not run on sunday and monday mornings to give VZ team time to QA records imported over weekend
     schedule_interval="0 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     start_date=datetime(2024, 8, 1, tz="America/Chicago"),
     tags=["vision-zero", "repo:vision-zero"],


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/20999

This PR is a companion to https://github.com/cityofaustin/vision-zero/pull/1708. I have pushed up a docker image that should be pulled automatically when you trigger the DAG.


## Associated repo

* vision-zero

## Testing

You need VPN access to test this PR, because it uses the 1pass connect server.

Spin up your local VZ, check out `john/20999-locaiton-crashes-view`, and apply migrations and metadata. 

Start Airflow and trigger this new DAG, which is called `vz-location-crashes-refresh`


---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
