### PR TITLE
Maximo reporting DAG refactor + work order status history

### DIFF
--- a/dags/dts_maximo_reporting.py
+++ b/dags/dts_maximo_reporting.py
@@ -66,7 +66,7 @@ REQUIRED_SECRETS = {
 }
 
 with DAG(
-    dag_id=f"dts_maximo_reporting_workorders",
+    dag_id=f"dts_maximo_reporting",
     description="Uploads the last 7 days of Maximo work orders to Socrata from the Maximo data warehouse.",
     default_args=DEFAULT_ARGS,
     schedule_interval="00 6 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
@@ -82,11 +82,35 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f"python etl/work_orders_to_socrata.py",
+        command=f"python etl/maximo_to_socrata.py --query work_orders",
         environment=env_vars,
         tty=True,
         force_pull=True,
         mount_tmp_dir=False,
     )
 
-    t1
+    t2 = DockerOperator(
+        task_id="maximo_service_requests_to_socrata",
+        image=docker_image,
+        docker_conn_id="docker_default",
+        auto_remove="force",
+        command=f"python etl/maximo_to_socrata.py --query service_requests",
+        environment=env_vars,
+        tty=True,
+        force_pull=False,
+        mount_tmp_dir=False,
+    )
+
+    t3 = DockerOperator(
+        task_id="maximo_work_order_history_to_socrata",
+        image=docker_image,
+        docker_conn_id="docker_default",
+        auto_remove="force",
+        command=f"python etl/maximo_to_socrata.py --query work_order_status_history",
+        environment=env_vars,
+        tty=True,
+        force_pull=False,
+        mount_tmp_dir=False,
+    )
+
+    t1 >> t2 >> t3


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/22843

## Associated repo
https://github.com/cityofaustin/dts-maximo-reporting

## Testing

I've did some refactoring of the dts-maximo-reporting script so this PR will need to be merged around the same time as [this PR](https://github.com/cityofaustin/dts-maximo-reporting/pull/6). You will need to build this image yourself as these changes have not been deployed to the main branch yet.

**Steps to test:**
1. checkout the latest PR from dts-maximo-reporting `charlie/alt-reference-id`  
2. `docker build -t atddocker/dts-maximo-reporting:local .`
3. Change line 76 of this DAG script to point at the local tag `atddocker/dts-maximo-reporting:production` -> `atddocker/dts-maximo-reporting:local`
4. I comment out the `force_pull=True` on line 88 but I don't think that's necessary.
5. Run the DAG and check it completes, `docker compose run --rm airflow-cli dags test dts_maximo_reporting`

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
