### PR TITLE
Refactor use of `os` library as an Airflow optimization

### DIFF
--- a/dags/airflow-database-backup.py
+++ b/dags/airflow-database-backup.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 from pendulum import datetime, duration
 
 from airflow.decorators import task
@@ -9,7 +9,7 @@ from datetime import datetime as vanilla_datetime
 
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",

--- a/dags/atd_airflow_docker_image_prune.py
+++ b/dags/atd_airflow_docker_image_prune.py
@@ -6,7 +6,8 @@ layers contain ETL code. When that code changes, the previous layer is discarded
 resulting in dangling docker images that can consume signficant disk space. This DAG
 removes those dangling images.
 """
-import os
+
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.bash_operator import BashOperator
@@ -14,7 +15,7 @@ from pendulum import datetime, duration
 
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT")
 
 default_args = {
     "owner": "airflow",

--- a/dags/atd_cost_of_service_fees.py
+++ b/dags/atd_cost_of_service_fees.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -7,7 +7,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_finance_data_fdus.py
+++ b/dags/atd_finance_data_fdus.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_fdus
 
-import os
+from os import getenv
 
 from airflow.decorators import task
 from airflow.models import DAG
@@ -10,7 +10,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_finance_data_master_agreements.py
+++ b/dags/atd_finance_data_master_agreements.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_master_agreements
 
-import os
+from os import getenv
 
 from airflow.decorators import task
 from airflow.models import DAG
@@ -10,7 +10,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_finance_data_objects.py
+++ b/dags/atd_finance_data_objects.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_objects
 
-import os
+from os import getenv
 
 from airflow.decorators import task
 from airflow.models import DAG
@@ -10,7 +10,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_finance_data_subprojects.py
+++ b/dags/atd_finance_data_subprojects.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_subprojects
 
-import os
+from os import getenv
 
 from airflow.decorators import task
 from airflow.models import DAG
@@ -10,7 +10,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_finance_data_task_orders.py
+++ b/dags/atd_finance_data_task_orders.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_task_orders
 
-import os
+from os import getenv
 
 from airflow.decorators import task
 from airflow.models import DAG
@@ -10,7 +10,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_finance_data_units.py
+++ b/dags/atd_finance_data_units.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_finance_data_units
 
-import os
+from os import getenv
 
 from airflow.decorators import task
 from airflow.models import DAG
@@ -10,7 +10,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_kits_dms_message.py
+++ b/dags/atd_kits_dms_message.py
@@ -1,6 +1,6 @@
 # Test locally with: docker compose run --rm airflow-cli dags test atd_kits_dms_message_pub
 
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -9,7 +9,7 @@ from pendulum import datetime, duration, now
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_kits_sig_stat_pub.py
+++ b/dags/atd_kits_sig_stat_pub.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -7,7 +7,7 @@ from pendulum import datetime, duration, now
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_amd_preventative_maintenance.py
+++ b/dags/atd_knack_amd_preventative_maintenance.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_knack_amd_pm
 
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -10,7 +10,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 from utils.knack import get_date_filter_arg
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -93,6 +93,5 @@ with DAG(
         tty=True,
         mount_tmp_dir=False,
     )
-
 
     date_filter_arg >> t1 >> t2

--- a/dags/atd_knack_artbox_signals.py
+++ b/dags/atd_knack_artbox_signals.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 from utils.knack import get_date_filter_arg
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_arterial_managment_locations.py
+++ b/dags/atd_knack_arterial_managment_locations.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_cctv_cameras.py
+++ b/dags/atd_knack_cctv_cameras.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_corridor_retiming.py
+++ b/dags/atd_knack_corridor_retiming.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 from utils.knack import get_date_filter_arg
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -49,7 +49,7 @@ REQUIRED_SECRETS = {
     "PGREST_JWT": {
         "opitem": "atd-knack-services PostgREST",
         "opfield": "production.jwt",
-    }
+    },
 }
 
 

--- a/dags/atd_knack_data_tracker_location_updater.py
+++ b/dags/atd_knack_data_tracker_location_updater.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.knack import get_date_filter_arg
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -50,15 +50,15 @@ with DAG(
 ) as dag:
     docker_image = "atddocker/atd-knack-services:production"
     app_name = "data-tracker"
-    container = "view_1201" 
+    container = "view_1201"
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
-    
+
     date_filter_arg = get_date_filter_arg()
 
     t1 = DockerOperator(
         task_id="update_locations",
-        image= "atddocker/atd-knack-services:production",
+        image="atddocker/atd-knack-services:production",
         docker_conn_id="docker_default",
         auto_remove="force",
         command=f"./atd-knack-services/services/knack_location_updater.py -a {app_name} -c {container} {date_filter_arg}",

--- a/dags/atd_knack_data_tracker_sr_asset_assign.py
+++ b/dags/atd_knack_data_tracker_sr_asset_assign.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -7,7 +7,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -59,7 +59,7 @@ with DAG(
 
     t1 = DockerOperator(
         task_id="service_request_asset_assign",
-        image= "atddocker/atd-knack-services:production",
+        image="atddocker/atd-knack-services:production",
         docker_conn_id="docker_default",
         auto_remove="force",
         command=f"./atd-knack-services/services/sr_asset_assign.py -a data-tracker -c view_2362 -s signals",

--- a/dags/atd_knack_data_tracker_street_segment_updater.py
+++ b/dags/atd_knack_data_tracker_street_segment_updater.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.knack import get_date_filter_arg
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_detectors.py
+++ b/dags/atd_knack_detectors.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -7,7 +7,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_dms.py
+++ b/dags/atd_knack_dms.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_knack_dms
 
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -9,7 +9,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_employees_tpw_hire.py
+++ b/dags/atd_knack_employees_tpw_hire.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_knack_employees_tpw_hire
 
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -10,7 +10,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 from utils.knack import get_date_filter_arg
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -76,7 +76,7 @@ with DAG(
     catchup=False,
 ) as dag:
     docker_image = "atddocker/atd-knack-services:production"
-    app_name_src =  "hr-manager" 
+    app_name_src = "hr-manager"
     container_src = "view_684"
     app_name_dest = "tpw-hire"
     container_dest = "view_148"

--- a/dags/atd_knack_esb_311.py
+++ b/dags/atd_knack_esb_311.py
@@ -1,16 +1,16 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
-from docker.types import Mount 
+from docker.types import Mount
 from pendulum import datetime, duration, now
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
-DOCKER_IMAGE ="atddocker/atd-knack-311:production"
+DOCKER_IMAGE = "atddocker/atd-knack-311:production"
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -35,7 +35,7 @@ REQUIRED_SECRETS_DATA_TRACKER = {
     "ESB_ENDPOINT": {
         "opitem": "CTM Enterprise Service Bus - ESB - 311 Interface",
         "opfield": f"production.endpoint",
-    }
+    },
 }
 
 REQUIRED_SECRETS_SIGNS_MARKINGS = {
@@ -50,7 +50,7 @@ REQUIRED_SECRETS_SIGNS_MARKINGS = {
     "ESB_ENDPOINT": {
         "opitem": "CTM Enterprise Service Bus - ESB - 311 Interface",
         "opfield": f"production.endpoint",
-    }
+    },
 }
 
 
@@ -58,7 +58,9 @@ with DAG(
     dag_id=f"atd_knack_esb_311",
     description="Publishes 311 SR activities from Knack to 311 CSR via the CTM ESB",
     default_args=DEFAULT_ARGS,
-    schedule_interval="1-59/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval=(
+        "1-59/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+    ),
     tags=["repo:atd-knack-311", "311", "knack", "esb"],
     catchup=False,
 ) as dag:
@@ -67,10 +69,10 @@ with DAG(
 
     # the self-signed certificate and key must be stored within the airflow project directory
     # according to the path specified in the docker compose volumne definition
-    cert_mount =  Mount(
-        source="atd-airflow_knack-certs", 
+    cert_mount = Mount(
+        source="atd-airflow_knack-certs",
         target="/app/atd-knack-311/certs",
-        type="volume"
+        type="volume",
     )
 
     t1 = DockerOperator(
@@ -84,7 +86,7 @@ with DAG(
         force_pull=True,
         mount_tmp_dir=False,
         network_mode="bridge",
-        mounts=[cert_mount]
+        mounts=[cert_mount],
     )
 
     t2 = DockerOperator(
@@ -98,7 +100,7 @@ with DAG(
         force_pull=True,
         mount_tmp_dir=False,
         network_mode="bridge",
-        mounts=[cert_mount]
+        mounts=[cert_mount],
     )
 
     t1 >> t2

--- a/dags/atd_knack_flashing_beacons.py
+++ b/dags/atd_knack_flashing_beacons.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_inventory_items_finance_to_data_tracker.py
+++ b/dags/atd_knack_inventory_items_finance_to_data_tracker.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_inventory_items_nightly_snapshot.py
+++ b/dags/atd_knack_inventory_items_nightly_snapshot.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -7,7 +7,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_inventory_transactions.py
+++ b/dags/atd_knack_inventory_transactions.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_markings_attachments.py
+++ b/dags/atd_knack_markings_attachments.py
@@ -1,6 +1,6 @@
 # test locally: docker compose run --rm airflow-cli dags test atd_knack_markings_attachments
 
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -10,7 +10,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -55,7 +55,9 @@ with DAG(
     dag_id="atd_knack_markings_attachments",
     description="Loads markings attachments records from Knack to Postgrest to AGOL",
     default_args=DEFAULT_ARGS,
-    schedule_interval="05 12,14 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval=(
+        "05 12,14 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+    ),
     tags=["repo:atd-knack-services", "knack", "agol", "signs-markings"],
     catchup=False,
 ) as dag:
@@ -78,7 +80,6 @@ with DAG(
         force_pull=True,
         mount_tmp_dir=False,
     )
-
 
     t2 = DockerOperator(
         task_id="atd_knack_markings_attachments_to_agol",

--- a/dags/atd_knack_markings_materials.py
+++ b/dags/atd_knack_markings_materials.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -53,7 +53,9 @@ with DAG(
     dag_id="atd_knack_markings_materials",
     description="Loads markings materials records from Knack to Postgrest to AGOL",
     default_args=DEFAULT_ARGS,
-    schedule_interval="10 12,14 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval=(
+        "10 12,14 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+    ),
     tags=["repo:atd-knack-services", "knack", "agol", "signs-markings"],
     catchup=False,
 ) as dag:
@@ -76,7 +78,6 @@ with DAG(
         force_pull=True,
         mount_tmp_dir=False,
     )
-
 
     t2 = DockerOperator(
         task_id="atd_knack_markings_materials_to_agol",

--- a/dags/atd_knack_markings_specifications.py
+++ b/dags/atd_knack_markings_specifications.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -54,7 +54,9 @@ with DAG(
     description="Loads markings specifications records from Knack to Postgrest to AGOL",
     default_args=DEFAULT_ARGS,
     # runs once at 1130a ct and again at 140pm ct
-    schedule_interval="50 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval=(
+        "50 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+    ),
     tags=["repo:atd-knack-services", "knack", "agol", "signs-markings"],
     catchup=False,
 ) as dag:
@@ -77,7 +79,6 @@ with DAG(
         force_pull=True,
         mount_tmp_dir=False,
     )
-
 
     t2 = DockerOperator(
         task_id="atd_knack_markings_specifications_to_agol",

--- a/dags/atd_knack_markings_work_orders_jobs.py
+++ b/dags/atd_knack_markings_work_orders_jobs.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -66,7 +66,9 @@ with DAG(
     description="Load work orders markings jobs (view_3100) records from Knack to Postgrest to AGOL, Socrata",
     default_args=DEFAULT_ARGS,
     # runs once at 1130a ct and again at 140pm ct
-    schedule_interval="40 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval=(
+        "40 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+    ),
     tags=["repo:atd-knack-services", "knack", "socrata", "agol", "signs-markings"],
     catchup=False,
 ) as dag:
@@ -90,7 +92,6 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-
     t2 = DockerOperator(
         task_id="atd_knack_markings_work_orders_jobs_to_agol",
         image=docker_image,
@@ -108,7 +109,7 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f'./atd-knack-services/services/agol_build_markings_segment_geometries.py -l markings_jobs  {date_filter_arg}',
+        command=f"./atd-knack-services/services/agol_build_markings_segment_geometries.py -l markings_jobs  {date_filter_arg}",
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,
@@ -119,7 +120,7 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f'./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}',
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,

--- a/dags/atd_knack_mmc_activities_to_socrata.py
+++ b/dags/atd_knack_mmc_activities_to_socrata.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_mmc_issues.py
+++ b/dags/atd_knack_mmc_issues.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_purchase_request_copier.py
+++ b/dags/atd_knack_purchase_request_copier.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -7,7 +7,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -54,8 +54,8 @@ with DAG(
         command=f"./atd-knack-services/services/purchase_request_copier.py -a {app_name} -c {container}",
         environment=env_vars,
         tty=True,
-        force_pull=False,   # atd_knack_signals pulls this image every 5 minutes
+        force_pull=False,  # atd_knack_signals pulls this image every 5 minutes
         mount_tmp_dir=False,
     )
-    
+
     t1

--- a/dags/atd_knack_school_beacons.py
+++ b/dags/atd_knack_school_beacons.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_school_zone_beacon_zones.py
+++ b/dags/atd_knack_school_zone_beacon_zones.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -7,7 +7,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -78,7 +78,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2  = DockerOperator(
+    t2 = DockerOperator(
         task_id="atd_knack_school_zone_beacon_zones_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_secondary_signals.py
+++ b/dags/atd_knack_secondary_signals.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_knack_secondary_signals
 
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -9,7 +9,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_signal_cabinets.py
+++ b/dags/atd_knack_signal_cabinets.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_signal_detection_status_log.py
+++ b/dags/atd_knack_signal_detection_status_log.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_signal_requests.py
+++ b/dags/atd_knack_signal_requests.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.decorators import task
 from airflow.models import DAG
@@ -9,7 +9,7 @@ from utils.knack import get_date_filter_arg
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_signal_studies.py
+++ b/dags/atd_knack_signal_studies.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.decorators import task
 from airflow.models import DAG
@@ -7,7 +7,7 @@ from pendulum import datetime, duration
 
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",

--- a/dags/atd_knack_signal_work_orders.py
+++ b/dags/atd_knack_signal_work_orders.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_signals.py
+++ b/dags/atd_knack_signals.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 from utils.knack import get_date_filter_arg
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_signs_markings_reimbursements.py
+++ b/dags/atd_knack_signs_markings_reimbursements.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -86,11 +86,10 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f'./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}',
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,
     )
-
 
     date_filter_arg >> t1 >> t2

--- a/dags/atd_knack_signs_markings_time_logs.py
+++ b/dags/atd_knack_signs_markings_time_logs.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -57,8 +57,10 @@ with DAG(
     dag_id="atd_knack_signs_markings_time_logs",
     description="Load signs markings time logs (view_3516) records from Knack to Postgrest to Socrata",
     default_args=DEFAULT_ARGS,
-     # runs once at 950a cst and again at 150pm cst
-    schedule_interval="50 9,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    # runs once at 950a cst and again at 150pm cst
+    schedule_interval=(
+        "50 9,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+    ),
     tags=["repo:atd-knack-services", "knack", "socrata", "signs-markings"],
     catchup=False,
 ) as dag:
@@ -94,13 +96,12 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-
     t3 = DockerOperator(
         task_id="atd_knack_signs_time_logs_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f'./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container_signs} {date_filter_arg}',
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container_signs} {date_filter_arg}",
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,
@@ -111,7 +112,7 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f'./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container_markings} {date_filter_arg}',
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container_markings} {date_filter_arg}",
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,

--- a/dags/atd_knack_signs_materials.py
+++ b/dags/atd_knack_signs_materials.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_signs_work_order_attachments.py
+++ b/dags/atd_knack_signs_work_order_attachments.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_signs_work_order_specifications.py
+++ b/dags/atd_knack_signs_work_order_specifications.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_signs_work_orders.py
+++ b/dags/atd_knack_signs_work_orders.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -66,9 +66,9 @@ with DAG(
     description="Load work orders signs (view_3107) records from Knack to Postgrest to AGOL, Socrata",
     default_args=DEFAULT_ARGS,
     # runs once at ~10a cst and again at ~2pm cst
-    schedule_interval="50 9,13 * * *"
-    if DEPLOYMENT_ENVIRONMENT == "production"
-    else None,
+    schedule_interval=(
+        "50 9,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+    ),
     tags=["repo:atd-knack-services", "knack", "socrata", "signs-markings"],
     catchup=False,
 ) as dag:

--- a/dags/atd_knack_smd_311_csr.py
+++ b/dags/atd_knack_smd_311_csr.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -91,6 +91,5 @@ with DAG(
         tty=True,
         mount_tmp_dir=False,
     )
-
 
     date_filter_arg >> t1 >> t2

--- a/dags/atd_knack_tcp_submissions.py
+++ b/dags/atd_knack_tcp_submissions.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 from utils.knack import get_date_filter_arg
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -49,7 +49,7 @@ REQUIRED_SECRETS = {
     "PGREST_JWT": {
         "opitem": "atd-knack-services PostgREST",
         "opfield": "production.jwt",
-    }
+    },
 }
 
 

--- a/dags/atd_knack_traffic_detectors_weekly_snapshot.py
+++ b/dags/atd_knack_traffic_detectors_weekly_snapshot.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_knack_traffic_detectors_weekly_snapshot
 
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -9,7 +9,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_knack_work_orders_markings.py
+++ b/dags/atd_knack_work_orders_markings.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -66,7 +66,9 @@ with DAG(
     description="Load work orders markings (view_3099) records from Knack to Postgrest to AGOL, Socrata",
     default_args=DEFAULT_ARGS,
     # runs once at 1130a ct and again at 140pm ct
-    schedule_interval="30 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval=(
+        "30 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+    ),
     tags=["repo:atd-knack-services", "knack", "socrata", "agol", "signs-markings"],
     catchup=False,
 ) as dag:
@@ -90,7 +92,6 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-
     t2 = DockerOperator(
         task_id="atd_knack_markings_work_orders_to_agol",
         image=docker_image,
@@ -108,7 +109,7 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f'./atd-knack-services/services/agol_build_markings_segment_geometries.py -l markings_jobs  {date_filter_arg}',
+        command=f"./atd-knack-services/services/agol_build_markings_segment_geometries.py -l markings_jobs  {date_filter_arg}",
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,
@@ -119,7 +120,7 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f'./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}',
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,

--- a/dags/atd_knack_work_orders_markings_contractors.py
+++ b/dags/atd_knack_work_orders_markings_contractors.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -90,7 +90,6 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-
     t2 = DockerOperator(
         task_id="atd_knack_markings_work_orders_to_agol",
         image=docker_image,
@@ -108,7 +107,7 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f'./atd-knack-services/services/agol_build_markings_segment_geometries.py -l markings_jobs  {date_filter_arg}',
+        command=f"./atd-knack-services/services/agol_build_markings_segment_geometries.py -l markings_jobs  {date_filter_arg}",
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,
@@ -119,7 +118,7 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f'./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}',
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,

--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -1,6 +1,6 @@
 # Test locally with: docker compose run --rm airflow-cli dags test atd_moped_components_to_agol
 
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -11,7 +11,7 @@ from pendulum import datetime, duration, parse
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -1,6 +1,6 @@
 # Test locally with: docker compose run --rm airflow-cli dags test atd_moped_data_tracker_sync
 
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -10,7 +10,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 from utils.knack import get_date_filter_arg
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_moped_ecapris_status_sync.py
+++ b/dags/atd_moped_ecapris_status_sync.py
@@ -1,6 +1,6 @@
 # Test locally with: docker compose run --rm airflow-cli dags test atd_moped_ecapris_status_sync
 
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -9,7 +9,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -31,9 +31,10 @@ REQUIRED_SECRETS = {
         "opitem": "Moped Hasura Admin",
         "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Secret",
     },
-    "ORACLE_USER":{
+    "ORACLE_USER": {
         "opitem": "Finance Data Warehouse Oracle DB",
-        "opfield": "production.Username",},
+        "opfield": "production.Username",
+    },
     "ORACLE_PASSWORD": {
         "opitem": "Finance Data Warehouse Oracle DB",
         "opfield": "production.Password",
@@ -49,7 +50,7 @@ REQUIRED_SECRETS = {
     "ORACLE_SERVICE": {
         "opitem": "Finance Data Warehouse Oracle DB",
         "opfield": "production.Service",
-    }, 
+    },
 }
 
 
@@ -57,7 +58,9 @@ with DAG(
     dag_id="atd_moped_ecapris_status_sync",
     description="sync eCapris statuses to Moped database",
     default_args=DEFAULT_ARGS,
-    schedule_interval="*/30 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval=(
+        "*/30 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+    ),
     dagrun_timeout=duration(minutes=30),
     tags=["repo:atd-moped", "moped", "ecapris"],
     catchup=False,

--- a/dags/atd_parking_data.py
+++ b/dags/atd_parking_data.py
@@ -1,5 +1,5 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_parking_data
-import os
+from os import getenv
 from datetime import timedelta
 
 from airflow.decorators import task
@@ -13,7 +13,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",

--- a/dags/atd_road_conditions_socrata.py
+++ b/dags/atd_road_conditions_socrata.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 from pendulum import datetime, duration
 
 from airflow.decorators import task
@@ -7,7 +7,7 @@ from airflow.operators.docker_operator import DockerOperator
 
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",

--- a/dags/atd_service_bot_intake.py
+++ b/dags/atd_service_bot_intake.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 from pendulum import datetime, duration
 
 from airflow.decorators import task
@@ -7,7 +7,7 @@ from airflow.operators.docker_operator import DockerOperator
 
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",
@@ -16,7 +16,7 @@ default_args = {
     "start_date": datetime(2015, 12, 1, tz="America/Chicago"),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0, 
+    "retries": 0,
     "execution_timeout": duration(minutes=5),
     "on_failure_callback": task_fail_slack_alert,
 }
@@ -53,16 +53,18 @@ with DAG(
     tags=["repo:atd-service-bot", "knack", "github"],
     catchup=False,
 ) as dag:
+
     @task(
         task_id="get_env_vars",
         execution_timeout=duration(seconds=30),
     )
     def get_env_vars():
         from utils.onepassword import load_dict
+
         return load_dict(REQUIRED_SECRETS)
 
     env_vars = get_env_vars()
-    
+
     DockerOperator(
         task_id="dts_sr_to_github",
         image=docker_image,

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 from pendulum import datetime, duration
 
 from airflow.decorators import task
@@ -8,7 +8,7 @@ from airflow.operators.docker_operator import DockerOperator
 from utils.slack_operator import task_fail_slack_alert
 
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",
@@ -56,7 +56,6 @@ REQUIRED_SECRETS = {
 }
 
 
-
 with DAG(
     dag_id=f"atd_service_bot_github_to_socrata_{DEPLOYMENT_ENVIRONMENT}",
     default_args=default_args,
@@ -64,17 +63,19 @@ with DAG(
     tags=["repo:atd-service-bot", "socrata", "github"],
     catchup=False,
 ) as dag:
+
     @task(
         task_id="get_env_vars",
         execution_timeout=duration(seconds=30),
     )
     def get_env_vars():
         from utils.onepassword import load_dict
+
         env_vars = load_dict(REQUIRED_SECRETS)
         return env_vars
-    
+
     env_vars = get_env_vars()
-    
+
     DockerOperator(
         task_id="dts_github_to_socrata",
         image=docker_image,
@@ -86,4 +87,3 @@ with DAG(
         tty=True,
         force_pull=True,
     )
-

--- a/dags/atd_signal_comms.py
+++ b/dags/atd_signal_comms.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = "prod" if os.getenv("ENVIRONMENT") == "production" else "dev"
+DEPLOYMENT_ENVIRONMENT = "prod" if getenv("ENVIRONMENT") == "production" else "dev"
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/atd_traffic_incident_reports.py
+++ b/dags/atd_traffic_incident_reports.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 from utils.knack import get_date_filter_arg
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -55,7 +55,7 @@ REQUIRED_SECRETS = {
     # Socrata
     "SOCRATA_RESOURCE_ID": {
         "opitem": "atd-traffic-incident-reports",
-        "opfield": "production.Socrata Resource ID"
+        "opfield": "production.Socrata Resource ID",
     },
     "SOCRATA_API_KEY_ID": {
         "opitem": "Socrata Key ID, Secret, and Token",
@@ -69,7 +69,6 @@ REQUIRED_SECRETS = {
         "opitem": "Socrata Key ID, Secret, and Token",
         "opfield": "socrata.appToken",
     },
-
 }
 
 

--- a/dags/atd_trail_counters.py
+++ b/dags/atd_trail_counters.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test atd_trail_counters
 
-import os
+from os import getenv
 
 from datetime import timedelta
 
@@ -12,7 +12,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",

--- a/dags/dts_csr_report_publishing.py
+++ b/dags/dts_csr_report_publishing.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test dts_csr_report_publishing
 
-import os
+from os import getenv
 
 from datetime import timedelta
 
@@ -12,7 +12,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",
@@ -145,7 +145,9 @@ with DAG(
     dag_id="dts_csr_report_publishing",
     description="Downloads reports of 311 service requests for TPW and publishes it in a Socrata dataset.",
     default_args=default_args,
-    schedule_interval="36 2,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule_interval=(
+        "36 2,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+    ),
     dagrun_timeout=timedelta(minutes=60),
     tags=["repo:dts-311-reporting", "socrata", "csr"],
     catchup=False,

--- a/dags/dts_finances_report_publishing.py
+++ b/dags/dts_finances_report_publishing.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test dts_finances_report_publishing
 
-import os
+from os import getenv
 
 from datetime import timedelta
 
@@ -12,7 +12,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",
@@ -91,9 +91,8 @@ with DAG(
     catchup=False,
 ) as dag:
     docker_image = "atddocker/dts-finance-reporting:production"
-    
-    env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperator(
         task_id="download_microstrategy_reports",

--- a/dags/dts_inspector_priority.py
+++ b/dags/dts_inspector_priority.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test dts_inspector_priority
 
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -9,7 +9,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -157,6 +157,5 @@ with DAG(
         mount_tmp_dir=False,
         trigger_rule="all_done",
     )
-
 
     t1 >> t2 >> t3 >> t4

--- a/dags/dts_maximo_reporting_work_orders.py
+++ b/dags/dts_maximo_reporting_work_orders.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test dts_maximo_reporting_workorders
 
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -9,7 +9,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/dts_row_reporting.py
+++ b/dags/dts_row_reporting.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test dts_row_reporting
 
-import os
+from os import getenv
 
 from airflow.decorators import task
 from airflow.models import DAG
@@ -10,7 +10,7 @@ from pendulum import datetime, duration, now
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -117,9 +117,10 @@ SECRETS_SOCRATA_BACKUP = {
     },
 }
 
+
 @task
 def get_dataset_id(env_vars):
-    return env_vars['ACTIVE_DATASET']
+    return env_vars["ACTIVE_DATASET"]
 
 
 with DAG(
@@ -347,5 +348,20 @@ with DAG(
         trigger_rule="all_done",
     )
 
-
-    t1 >> t2 >> t3 >> t4 >> t5 >> t6 >> t7 >> t8 >> t9 >> t10 >> t11 >> t12 >> t13 >> t14 >> t15
+    (
+        t1
+        >> t2
+        >> t3
+        >> t4
+        >> t5
+        >> t6
+        >> t7
+        >> t8
+        >> t9
+        >> t10
+        >> t11
+        >> t12
+        >> t13
+        >> t14
+        >> t15
+    )

--- a/dags/dts_socrata_reporting.py
+++ b/dags/dts_socrata_reporting.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test dts_socrata_reporting
 
-import os
+from os import getenv
 
 from datetime import timedelta
 
@@ -12,7 +12,7 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",

--- a/dags/dts_work_zone_data_feed.py
+++ b/dags/dts_work_zone_data_feed.py
@@ -1,6 +1,6 @@
 # test locally with: docker compose run --rm airflow-cli dags test dts_work_zone_data_feed
 
-import os
+from os import getenv
 
 from airflow.decorators import task
 from airflow.models import DAG
@@ -10,7 +10,7 @@ from pendulum import datetime, duration, now
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
@@ -103,4 +103,4 @@ with DAG(
         retry_delay=duration(seconds=60),
     )
 
-    t1 
+    t1

--- a/dags/maximo_geo_emergency_mgmt_email_parser.py
+++ b/dags/maximo_geo_emergency_mgmt_email_parser.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 from pendulum import datetime, duration
 
 from airflow.decorators import task
@@ -7,7 +7,7 @@ from airflow.operators.docker_operator import DockerOperator
 
 from utils.slack_operator import task_fail_slack_alert
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",

--- a/dags/test_docker_failure.py
+++ b/dags/test_docker_failure.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
@@ -6,7 +6,7 @@ from pendulum import datetime, duration, now
 
 from utils.slack_operator import task_fail_slack_alert, slack_member_ids
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",

--- a/dags/test_slack_notifier.py
+++ b/dags/test_slack_notifier.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 from pendulum import datetime, duration
 
 from airflow.models import DAG
@@ -6,7 +6,7 @@ from airflow.operators.python_operator import PythonOperator
 
 from utils.slack_operator import task_fail_slack_alert, slack_member_ids
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 default_args = {
     "owner": "airflow",

--- a/dags/utils/onepassword.py
+++ b/dags/utils/onepassword.py
@@ -2,16 +2,17 @@
 Various utilities for interacting with the onepasswordconnectsdk.
 See: https://github.com/1Password/connect-sdk-python
 """
