### PR TITLE
double timeout duration for signs work order specifications

### DIFF
--- a/dags/atd_knack_signs_work_order_specifications.py
+++ b/dags/atd_knack_signs_work_order_specifications.py
@@ -17,7 +17,7 @@ DEFAULT_ARGS = {
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 0,
-    "execution_timeout": duration(minutes=60),
+    "execution_timeout": duration(minutes=120),
     "on_failure_callback": task_fail_slack_alert,
 }
 


### PR DESCRIPTION
Giving it some more time before it throws in the towel since its been taking longer than 60 minutes doing a full replace

## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/22965

