### PR TITLE
📢  Stacked exception enunciator for airflow slack integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ with DAG(
 
 ### Slack operator utility
 
-The Slack operator utility makes use of the integration between the Airflow and a Slack app webhook. The purpose of the utility is to add Slack notifications to DAGs using the [callback](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/callbacks.html#callback-types) parameters. Failure, critical failure, and success notifications are implemented.
+The Slack operator utility makes use of the integration between Airflow and a Slack app webhook. The purpose of the utility is to add Slack notifications to DAGs using the [callback](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/callbacks.html#callback-types) parameters. Failure and success notifications are implemented.
 
 To configure the Slack operator in your local instance, from the Airflow UI go to **Admin** > **Connections** and choose **Slack API** as the **connection type**. You can find the remaining settings in 1Password under the **Airflow - Slack Bot** item.
 
@@ -208,7 +208,7 @@ with DAG(
     <snip>
 ```
 
-**To test the Slack operator locally**, see the DAG named `test_slack_notifier`.
+**To test the Slack operator locally**, see the DAGs `test_slack_notifier` and `test_docker_failure`.
 
 ## Useful Commands
 

--- a/dags/test_docker_failure.py
+++ b/dags/test_docker_failure.py
@@ -21,19 +21,52 @@ DEFAULT_ARGS = {
 
 with DAG(
     dag_id=f"test_docker_failure",
-    description="Throws a python exception from within a docker container",
+    description="Throws stacked python exceptions from within a docker container",
     default_args=DEFAULT_ARGS,
     schedule_interval=None,
     tags=["repo:atd-airflow", "slack"],
     catchup=False,
 ) as dag:
-    dag.byline = f"Test failure in a docker container"
+    dag.byline = f"Test stacked exceptions in a docker container"
     dag.icon = ":test_tube:"
 
     t1 = DockerOperator(
         task_id="docker_failure",
         image="atddocker/atd-airflow:production",
-        command="python -c \"raise Exception('This is a test exception')\"",
+        command=[
+            "python",
+            "-c",
+            """
+import sys
+import traceback
+
+def outer_function():
+    try:
+        middle_function()
+    except Exception as e:
+        print("Caught exception in outer_function: " + str(e))
+        raise RuntimeError("Failed in outer function") from e
+
+def middle_function():
+    try:
+        inner_function()
+    except Exception as e:
+        print("Caught exception in middle_function: " + str(e))
+        raise ValueError("Failed in middle function") from e
+
+def inner_function():
+    print("About to raise ConnectionError")
+    raise ConnectionError("Connection failed")
+
+if __name__ == "__main__":
+    try:
+        outer_function()
+    except Exception as e:
+        print("Final exception caught at top level:")
+        traceback.print_exc()
+        sys.exit(1)
+""",
+        ],
         docker_conn_id="docker_default",
         auto_remove="force",
         tty=True,

--- a/dags/utils/log_parsing.py
+++ b/dags/utils/log_parsing.py
@@ -1,0 +1,141 @@
+def extract_exception_from_log(log_text):
+    import re
+
+    # Find the last occurrence of 'Traceback (most recent call last):'
+    traceback_start = log_text.rfind("Traceback (most recent call last):")
+    if traceback_start == -1:
+        return None, None  # No traceback found
+
+    # Extract the traceback portion
+    traceback_text = log_text[traceback_start:]
+
+    # Find the last line (which usually contains the exception type and message)
+    last_line = traceback_text.strip().split("\n")[-1]
+
+    # Extract exception type and message
+    match = re.match(r"([\w.]+): (.*)", last_line)
+    if match:
+        return match.group(1), match.group(2)
+
+    return None, None
+
+
+def extract_all_exceptions_from_log(log_text):
+    """
+    Extract all Python exceptions from raw Airflow logs.
+    Returns list of tuples (exception_type, exception_message, source).
+    Source is "ETL" for exceptions before "Task failed with exception" line,
+    "Airflow" for exceptions after that line.
+    """
+
+    exceptions = []
+    lines = log_text.split("\n")
+
+    # Find the "Task failed with exception" dividing line
+    task_failed_line_idx = None
+    for i, line in enumerate(lines):
+        if "Task failed with exception" in line:
+            task_failed_line_idx = i
+            break
+
+    # Look for all traceback sections
+    traceback_starts = []
+    for i, line in enumerate(lines):
+        if "Traceback (most recent call last):" in line:
+            traceback_starts.append(i)
+
+    # Process each traceback section
+    for start_idx in traceback_starts:
+        # Determine source based on position relative to "Task failed with exception"
+        if task_failed_line_idx is None:
+            source = "ETL"  # Default to ETL if no dividing line found
+        elif start_idx < task_failed_line_idx:
+            source = "ETL"
+        else:
+            source = "Airflow"
+
+        # Find the exception line for this traceback
+        exception_line = _find_exception_line_in_traceback(lines, start_idx)
+
+        if exception_line:
+            exc_type, exc_msg = _parse_exception_line(exception_line)
+            if exc_type:
+                exceptions.append((exc_type, exc_msg, source))
+
+    return exceptions if exceptions else [(None, None, "Unknown")]
+
+
+def _find_exception_line_in_traceback(lines, traceback_start_idx):
+    """
+    Find the actual exception line (final line) in a traceback section.
+    """
+    # Start from the traceback line and look forward
+    i = traceback_start_idx + 1
+
+    while i < len(lines):
+        line = lines[i].strip()
+
+        # Stop if we hit another traceback
+        if "Traceback (most recent call last):" in line:
+            break
+
+        # Stop if we hit certain log markers that indicate end of traceback
+        if line.startswith("During handling of the above exception") or line.startswith(
+            "The above exception was the direct cause"
+        ):
+            i += 1
+            continue
+
+        # Check if this is an exception line
+        if _is_exception_line(line):
+            return line
+
+        i += 1
+
+    return None
+
+
+def _is_exception_line(line):
+    """Check if a line contains a Python exception"""
+    import re
+
+    line = line.strip()
+
+    # Skip obvious non-exception lines
+    if (
+        not line
+        or line.startswith("File ")
+        or line.startswith("    ")
+        or line.startswith("^")
+        or "Traceback" in line
+        or line.startswith("During handling")
+        or line.startswith("The above exception")
+    ):
+        return False
+
+    # Look for Python exception patterns
+    # Must start with a capital letter followed by word characters, dots, underscores
+    # Common exception endings but not required
+    exception_pattern = (
+        r"^[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Warning|Timeout)?(?::\s|$)"
+    )
+    return re.match(exception_pattern, line) is not None
+
+
+def _parse_exception_line(line):
+    """Parse an exception line into (type, message)"""
+    import re
+
+    line = line.strip()
+
+    # Pattern for ExceptionType: message
+    match = re.match(r"^([A-Z][A-Za-z0-9_.]*)\s*:\s*(.*)", line)
+    if match:
+        return match.group(1), match.group(2)
+
+    # Pattern for just ExceptionType (no colon/message)
+    match = re.match(r"^([A-Z][A-Za-z0-9_.]*)$", line)
+    if match:
+        return match.group(1), ""
+
+    return None, None

--- a/dags/utils/log_parsing.py
+++ b/dags/utils/log_parsing.py
@@ -1,3 +1,49 @@
+def extract_all_exceptions(context):
+    exception = context.get("exception")
+    exception_type = type(exception).__name__ if exception else "Unknown"
+    exception_message = (
+        str(exception) if exception else "No exception message available"
+    )
+
+    # Extract all exceptions from logs if available
+    all_exceptions = []
+
+    # DEBUG: Set this to a string containing log text to test exception parsing
+    # When None, normal operation resumes
+    DEBUG_LOG_TEXT = None
+
+    # First, get exceptions from Docker container logs if available
+    if DEBUG_LOG_TEXT is not None:
+        # DEBUG MODE: Use the debug log text instead of actual logs
+        print(f"DEBUG MODE: Using debug log text for parsing")
+        parsed_exceptions = extract_all_exceptions_from_log(DEBUG_LOG_TEXT)
+
+        # Add parsed exceptions (filter out None entries)
+        for exc in parsed_exceptions:
+            if exc[0] is not None:
+                all_exceptions.append(exc)
+    elif exception and hasattr(exception, "logs") and exception.logs:
+        logs = exception.logs
+        parsed_exceptions = extract_all_exceptions_from_log("\n".join(logs))
+
+        # Add parsed exceptions (filter out None entries)
+        for exc in parsed_exceptions:
+            if exc[0] is not None:
+                all_exceptions.append(exc)
+
+    # Always add the Airflow-level exception as well if not already found
+    airflow_exception = (exception_type, exception_message, "Airflow")
+    # Check if we already have this exception from parsing
+    airflow_already_found = any(
+        exc[0] == exception_type and exc[1] == exception_message
+        for exc in all_exceptions
+    )
+    if not airflow_already_found:
+        all_exceptions.append(airflow_exception)
+
+    return all_exceptions
+
+
 def extract_exception_from_log(log_text):
     import re
 

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -276,11 +276,6 @@ def task_fail_slack_alert(context):
     if not airflow_already_found:
         all_exceptions.append(airflow_exception)
 
-    # Use the last exception as primary for backward compatibility
-    if all_exceptions:
-        exception_type = all_exceptions[-1][0]
-        exception_message = all_exceptions[-1][1]
-
     # Extract additional information
     dag = context.get("dag")
     dag_id = task_instance.dag_id
@@ -305,6 +300,8 @@ def task_fail_slack_alert(context):
     exceptions_text = ""
     if len(all_exceptions) == 1:
         # Single exception - use original format with source
+        exception_type = all_exceptions[-1][0]
+        exception_message = all_exceptions[-1][1]
         source = all_exceptions[0][2] if len(all_exceptions[0]) > 2 else "Unknown"
         exceptions_text = f"*Exception Type*: `{exception_type}` _(from {source})_\n        *Exception Message*: `{exception_message}`"
     else:

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -109,6 +109,41 @@ def extract_exception_from_log(log_text):
     return None, None
 
 
+def extract_all_exceptions_from_log(log_text):
+    import re
+
+    # Find all occurrences of 'Traceback (most recent call last):'
+    exceptions = []
+    traceback_pattern = "Traceback (most recent call last):"
+    
+    start_pos = 0
+    while True:
+        traceback_start = log_text.find(traceback_pattern, start_pos)
+        if traceback_start == -1:
+            break
+        
+        # Find the end of this traceback by looking for the next traceback or end of text
+        next_traceback = log_text.find(traceback_pattern, traceback_start + len(traceback_pattern))
+        if next_traceback == -1:
+            traceback_text = log_text[traceback_start:]
+        else:
+            traceback_text = log_text[traceback_start:next_traceback]
+        
+        # Find the last line of this traceback (which contains the exception)
+        lines = traceback_text.strip().split("\n")
+        if len(lines) > 1:
+            last_line = lines[-1]
+            
+            # Extract exception type and message
+            match = re.match(r"([\w.]+): (.*)", last_line)
+            if match:
+                exceptions.append((match.group(1), match.group(2)))
+        
+        start_pos = traceback_start + len(traceback_pattern)
+    
+    return exceptions if exceptions else [(None, None)]
+
+
 def task_fail_slack_alert(context):
 
     task_instance = context.get("task_instance")
@@ -119,14 +154,23 @@ def task_fail_slack_alert(context):
         str(exception) if exception else "No exception message available"
     )
 
+    # Extract all exceptions from logs if available
+    all_exceptions = []
     if exception and hasattr(exception, "logs") and exception.logs:
         logs = exception.logs
-        parsed_exception_type, parsed_exception_message = extract_exception_from_log(
-            "\n".join(logs)
-        )
-        if parsed_exception_message and parsed_exception_type:
-            exception_type = parsed_exception_type
-            exception_message = parsed_exception_message
+        all_exceptions = extract_all_exceptions_from_log("\n".join(logs))
+        
+        # If we found exceptions in logs, use them; otherwise keep the original exception
+        if all_exceptions and all_exceptions[0][0] is not None:
+            # Use the last exception as the primary one for backward compatibility
+            exception_type = all_exceptions[-1][0]
+            exception_message = all_exceptions[-1][1]
+        else:
+            # Fallback to original exception if no parsed exceptions found
+            all_exceptions = [(exception_type, exception_message)]
+    else:
+        # No logs available, use the original exception
+        all_exceptions = [(exception_type, exception_message)]
 
     # Extract additional information
     dag = context.get("dag")
@@ -148,6 +192,17 @@ def task_fail_slack_alert(context):
     if DEPLOYMENT_ENVIRONMENT != "production":
         env_indicator = f" *{DEPLOYMENT_ENVIRONMENT.capitalize()} Environment*"
 
+    # Format all exceptions for display
+    exceptions_text = ""
+    if len(all_exceptions) == 1:
+        # Single exception - use original format
+        exceptions_text = f"*Exception Type*: `{exception_type}`\n        *Exception Message*: `{exception_message}`"
+    else:
+        # Multiple exceptions - list them all
+        exceptions_text = f"*Exceptions Found ({len(all_exceptions)} total)*:"
+        for i, (exc_type, exc_msg) in enumerate(all_exceptions, 1):
+            exceptions_text += f"\n        {i}. *{exc_type}*: `{exc_msg}`"
+
     slack_msg = f"""
         {icon}{env_indicator} *Task failure* 
         {'\n\t\t' + byline if byline else ''}
@@ -156,8 +211,7 @@ def task_fail_slack_alert(context):
         *Execution Time*: `{exec_date}`
         *Schedule*: `{schedule_description}`
         *Duration*: `{duration} seconds`
-        *Exception Type*: `{exception_type}`
-        *Exception Message*: `{exception_message}`
+        {exceptions_text}
         <{log_url}|*View Task Log*>
     """
 

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -112,36 +112,85 @@ def extract_exception_from_log(log_text):
 def extract_all_exceptions_from_log(log_text):
     import re
 
-    # Find all occurrences of 'Traceback (most recent call last):'
     exceptions = []
-    traceback_pattern = "Traceback (most recent call last):"
     
-    start_pos = 0
-    while True:
-        traceback_start = log_text.find(traceback_pattern, start_pos)
-        if traceback_start == -1:
-            break
+    # Split log into lines for easier processing
+    lines = log_text.split('\n')
+    
+    # Track whether we're in a traceback section
+    in_traceback = False
+    current_traceback_lines = []
+    
+    for line in lines:
+        line = line.strip()
         
-        # Find the end of this traceback by looking for the next traceback or end of text
-        next_traceback = log_text.find(traceback_pattern, traceback_start + len(traceback_pattern))
-        if next_traceback == -1:
-            traceback_text = log_text[traceback_start:]
-        else:
-            traceback_text = log_text[traceback_start:next_traceback]
-        
-        # Find the last line of this traceback (which contains the exception)
-        lines = traceback_text.strip().split("\n")
-        if len(lines) > 1:
-            last_line = lines[-1]
+        # Start of a new traceback
+        if "Traceback (most recent call last):" in line:
+            # Process previous traceback if we have one
+            if in_traceback and current_traceback_lines:
+                exception = _extract_exception_from_traceback_lines(current_traceback_lines)
+                if exception:
+                    exceptions.append(exception)
             
-            # Extract exception type and message
-            match = re.match(r"([\w.]+): (.*)", last_line)
-            if match:
-                exceptions.append((match.group(1), match.group(2)))
-        
-        start_pos = traceback_start + len(traceback_pattern)
+            # Start new traceback
+            in_traceback = True
+            current_traceback_lines = [line]
+            
+        elif in_traceback:
+            # Check if this line ends the current traceback
+            # Lines that typically end a traceback: empty lines, INFO logs, or new sections
+            if (line == "" or 
+                "INFO -" in line or 
+                "ERROR -" in line or 
+                "WARNING -" in line or
+                "The above exception was the direct cause of the following exception:" in line):
+                
+                # Process current traceback before ending
+                if current_traceback_lines:
+                    exception = _extract_exception_from_traceback_lines(current_traceback_lines)
+                    if exception:
+                        exceptions.append(exception)
+                
+                # Reset for potential next traceback
+                if "The above exception was the direct cause of the following exception:" in line:
+                    # This indicates chained exceptions, stay in traceback mode
+                    current_traceback_lines = []
+                else:
+                    # End of traceback section
+                    in_traceback = False
+                    current_traceback_lines = []
+            else:
+                # Add line to current traceback
+                current_traceback_lines.append(line)
     
+    # Process final traceback if we ended while in one
+    if in_traceback and current_traceback_lines:
+        exception = _extract_exception_from_traceback_lines(current_traceback_lines)
+        if exception:
+            exceptions.append(exception)
+    
+    print("Found exceptions: ", exceptions)
     return exceptions if exceptions else [(None, None)]
+
+
+def _extract_exception_from_traceback_lines(traceback_lines):
+    import re
+    
+    # Look for the exception line (usually the last non-empty line)
+    for line in reversed(traceback_lines):
+        line = line.strip()
+        if line and not line.startswith('File ') and not line.startswith('Traceback'):
+            # Try to match exception pattern: ExceptionType: message
+            match = re.match(r'^([\w.]+):\s*(.*)', line)
+            if match:
+                return (match.group(1), match.group(2))
+            
+            # Sometimes exceptions don't have messages, just the type
+            match = re.match(r'^([\w.]+)$', line)
+            if match:
+                return (match.group(1), "")
+    
+    return None
 
 
 def task_fail_slack_alert(context):
@@ -156,21 +205,25 @@ def task_fail_slack_alert(context):
 
     # Extract all exceptions from logs if available
     all_exceptions = []
+    
+    # First, get exceptions from Docker container logs if available
     if exception and hasattr(exception, "logs") and exception.logs:
         logs = exception.logs
-        all_exceptions = extract_all_exceptions_from_log("\n".join(logs))
+        container_exceptions = extract_all_exceptions_from_log("\n".join(logs))
         
-        # If we found exceptions in logs, use them; otherwise keep the original exception
-        if all_exceptions and all_exceptions[0][0] is not None:
-            # Use the last exception as the primary one for backward compatibility
-            exception_type = all_exceptions[-1][0]
-            exception_message = all_exceptions[-1][1]
-        else:
-            # Fallback to original exception if no parsed exceptions found
-            all_exceptions = [(exception_type, exception_message)]
-    else:
-        # No logs available, use the original exception
-        all_exceptions = [(exception_type, exception_message)]
+        # Add container exceptions (filter out None entries)
+        for exc in container_exceptions:
+            if exc[0] is not None:
+                all_exceptions.append(exc)
+    
+    # Always add the Airflow-level exception as well
+    airflow_exception = (exception_type, exception_message)
+    all_exceptions.append(airflow_exception)
+    
+    # Use the last exception (Airflow-level) as primary for backward compatibility
+    if all_exceptions:
+        exception_type = all_exceptions[-1][0]
+        exception_message = all_exceptions[-1][1]
 
     # Extract additional information
     dag = context.get("dag")

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -3,7 +3,7 @@ from os import getenv
 from cron_descriptor import get_description
 from airflow.hooks.base import BaseHook
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
-from utils.log_parsing import extract_all_exceptions_from_log
+from utils.log_parsing import extract_all_exceptions_from_log, extract_all_exceptions
 
 # This is the Conn Id that we set when creating the connection in the Airflow dashboard
 # in Admin > Connections.
@@ -88,71 +88,7 @@ def get_central_time_exec_data(context):
     return local_tz.convert(execution_date_timestamp).format("MM/DD/YYYY hh:mm:ss A")
 
 
-def task_fail_slack_alert(context):
-
-    task_instance = context.get("task_instance")
-    exception = context.get("exception")
-    exception_type = type(exception).__name__ if exception else "Unknown"
-    exception_message = (
-        str(exception) if exception else "No exception message available"
-    )
-
-    # Extract all exceptions from logs if available
-    all_exceptions = []
-
-    # DEBUG: Set this to a string containing log text to test exception parsing
-    # When None, normal operation resumes
-    DEBUG_LOG_TEXT = None
-
-    # First, get exceptions from Docker container logs if available
-    if DEBUG_LOG_TEXT is not None:
-        # DEBUG MODE: Use the debug log text instead of actual logs
-        print(f"DEBUG MODE: Using debug log text for parsing")
-        parsed_exceptions = extract_all_exceptions_from_log(DEBUG_LOG_TEXT)
-
-        # Add parsed exceptions (filter out None entries)
-        for exc in parsed_exceptions:
-            if exc[0] is not None:
-                all_exceptions.append(exc)
-    elif exception and hasattr(exception, "logs") and exception.logs:
-        logs = exception.logs
-        parsed_exceptions = extract_all_exceptions_from_log("\n".join(logs))
-
-        # Add parsed exceptions (filter out None entries)
-        for exc in parsed_exceptions:
-            if exc[0] is not None:
-                all_exceptions.append(exc)
-
-    # Always add the Airflow-level exception as well if not already found
-    airflow_exception = (exception_type, exception_message, "Airflow")
-    # Check if we already have this exception from parsing
-    airflow_already_found = any(
-        exc[0] == exception_type and exc[1] == exception_message
-        for exc in all_exceptions
-    )
-    if not airflow_already_found:
-        all_exceptions.append(airflow_exception)
-
-    # Extract additional information
-    dag = context.get("dag")
-    dag_id = task_instance.dag_id
-    task_id = task_instance.task_id
-    exec_date = get_central_time_exec_data(context)
-    log_url = task_instance.log_url
-    duration = getattr(task_instance, "duration", "Not available")
-
-    schedule_interval = dag.schedule_interval if dag else None
-
-    schedule_description = format_schedule(schedule_interval)
-
-    byline = getattr(dag, "byline", "")
-    icon = getattr(dag, "icon", ":red_circle:")
-
-    # Add deployment environment indication if not production
-    env_indicator = ""
-    if DEPLOYMENT_ENVIRONMENT != "production":
-        env_indicator = f" *{DEPLOYMENT_ENVIRONMENT.capitalize()} Environment*"
-
+def build_exception_text(all_exceptions):
     # Format all exceptions for display
     exceptions_text = ""
     if len(all_exceptions) == 1:
@@ -171,6 +107,31 @@ def task_fail_slack_alert(context):
             exceptions_text += (
                 f"\n        {i}. *{exc_type}* _(from {source})_: `{exc_msg}`"
             )
+    return exceptions_text
+
+
+def task_fail_slack_alert(context):
+    task_instance = context.get("task_instance")
+    dag = context.get("dag")
+    dag_id = task_instance.dag_id
+    task_id = task_instance.task_id
+    exec_date = get_central_time_exec_data(context)
+    log_url = task_instance.log_url
+    duration = getattr(task_instance, "duration", "Not available")
+
+    schedule_interval = dag.schedule_interval if dag else None
+    schedule_description = format_schedule(schedule_interval)
+
+    all_exceptions = extract_all_exceptions(context)
+    exceptions_text = build_exception_text(all_exceptions)
+
+    byline = getattr(dag, "byline", "")
+    icon = getattr(dag, "icon", ":red_circle:")
+
+    # Add deployment environment indication if not production
+    env_indicator = ""
+    if DEPLOYMENT_ENVIRONMENT != "production":
+        env_indicator = f" *{DEPLOYMENT_ENVIRONMENT.capitalize()} Environment*"
 
     slack_msg = f"""
         {icon}{env_indicator} *Task failure* 

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -87,28 +87,6 @@ def get_central_time_exec_data(context):
     return local_tz.convert(execution_date_timestamp).format("MM/DD/YYYY hh:mm:ss A")
 
 
-def task_fail_slack_alert_critical(context):
-    slack_msg = """
-            <!channel> :red_circle: Critical Failure
-            *Task*: {task}  
-            *DAG*: {dag} 
-            *Execution Time*: {exec_date}  
-            *Log URL*: {log_url} 
-            """.format(
-        task=context.get("task_instance").task_id,
-        dag=context.get("task_instance").dag_id,
-        exec_date=get_central_time_exec_data(context),
-        log_url=context.get("task_instance").log_url,
-    )
-    failed_alert = SlackWebhookOperator(
-        task_id="slack_critical_failure",
-        slack_webhook_conn_id=SLACK_CONN_ID,
-        message=slack_msg,
-        username="airflow",
-    )
-    return failed_alert.execute(context=context)
-
-
 def extract_exception_from_log(log_text):
     import re
 

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -3,7 +3,7 @@ from os import getenv
 from cron_descriptor import get_description
 from airflow.hooks.base import BaseHook
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
-
+from utils.log_parsing import extract_all_exceptions_from_log
 
 # This is the Conn Id that we set when creating the connection in the Airflow dashboard
 # in Admin > Connections.
@@ -11,9 +11,6 @@ SLACK_CONN_ID = "slack"
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
-# DEBUG: Set this to a string containing log text to test exception parsing
-# When None, normal operation resumes
-DEBUG_LOG_TEXT = None
 
 slack_member_ids = {
     "Frank": "<@UMS32US1E>",
@@ -91,149 +88,6 @@ def get_central_time_exec_data(context):
     return local_tz.convert(execution_date_timestamp).format("MM/DD/YYYY hh:mm:ss A")
 
 
-def extract_exception_from_log(log_text):
-    import re
-
-    # Find the last occurrence of 'Traceback (most recent call last):'
-    traceback_start = log_text.rfind("Traceback (most recent call last):")
-    if traceback_start == -1:
-        return None, None  # No traceback found
-
-    # Extract the traceback portion
-    traceback_text = log_text[traceback_start:]
-
-    # Find the last line (which usually contains the exception type and message)
-    last_line = traceback_text.strip().split("\n")[-1]
-
-    # Extract exception type and message
-    match = re.match(r"([\w.]+): (.*)", last_line)
-    if match:
-        return match.group(1), match.group(2)
-
-    return None, None
-
-
-def extract_all_exceptions_from_log(log_text):
-    """
-    Extract all Python exceptions from raw Airflow logs.
-    Returns list of tuples (exception_type, exception_message, source).
-    Source is "ETL" for exceptions before "Task failed with exception" line,
-    "Airflow" for exceptions after that line.
-    """
-
-    exceptions = []
-    lines = log_text.split("\n")
-
-    # Find the "Task failed with exception" dividing line
-    task_failed_line_idx = None
-    for i, line in enumerate(lines):
-        if "Task failed with exception" in line:
-            task_failed_line_idx = i
-            break
-
-    # Look for all traceback sections
-    traceback_starts = []
-    for i, line in enumerate(lines):
-        if "Traceback (most recent call last):" in line:
-            traceback_starts.append(i)
-
-    # Process each traceback section
-    for start_idx in traceback_starts:
-        # Determine source based on position relative to "Task failed with exception"
-        if task_failed_line_idx is None:
-            source = "ETL"  # Default to ETL if no dividing line found
-        elif start_idx < task_failed_line_idx:
-            source = "ETL"
-        else:
-            source = "Airflow"
-
-        # Find the exception line for this traceback
-        exception_line = _find_exception_line_in_traceback(lines, start_idx)
-
-        if exception_line:
-            exc_type, exc_msg = _parse_exception_line(exception_line)
-            if exc_type:
-                exceptions.append((exc_type, exc_msg, source))
-
-    return exceptions if exceptions else [(None, None, "Unknown")]
-
-
-def _find_exception_line_in_traceback(lines, traceback_start_idx):
-    """
-    Find the actual exception line (final line) in a traceback section.
-    """
-    # Start from the traceback line and look forward
-    i = traceback_start_idx + 1
-
-    while i < len(lines):
-        line = lines[i].strip()
-
-        # Stop if we hit another traceback
-        if "Traceback (most recent call last):" in line:
-            break
-
-        # Stop if we hit certain log markers that indicate end of traceback
-        if line.startswith("During handling of the above exception") or line.startswith(
-            "The above exception was the direct cause"
-        ):
-            i += 1
-            continue
-
-        # Check if this is an exception line
-        if _is_exception_line(line):
-            return line
-
-        i += 1
-
-    return None
-
-
-def _is_exception_line(line):
-    """Check if a line contains a Python exception"""
-    import re
-
-    line = line.strip()
-
-    # Skip obvious non-exception lines
-    if (
-        not line
-        or line.startswith("File ")
-        or line.startswith("    ")
-        or line.startswith("^")
-        or "Traceback" in line
-        or line.startswith("During handling")
-        or line.startswith("The above exception")
-    ):
-        return False
-
-    # Look for Python exception patterns
-    # Must start with a capital letter followed by word characters, dots, underscores
-    # Common exception endings but not required
-    exception_pattern = (
-        r"^[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Warning|Timeout)?(?::\s|$)"
-    )
-    return re.match(exception_pattern, line) is not None
-
-
-def _parse_exception_line(line):
-    """Parse an exception line into (type, message)"""
-    import re
-
-    line = line.strip()
-
-    # Pattern for ExceptionType: message
-    match = re.match(r"^([A-Z][A-Za-z0-9_.]*)\s*:\s*(.*)", line)
-    if match:
-        return match.group(1), match.group(2)
-
-    # Pattern for just ExceptionType (no colon/message)
-    match = re.match(r"^([A-Z][A-Za-z0-9_.]*)$", line)
-    if match:
-        return match.group(1), ""
-
-    return None, None
-
-
 def task_fail_slack_alert(context):
 
     task_instance = context.get("task_instance")
@@ -246,6 +100,10 @@ def task_fail_slack_alert(context):
 
     # Extract all exceptions from logs if available
     all_exceptions = []
+
+    # DEBUG: Set this to a string containing log text to test exception parsing
+    # When None, normal operation resumes
+    DEBUG_LOG_TEXT = None
 
     # First, get exceptions from Docker container logs if available
     if DEBUG_LOG_TEXT is not None:

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -155,7 +155,6 @@ def extract_all_exceptions_from_log(log_text):
             if exc_type:
                 exceptions.append((exc_type, exc_msg, source))
     
-    print(f"Found exceptions: {exceptions}")
     return exceptions if exceptions else [(None, None, "Unknown")]
 
 

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -115,28 +115,28 @@ def extract_exception_from_log(log_text):
 
 def extract_all_exceptions_from_log(log_text):
     """
-    Extract all Python exceptions from raw Airflow logs. 
+    Extract all Python exceptions from raw Airflow logs.
     Returns list of tuples (exception_type, exception_message, source).
     Source is "ETL" for exceptions before "Task failed with exception" line,
     "Airflow" for exceptions after that line.
     """
-    
+
     exceptions = []
-    lines = log_text.split('\n')
-    
+    lines = log_text.split("\n")
+
     # Find the "Task failed with exception" dividing line
     task_failed_line_idx = None
     for i, line in enumerate(lines):
         if "Task failed with exception" in line:
             task_failed_line_idx = i
             break
-    
+
     # Look for all traceback sections
     traceback_starts = []
     for i, line in enumerate(lines):
         if "Traceback (most recent call last):" in line:
             traceback_starts.append(i)
-    
+
     # Process each traceback section
     for start_idx in traceback_starts:
         # Determine source based on position relative to "Task failed with exception"
@@ -146,15 +146,15 @@ def extract_all_exceptions_from_log(log_text):
             source = "ETL"
         else:
             source = "Airflow"
-        
+
         # Find the exception line for this traceback
         exception_line = _find_exception_line_in_traceback(lines, start_idx)
-        
+
         if exception_line:
             exc_type, exc_msg = _parse_exception_line(exception_line)
             if exc_type:
                 exceptions.append((exc_type, exc_msg, source))
-    
+
     return exceptions if exceptions else [(None, None, "Unknown")]
 
 
@@ -164,68 +164,73 @@ def _find_exception_line_in_traceback(lines, traceback_start_idx):
     """
     # Start from the traceback line and look forward
     i = traceback_start_idx + 1
-    
+
     while i < len(lines):
         line = lines[i].strip()
-        
+
         # Stop if we hit another traceback
         if "Traceback (most recent call last):" in line:
             break
-            
+
         # Stop if we hit certain log markers that indicate end of traceback
-        if (line.startswith('During handling of the above exception') or
-            line.startswith('The above exception was the direct cause')):
+        if line.startswith("During handling of the above exception") or line.startswith(
+            "The above exception was the direct cause"
+        ):
             i += 1
             continue
-            
+
         # Check if this is an exception line
         if _is_exception_line(line):
             return line
-            
+
         i += 1
-    
+
     return None
 
 
 def _is_exception_line(line):
     """Check if a line contains a Python exception"""
     import re
-    
+
     line = line.strip()
-    
+
     # Skip obvious non-exception lines
-    if (not line or
-        line.startswith('File ') or 
-        line.startswith('    ') or 
-        line.startswith('^') or
-        'Traceback' in line or
-        line.startswith('During handling') or
-        line.startswith('The above exception')):
+    if (
+        not line
+        or line.startswith("File ")
+        or line.startswith("    ")
+        or line.startswith("^")
+        or "Traceback" in line
+        or line.startswith("During handling")
+        or line.startswith("The above exception")
+    ):
         return False
-    
+
     # Look for Python exception patterns
     # Must start with a capital letter followed by word characters, dots, underscores
     # Common exception endings but not required
-    exception_pattern = r'^[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Warning|Timeout)?(?::\s|$)'
+    exception_pattern = (
+        r"^[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Warning|Timeout)?(?::\s|$)"
+    )
     return re.match(exception_pattern, line) is not None
 
 
 def _parse_exception_line(line):
     """Parse an exception line into (type, message)"""
     import re
-    
+
     line = line.strip()
-    
+
     # Pattern for ExceptionType: message
-    match = re.match(r'^([A-Z][A-Za-z0-9_.]*)\s*:\s*(.*)', line)
+    match = re.match(r"^([A-Z][A-Za-z0-9_.]*)\s*:\s*(.*)", line)
     if match:
         return match.group(1), match.group(2)
-    
+
     # Pattern for just ExceptionType (no colon/message)
-    match = re.match(r'^([A-Z][A-Za-z0-9_.]*)$', line)
+    match = re.match(r"^([A-Z][A-Za-z0-9_.]*)$", line)
     if match:
         return match.group(1), ""
-    
+
     return None, None
 
 
@@ -241,13 +246,13 @@ def task_fail_slack_alert(context):
 
     # Extract all exceptions from logs if available
     all_exceptions = []
-    
+
     # First, get exceptions from Docker container logs if available
     if DEBUG_LOG_TEXT is not None:
         # DEBUG MODE: Use the debug log text instead of actual logs
         print(f"DEBUG MODE: Using debug log text for parsing")
         parsed_exceptions = extract_all_exceptions_from_log(DEBUG_LOG_TEXT)
-        
+
         # Add parsed exceptions (filter out None entries)
         for exc in parsed_exceptions:
             if exc[0] is not None:
@@ -255,20 +260,22 @@ def task_fail_slack_alert(context):
     elif exception and hasattr(exception, "logs") and exception.logs:
         logs = exception.logs
         parsed_exceptions = extract_all_exceptions_from_log("\n".join(logs))
-        
+
         # Add parsed exceptions (filter out None entries)
         for exc in parsed_exceptions:
             if exc[0] is not None:
                 all_exceptions.append(exc)
-    
+
     # Always add the Airflow-level exception as well if not already found
     airflow_exception = (exception_type, exception_message, "Airflow")
     # Check if we already have this exception from parsing
-    airflow_already_found = any(exc[0] == exception_type and exc[1] == exception_message 
-                                for exc in all_exceptions)
+    airflow_already_found = any(
+        exc[0] == exception_type and exc[1] == exception_message
+        for exc in all_exceptions
+    )
     if not airflow_already_found:
         all_exceptions.append(airflow_exception)
-    
+
     # Use the last exception as primary for backward compatibility
     if all_exceptions:
         exception_type = all_exceptions[-1][0]
@@ -305,9 +312,11 @@ def task_fail_slack_alert(context):
         exceptions_text = f"*Exceptions Found ({len(all_exceptions)} total)*:"
         for i, exc_tuple in enumerate(all_exceptions, 1):
             exc_type = exc_tuple[0]
-            exc_msg = exc_tuple[1] 
+            exc_msg = exc_tuple[1]
             source = exc_tuple[2] if len(exc_tuple) > 2 else "Unknown"
-            exceptions_text += f"\n        {i}. *{exc_type}* _(from {source})_: `{exc_msg}`"
+            exceptions_text += (
+                f"\n        {i}. *{exc_type}* _(from {source})_: `{exc_msg}`"
+            )
 
     slack_msg = f"""
         {icon}{env_indicator} *Task failure* 

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -11,6 +11,10 @@ SLACK_CONN_ID = "slack"
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
+# DEBUG: Set this to a string containing log text to test exception parsing
+# When None, normal operation resumes
+DEBUG_LOG_TEXT = None
+
 slack_member_ids = {
     "Frank": "<@UMS32US1E>",
     "Amenity": "<@U0PQDEMRD>",
@@ -110,87 +114,120 @@ def extract_exception_from_log(log_text):
 
 
 def extract_all_exceptions_from_log(log_text):
-    import re
-
-    exceptions = []
+    """
+    Extract all Python exceptions from raw Airflow logs. 
+    Returns list of tuples (exception_type, exception_message, source).
+    Source is "ETL" for exceptions before "Task failed with exception" line,
+    "Airflow" for exceptions after that line.
+    """
     
-    # Split log into lines for easier processing
+    exceptions = []
     lines = log_text.split('\n')
     
-    # Track whether we're in a traceback section
-    in_traceback = False
-    current_traceback_lines = []
+    # Find the "Task failed with exception" dividing line
+    task_failed_line_idx = None
+    for i, line in enumerate(lines):
+        if "Task failed with exception" in line:
+            task_failed_line_idx = i
+            break
     
-    for line in lines:
-        line = line.strip()
-        
-        # Start of a new traceback
+    # Look for all traceback sections
+    traceback_starts = []
+    for i, line in enumerate(lines):
         if "Traceback (most recent call last):" in line:
-            # Process previous traceback if we have one
-            if in_traceback and current_traceback_lines:
-                exception = _extract_exception_from_traceback_lines(current_traceback_lines)
-                if exception:
-                    exceptions.append(exception)
-            
-            # Start new traceback
-            in_traceback = True
-            current_traceback_lines = [line]
-            
-        elif in_traceback:
-            # Check if this line ends the current traceback
-            # Lines that typically end a traceback: empty lines, INFO logs, or new sections
-            if (line == "" or 
-                "INFO -" in line or 
-                "ERROR -" in line or 
-                "WARNING -" in line or
-                "The above exception was the direct cause of the following exception:" in line):
-                
-                # Process current traceback before ending
-                if current_traceback_lines:
-                    exception = _extract_exception_from_traceback_lines(current_traceback_lines)
-                    if exception:
-                        exceptions.append(exception)
-                
-                # Reset for potential next traceback
-                if "The above exception was the direct cause of the following exception:" in line:
-                    # This indicates chained exceptions, stay in traceback mode
-                    current_traceback_lines = []
-                else:
-                    # End of traceback section
-                    in_traceback = False
-                    current_traceback_lines = []
-            else:
-                # Add line to current traceback
-                current_traceback_lines.append(line)
+            traceback_starts.append(i)
     
-    # Process final traceback if we ended while in one
-    if in_traceback and current_traceback_lines:
-        exception = _extract_exception_from_traceback_lines(current_traceback_lines)
-        if exception:
-            exceptions.append(exception)
+    # Process each traceback section
+    for start_idx in traceback_starts:
+        # Determine source based on position relative to "Task failed with exception"
+        if task_failed_line_idx is None:
+            source = "ETL"  # Default to ETL if no dividing line found
+        elif start_idx < task_failed_line_idx:
+            source = "ETL"
+        else:
+            source = "Airflow"
+        
+        # Find the exception line for this traceback
+        exception_line = _find_exception_line_in_traceback(lines, start_idx)
+        
+        if exception_line:
+            exc_type, exc_msg = _parse_exception_line(exception_line)
+            if exc_type:
+                exceptions.append((exc_type, exc_msg, source))
     
-    print("Found exceptions: ", exceptions)
-    return exceptions if exceptions else [(None, None)]
+    print(f"Found exceptions: {exceptions}")
+    return exceptions if exceptions else [(None, None, "Unknown")]
 
 
-def _extract_exception_from_traceback_lines(traceback_lines):
-    import re
+def _find_exception_line_in_traceback(lines, traceback_start_idx):
+    """
+    Find the actual exception line (final line) in a traceback section.
+    """
+    # Start from the traceback line and look forward
+    i = traceback_start_idx + 1
     
-    # Look for the exception line (usually the last non-empty line)
-    for line in reversed(traceback_lines):
-        line = line.strip()
-        if line and not line.startswith('File ') and not line.startswith('Traceback'):
-            # Try to match exception pattern: ExceptionType: message
-            match = re.match(r'^([\w.]+):\s*(.*)', line)
-            if match:
-                return (match.group(1), match.group(2))
+    while i < len(lines):
+        line = lines[i].strip()
+        
+        # Stop if we hit another traceback
+        if "Traceback (most recent call last):" in line:
+            break
             
-            # Sometimes exceptions don't have messages, just the type
-            match = re.match(r'^([\w.]+)$', line)
-            if match:
-                return (match.group(1), "")
+        # Stop if we hit certain log markers that indicate end of traceback
+        if (line.startswith('During handling of the above exception') or
+            line.startswith('The above exception was the direct cause')):
+            i += 1
+            continue
+            
+        # Check if this is an exception line
+        if _is_exception_line(line):
+            return line
+            
+        i += 1
     
     return None
+
+
+def _is_exception_line(line):
+    """Check if a line contains a Python exception"""
+    import re
+    
+    line = line.strip()
+    
+    # Skip obvious non-exception lines
+    if (not line or
+        line.startswith('File ') or 
+        line.startswith('    ') or 
+        line.startswith('^') or
+        'Traceback' in line or
+        line.startswith('During handling') or
+        line.startswith('The above exception')):
+        return False
+    
+    # Look for Python exception patterns
+    # Must start with a capital letter followed by word characters, dots, underscores
+    # Common exception endings but not required
+    exception_pattern = r'^[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Warning|Timeout)?(?::\s|$)'
+    return re.match(exception_pattern, line) is not None
+
+
+def _parse_exception_line(line):
+    """Parse an exception line into (type, message)"""
+    import re
+    
+    line = line.strip()
+    
+    # Pattern for ExceptionType: message
+    match = re.match(r'^([A-Z][A-Za-z0-9_.]*)\s*:\s*(.*)', line)
+    if match:
+        return match.group(1), match.group(2)
+    
+    # Pattern for just ExceptionType (no colon/message)
+    match = re.match(r'^([A-Z][A-Za-z0-9_.]*)$', line)
+    if match:
+        return match.group(1), ""
+    
+    return None, None
 
 
 def task_fail_slack_alert(context):
@@ -207,20 +244,33 @@ def task_fail_slack_alert(context):
     all_exceptions = []
     
     # First, get exceptions from Docker container logs if available
-    if exception and hasattr(exception, "logs") and exception.logs:
-        logs = exception.logs
-        container_exceptions = extract_all_exceptions_from_log("\n".join(logs))
+    if DEBUG_LOG_TEXT is not None:
+        # DEBUG MODE: Use the debug log text instead of actual logs
+        print(f"DEBUG MODE: Using debug log text for parsing")
+        parsed_exceptions = extract_all_exceptions_from_log(DEBUG_LOG_TEXT)
         
-        # Add container exceptions (filter out None entries)
-        for exc in container_exceptions:
+        # Add parsed exceptions (filter out None entries)
+        for exc in parsed_exceptions:
+            if exc[0] is not None:
+                all_exceptions.append(exc)
+    elif exception and hasattr(exception, "logs") and exception.logs:
+        logs = exception.logs
+        parsed_exceptions = extract_all_exceptions_from_log("\n".join(logs))
+        
+        # Add parsed exceptions (filter out None entries)
+        for exc in parsed_exceptions:
             if exc[0] is not None:
                 all_exceptions.append(exc)
     
-    # Always add the Airflow-level exception as well
-    airflow_exception = (exception_type, exception_message)
-    all_exceptions.append(airflow_exception)
+    # Always add the Airflow-level exception as well if not already found
+    airflow_exception = (exception_type, exception_message, "Airflow")
+    # Check if we already have this exception from parsing
+    airflow_already_found = any(exc[0] == exception_type and exc[1] == exception_message 
+                                for exc in all_exceptions)
+    if not airflow_already_found:
+        all_exceptions.append(airflow_exception)
     
-    # Use the last exception (Airflow-level) as primary for backward compatibility
+    # Use the last exception as primary for backward compatibility
     if all_exceptions:
         exception_type = all_exceptions[-1][0]
         exception_message = all_exceptions[-1][1]
@@ -248,13 +298,17 @@ def task_fail_slack_alert(context):
     # Format all exceptions for display
     exceptions_text = ""
     if len(all_exceptions) == 1:
-        # Single exception - use original format
-        exceptions_text = f"*Exception Type*: `{exception_type}`\n        *Exception Message*: `{exception_message}`"
+        # Single exception - use original format with source
+        source = all_exceptions[0][2] if len(all_exceptions[0]) > 2 else "Unknown"
+        exceptions_text = f"*Exception Type*: `{exception_type}` _(from {source})_\n        *Exception Message*: `{exception_message}`"
     else:
-        # Multiple exceptions - list them all
+        # Multiple exceptions - list them all with sources
         exceptions_text = f"*Exceptions Found ({len(all_exceptions)} total)*:"
-        for i, (exc_type, exc_msg) in enumerate(all_exceptions, 1):
-            exceptions_text += f"\n        {i}. *{exc_type}*: `{exc_msg}`"
+        for i, exc_tuple in enumerate(all_exceptions, 1):
+            exc_type = exc_tuple[0]
+            exc_msg = exc_tuple[1] 
+            source = exc_tuple[2] if len(exc_tuple) > 2 else "Unknown"
+            exceptions_text += f"\n        {i}. *{exc_type}* _(from {source})_: `{exc_msg}`"
 
     slack_msg = f"""
         {icon}{env_indicator} *Task failure* 

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -91,7 +91,6 @@ def get_central_time_exec_data(context):
 def task_fail_slack_alert(context):
 
     task_instance = context.get("task_instance")
-    task = context.get("task")
     exception = context.get("exception")
     exception_type = type(exception).__name__ if exception else "Unknown"
     exception_message = (


### PR DESCRIPTION
# Associated issues

This PR intends to close https://github.com/cityofaustin/atd-data-tech/issues/22992.

# Associated repo

Airflow itself

# Testing

### Testing this is a real ~time~ mind warp. It's just a jump to the left...

Here's the problem: It's very challenging to test this PR in a single pass because you can either be testing the parsing capabilities by artificially injecting crafted logs to simulate one of the practically infinite ways in which an ETL can fail, or you can craft fake ETLs that fail in very predictable, uninteresting, non-varying ways. You either give up simulating the event's occurrence or you give up simulating the event's output.

So we're going to do both, and I'm going to propose a final stage of testing after approvals are gathered.

### First, let's try out a hand-crafted DAG that fails in a predictable way:

* Spin up your local stack and get up to date with this branch. 
* Fire up the test fixture DAG `test_docker_failure`. This one has been enhanced to fire up a docker container that fails in such a way it emits a 3-layer-deep stacked exception. 
* Take a look at the code in this DAG and the error in Airflow and the way it's reported in slack. 
* Think about the stack and how it has failed. Think about what errors happened inside of docker (from airflow's perspective) and which didn't.
* Do you like how this is reported in slack? Can you see what exceptions came out of our code and which came out of airflow's code?

### Second, let's take a whirl at putting some real world failures into our failure parsing gizmo:

* Get on slack and find a real error that is complicated, or not. You can pick any error. This is testing the real world robustness of the parser and how it handles whatever wacky thing we can dig up. 
  * Understand that this is a system that is entirely based on heuristics and it is always, absolutely, going to be be possible to craft up an error message that fails as it goes through the parser. This is about making one that is "good enough", not one that is perfect. 
    * I do think this one is pretty good though; I think it rides the fine line between simple and comprehensive well. 
* Follow the "View Task Log" link from slack, and you'll be dropped on the log page of the particular task in the particular DAG that you picked. Look in this log and copy the entire contents out of the log section between the following lines. Do not include the following lines. We're looking for the logging that *comes out of our ETL* and not out of the airflow system or the airflow UI.

Between this line:
```
[2025-07-23, 13:41:16 CDT] {docker.py:345} INFO - Starting docker container from image atddocker/some-dts-thing:production
```

and the line:

```
[2025-07-23, 13:41:29 CDT] {taskinstance.py:1226} INFO - Marking task as FAILED. dag_id=whatever-dag, task_id=whatever-task, run_id=scheduled__2025-07-23T16:40:00+00:00, execution_date=20250723T164000, start_date=20250723T184115, end_date=20250723T184129
```
* Now that you've got that copied, we need to remove all the logging cruft that airflow has decorated the output with. Go to your favorite LLM provider and give it the log and ask it to do the following:

> Remove timestamps, file/line references, and log level prefixes from this log output and return as clean text in a code block.

* Now that you have a cleaned up log, which represents the actual, literal bytes of text that came out of the docker container's `STDOUT`, as it would be presented to the slack operator's code, replace the `None` with a multiline (`"""` ... `"""`) assignment into `DEBUG_LOG_TEXT` variable at the top of the `slack_operator.py` file. 
* Fire off the same test DAG from above, but this time, you should see your hand-picked error represented in slack, as the operator will use what you provided in the debug variable instead of what actually came out of the docker container. 
  * **NB**: your UI in airflow will still be the actual error from docker, only the *slack* warning message will represent the error you prepared.
* Did it work? Can you break the parser? 
* Review the code and consider the methodology
  * Do you have any ideas on how this could be done better or more robustly? 


#### You made it to the end!
# 🙌 