-import os
+
+from os import getenv
 
 from airflow.decorators import task
 from onepasswordconnectsdk.client import Client, new_client
 import onepasswordconnectsdk
 from pendulum import duration
 
-ONEPASSWORD_CONNECT_HOST = os.getenv("OP_CONNECT")
-ONEPASSWORD_CONNECT_TOKEN = os.getenv("OP_API_TOKEN")
-VAULT_ID = os.getenv("OP_VAULT_ID")
+ONEPASSWORD_CONNECT_HOST = getenv("OP_CONNECT")
+ONEPASSWORD_CONNECT_TOKEN = getenv("OP_API_TOKEN")
+VAULT_ID = getenv("OP_VAULT_ID")
 
 
 def get_client():

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from cron_descriptor import get_description
 from airflow.hooks.base import BaseHook
@@ -9,7 +9,7 @@ from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
 # in Admin > Connections.
 SLACK_CONN_ID = "slack"
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 slack_member_ids = {
     "Frank": "<@UMS32US1E>",
@@ -143,8 +143,10 @@ def task_fail_slack_alert(context):
 
     if exception and hasattr(exception, "logs") and exception.logs:
         logs = exception.logs
-        parsed_exception_type, parsed_exception_message = extract_exception_from_log("\n".join(logs))
-        if (parsed_exception_message and parsed_exception_type):
+        parsed_exception_type, parsed_exception_message = extract_exception_from_log(
+            "\n".join(logs)
+        )
+        if parsed_exception_message and parsed_exception_type:
             exception_type = parsed_exception_type
             exception_message = parsed_exception_message
 

--- a/dags/vz_afd_ems_import.py
+++ b/dags/vz_afd_ems_import.py
@@ -1,4 +1,4 @@
-import os
+from os import getenv
 
 from airflow.decorators import dag
 from airflow.operators.docker_operator import DockerOperator
@@ -8,7 +8,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert, slack_member_ids
 
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT")
 
 secrets_env_prefix = None
 
@@ -72,7 +72,7 @@ def etl_data_import():
         command="ems",
         tty=True,
         force_pull=True,
-        mount_tmp_dir=False
+        mount_tmp_dir=False,
     )
 
     # AFD
