### PR TITLE
Correct airflow.cfg path in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,7 @@ x-airflow-common: &airflow-common
     - ${AIRFLOW_PROJ_DIR}/dags:/opt/airflow/dags
     - ${AIRFLOW_PROJ_DIR}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR}/plugins:/opt/airflow/plugins
-    - ${AIRFLOW_PROJ_DIR}/airflow.cfg:/opt/airflow/config/airflow.cfg
+    - ${AIRFLOW_PROJ_DIR}/airflow.cfg:/opt/airflow/airflow.cfg
     - knack-certs:/opt/airflow/certs/knack
     - /var/run/docker.sock:/var/run/docker.sock
   user: "${AIRFLOW_UID:-50000}:0"
@@ -231,7 +231,7 @@ services:
     user: "0:0"
     volumes:
       - ${AIRFLOW_PROJ_DIR}:/sources
-      - ${AIRFLOW_PROJ_DIR}/airflow.cfg:/opt/airflow/config/airflow.cfg
+      - ${AIRFLOW_PROJ_DIR}/airflow.cfg:/opt/airflow/airflow.cfg
 
   airflow-cli:
     <<: *airflow-common

--- a/toolbox/certbot/update_email_address_with_certbot.sh
+++ b/toolbox/certbot/update_email_address_with_certbot.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Get the domain that we are renewing from the script arg
+DOMAIN=$1
+
+echo "Updating email address for $DOMAIN"
+export ATD_AIRFLOW_HOMEDIR="/srv/atd-airflow";
+
+# Load the same environment variables as the Airflow stack
+source $ATD_AIRFLOW_HOMEDIR/.env
+
+# Pull op v2 (latest is currently outdated and does not include the op read command needed below)
+docker pull 1password/op:2
+
+# Retrieve and store the AWS Access Keys from 1Password
+AWS_ACCESS_KEY_ID=$(docker run --rm --name op \
+-e OP_CONNECT_HOST=$OP_CONNECT \
+-e OP_CONNECT_TOKEN=$OP_API_TOKEN \
+1password/op:2 op read op://$OP_VAULT_ID/Certbot\ IAM\ Access\ Key\ and\ Secret/accessKeyId)
+
+AWS_SECRET_ACCESS_KEY=$(docker run --rm --name op \
+-e OP_CONNECT_HOST=$OP_CONNECT \
+-e OP_CONNECT_TOKEN=$OP_API_TOKEN \
+1password/op:2 op read op://$OP_VAULT_ID/Certbot\ IAM\ Access\ Key\ and\ Secret/accessSecret)
+
+docker pull certbot/dns-route53:v2.6.0
+
+docker run --rm --name certbot \
+-e AWS_ACCESS_KEY_ID=$(echo $AWS_ACCESS_KEY_ID | tr -d '\r' ) \
+-e AWS_SECRET_ACCESS_KEY=$(echo $AWS_SECRET_ACCESS_KEY | tr -d '\r' ) \
+-v "/etc/letsencrypt:/etc/letsencrypt" \
+-v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
+certbot/dns-route53 update_account --email transportation.data@austintexas.gov


### PR DESCRIPTION
## Associated issues

Follow up to march update work

## Associated repo

airflow itself

## Testing

Please review the two line change, removing the `config` portion of the path.

## See Also

https://austininnovation.slack.com/archives/CHZE6BC6L/p1743604765195829

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
