### PR TITLE
Increase task timeout for atd_knack_signs_work_order_materials DAG

### DIFF
--- a/dags/atd_knack_signs_materials.py
+++ b/dags/atd_knack_signs_materials.py
@@ -17,7 +17,7 @@ DEFAULT_ARGS = {
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 0,
-    "execution_timeout": duration(minutes=30),
+    "execution_timeout": duration(minutes=60),
     "on_failure_callback": task_fail_slack_alert,
 }
 


### PR DESCRIPTION
## Associated issues
n/a

## Associated repo
n/a

## Testing

**Steps to test:**
1. Not much to test here - just giving this one extra time since it timed out the last few days
2. Check that this is the same DAG as https://austininnovation.slack.com/archives/C013G4RNJ01/p1751526937576189

---

#### Ship list

- [x] Code reviewed
- [x] Product manager approved
- ~[ ] Add note to 1PW secrets moved to API vault and check for duplicates~