@@ -84,7 +84,7 @@ def etl_data_import():
         auto_remove="force",
         command="afd",
         tty=True,
-        mount_tmp_dir=False
+        mount_tmp_dir=False,
     )
 
     # run the AFD task regardless of whether EMS succeeded or failed

--- a/dags/vz_cris_import.py
+++ b/dags/vz_cris_import.py
@@ -4,7 +4,7 @@ The target DB and S3 bucket subdirectory are controlled by the Airflow `ENVIRONM
 env var, which determines which 1pass secrets to apply to the docker runtime env.
 
 Check the 1Pass entry to understand exactly what will happen when you trigger
-this DAG in a given context, but the expected behavior is that you may set the 
+this DAG in a given context, but the expected behavior is that you may set the
 Airflow `ENVIRONMENT` to `production`, `staging`, or `dev`, with the following
 results:
 - production: use <bucket-name>/prod/inbox and production hasura cluster
@@ -12,7 +12,7 @@ results:
 - dev: use <bucket-name>/dev/inbox and localhost hasura cluster
 """
 
-import os
+from os import getenv
 from pendulum import datetime, duration
 
 from airflow.models import DAG
@@ -22,7 +22,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert, slack_member_ids
 
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT")
 secrets_env_prefix = None
 
 if DEPLOYMENT_ENVIRONMENT == "production":

--- a/dags/vz_moped_component_crashes.py
+++ b/dags/vz_moped_component_crashes.py
@@ -9,7 +9,7 @@ env var, which determines which 1pass secrets to apply to the docker runtime env
 Moped prod is always used as the source for Moped data.
 
 Check the 1Pass entry to understand exactly what will happen when you trigger
-this DAG in a given context, but the expected behavior is that you may set the 
+this DAG in a given context, but the expected behavior is that you may set the
 Airflow `ENVIRONMENT` to `production`, `staging`, or `dev`, with the following
 results:
 - production: use production VZ db and update production data portal datasets
@@ -17,7 +17,7 @@ results:
 - dev: use local VZ db and update staging data portal datasets
 """
 
-import os
+from os import getenv
 from pendulum import datetime, duration
 
 from airflow.models import DAG
@@ -27,7 +27,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT")
 secrets_env_prefix = None
 
 if DEPLOYMENT_ENVIRONMENT == "production":

--- a/dags/vz_refresh_location_crashes.py
+++ b/dags/vz_refresh_location_crashes.py
@@ -2,7 +2,7 @@
 This DAG refreshes the location_crashes_view in the Vision Zero database
 """
 
-import os
+from os import getenv
 from pendulum import datetime, duration
 
 from airflow.models import DAG
@@ -12,7 +12,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT")
 secrets_env_prefix = None
 
 if DEPLOYMENT_ENVIRONMENT == "production":

--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -6,7 +6,7 @@ The VZD source and the target datasets are controlled by the Airflow `ENVIRONMEN
 env var, which determines which 1pass secrets to apply to the docker runtime env.
 
 Check the 1Pass entry to understand exactly what will happen when you trigger
