### PR TITLE
Double the dms dag timeout

### DIFF
--- a/dags/atd_knack_dms.py
+++ b/dags/atd_knack_dms.py
@@ -18,7 +18,7 @@ DEFAULT_ARGS = {
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 0,
-    "execution_timeout": duration(minutes=5),
+    "execution_timeout": duration(minutes=10),
     "on_failure_callback": task_fail_slack_alert,
 }
 


### PR DESCRIPTION
## Associated issues

Its only 20 records, but agol struggles with deleting the features within 5 minutes and its noisy in the airflow channel. 

<img width="713" height="259" alt="Screenshot 2025-07-10 at 5 49 03 PM" src="https://github.com/user-attachments/assets/ce66d86f-42c1-46be-adc0-8b3fc82b1fee" />

I dont know why this times out so often. This is just a bandaid to quiet some noise, and a to be determined prize to whoever figures out whats actually going on. 

Not related to the agol timeouts, I was looking at the socrata version and the latitude / longitude columns are empty 
https://data.austintexas.gov/Transportation-and-Mobility/Dynamic-Message-Signs-DMS-/4r2j-b4rx/data_preview

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
