### PR TITLE
set 311 reporting DAG schedule to run twice daily

### DIFF
--- a/dags/dts_csr_report_publishing.py
+++ b/dags/dts_csr_report_publishing.py
@@ -145,7 +145,7 @@ with DAG(
     dag_id="dts_csr_report_publishing",
     description="Downloads reports of 311 service requests for TPW and publishes it in a Socrata dataset.",
     default_args=default_args,
-    schedule_interval="36 2 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval="36 2,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=timedelta(minutes=60),
     tags=["repo:dts-311-reporting", "socrata", "csr"],
     catchup=False,


### PR DESCRIPTION
We usually have a 24+ hour lag in data from these reports we pull from 311. I ran it this afternoon and found fresher data. I think it either takes a long time for these reports to run so we aren't catching it at 2AM or the time 311 sends new data is not set to midnight (which is what we were told).

Sets the schedule to run twice daily at 2:36 AM and 1:36PM. I will reflect a similar refresh time for[ Power BI](https://app.powerbigov.us/links/RqF4l_7Mgj?ctid=5c5e19f6-a6ab-4b45-b1d0-be4608a9a67f&pbi_source=linkShare) as well.

[slack thread](https://austininnovation.slack.com/archives/C050E76BUQH/p1748543712377749)

## Associated issues

## Associated repo
https://github.com/cityofaustin/dts-311-reporting

## Testing

**Steps to test:**

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