-this DAG in a given context, but the expected behavior is that you may set the 
+this DAG in a given context, but the expected behavior is that you may set the
 Airflow `ENVIRONMENT` to `production`, `staging`, or `dev`, with the following
 results:
 - production: use production VZ db and update production data portal datasets
@@ -14,7 +14,7 @@ results:
 - dev: use local VZ db and update staging data portal datasets
 """
 
-import os
+from os import getenv
 from pendulum import datetime, duration
 
 from airflow.models import DAG
@@ -24,7 +24,7 @@ from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
 
-DEPLOYMENT_ENVIRONMENT = os.getenv("ENVIRONMENT")
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT")
 secrets_env_prefix = None
 
 if DEPLOYMENT_ENVIRONMENT == "production":


### PR DESCRIPTION
# 👀 

See https://github.com/cityofaustin/atd-airflow/pull/285#discussion_r2136775920. This started as a thought experiment, but I think we want to merge it. 

# 🤖 

> I want you to go through every DAG in the 'dags' folder, and I want you to audit the use of the os library, in particular around how it's used to access environment variables. Be sure to look for other uses, don't just assume it's getenv only.
> 
> I want you to fix the use of os to comply with the spirit and the intent of this comment:
> 
> It'd be a nice touch to import the specific pendulum submodules here (or, for super-optimization, in the function that uses them), since these imports are constantly executed by the Airflow DAG importer service thingy.
> 
> I'm also noticing that 0% of our dags do this for the os import, where we could go with from os import getenv 😐

# 🍰 

By the nature of coming out of my code environment, this got linted by `black` too.

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
