### PR TITLE
Update AGOL credentials in DAGs to align with other DAGs

### DIFF
--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -34,12 +34,12 @@ REQUIRED_SECRETS = {
         "opfield": "production.Admin Secret",
     },
     "AGOL_USERNAME": {
-        "opitem": "AGOL Scripts Publisher",
-        "opfield": "production.Username",
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.username",
     },
     "AGOL_PASSWORD": {
-        "opitem": "AGOL Scripts Publisher",
-        "opfield": "production.Password",
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.password",
     },
 }
 

--- a/dags/dts_inspector_priority.py
+++ b/dags/dts_inspector_priority.py
@@ -84,12 +84,12 @@ REQUIRED_SECRETS = {
     },
     # ArcGIS Online
     "AGOL_USERNAME": {
-        "opitem": "AGOL Scripts Publisher",
-        "opfield": "production.Username",
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.username",
     },
     "AGOL_PASSWORD": {
-        "opitem": "AGOL Scripts Publisher",
-        "opfield": "production.Password",
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.password",
     },
 }
 
@@ -157,6 +157,5 @@ with DAG(
         mount_tmp_dir=False,
         trigger_rule="all_done",
     )
-
 
     t1 >> t2 >> t3 >> t4


### PR DESCRIPTION
## Associated issues

This PR will close https://github.com/cityofaustin/atd-data-tech/issues/22837.

## Associated repo

`dts-right-of-way-reporting` & `atd-moped`

## Testing

* Spin up your local development stack
* Kick off the DAG `dts_inspector_priority.py`
  * Did it succeed at the second to last task?

### Testing note 
@mddilley I did not personally test my changes on the moped DAG that was changed. It's the exact same credential copied in there, and I wasn't sure that it wouldn't be a struggle to get it to complete again. Should I have?

## Merger

On merge, the 1PW entry named `AGOL Scripts Publisher` will be archived.

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
