### PR TITLE
Revise log parsing for lower-cased exceptions

### DIFF
--- a/dags/utils/log_parsing.py
+++ b/dags/utils/log_parsing.py
@@ -160,11 +160,12 @@ def _is_exception_line(line):
         return False
 
     # Look for Python exception patterns
-    # Must start with a capital letter followed by word characters, dots, underscores
-    # Common exception endings but not required
-    exception_pattern = (
-        r"^[A-Z][A-Za-z0-9_.]*(?:Error|Exception|Warning|Timeout)?(?::\s|$)"
-    )
+    # Allow optional lowercase/dotted module path segments before a capitalized class name
+    # Example matches:
+    #   ValueError: message
+    #   mypkg.errors.CustomError: message
+    #   package.subpackage.Timeout
+    exception_pattern = r"^(?:[a-z][a-z0-9_]*\.)*[A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning|Timeout)?(?::\s|$)"
     return re.match(exception_pattern, line) is not None
 
 
@@ -174,13 +175,20 @@ def _parse_exception_line(line):
 
     line = line.strip()
 
-    # Pattern for ExceptionType: message
-    match = re.match(r"^([A-Z][A-Za-z0-9_.]*)\s*:\s*(.*)", line)
+    # Pattern for optional module path + ExceptionType: message
+    # Capture only the bare class name as the type
+    match = re.match(
+        r"^(?:[a-z][a-z0-9_]*\.)*([A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning|Timeout)?)\s*:\s*(.*)",
+        line,
+    )
     if match:
         return match.group(1), match.group(2)
 
-    # Pattern for just ExceptionType (no colon/message)
-    match = re.match(r"^([A-Z][A-Za-z0-9_.]*)$", line)
+    # Pattern for optional module path + just ExceptionType (no colon/message)
+    match = re.match(
+        r"^(?:[a-z][a-z0-9_]*\.)*([A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning|Timeout)?)$",
+        line,
+    )
     if match:
         return match.group(1), ""
 

--- a/dags/utils/log_parsing.py
+++ b/dags/utils/log_parsing.py
@@ -142,7 +142,29 @@ def _find_exception_line_in_traceback(lines, traceback_start_idx):
 
 
 def _is_exception_line(line):
-    """Check if a line contains a Python exception"""
+    """Determine whether a single log line is the exception line of a traceback.
+
+    This aims to capture the final line of a Python traceback which typically
+    contains the exception class (optionally prefixed by module paths) and an
+    optional message. We purposely skip stack frames, caret markers, and other
+    traceback metadata lines.
+
+    Matches (examples we want to catch):
+    - "ValueError: invalid literal for int() with base 10: 'abc'"
+    - "KeyError: 'foo'"
+    - "mypkg.errors.CustomError: something went wrong"
+    - "package.subpackage.Timeout"  (class name without a message)
+    - "RuntimeError:"  (class name with a trailing colon but empty message)
+
+    Non-matches (examples we want to ignore):
+    - "Traceback (most recent call last):"
+    - "  File \"/usr/local/lib/python3.10/site-packages/foo.py\", line 10, in bar"
+    - "    raise ValueError('bad')"  (indented code line inside stack frame)
+    - "^"  (caret lines from SyntaxError displays)
+    - "During handling of the above exception, another exception occurred:"
+    - "The above exception was the direct cause of the following exception:"
+    - ""  (empty/whitespace-only lines)
+    """
     import re
 
     line = line.strip()
@@ -159,12 +181,7 @@ def _is_exception_line(line):
     ):
         return False
 
-    # Look for Python exception patterns
     # Allow optional lowercase/dotted module path segments before a capitalized class name
-    # Example matches:
-    #   ValueError: message
-    #   mypkg.errors.CustomError: message
-    #   package.subpackage.Timeout
     exception_pattern = r"^(?:[a-z][a-z0-9_]*\.)*[A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning|Timeout)?(?::\s|$)"
     return re.match(exception_pattern, line) is not None
 


### PR DESCRIPTION
# Associated issues

Airflow [PR #330](https://github.com/cityofaustin/atd-airflow/pull/300)

# Associated repo

Airflow itself

# What is this

Now that the new airflow exception parser is in place, it's getting road tested with a diverse set of exceptions and errors. It has previously assumed that all `<exception type>: <exception message>` lines began with a capital letter, as they are often formatted, but we have [a DAG](https://austininnovation.slack.com/archives/C013G4RNJ01/p1755149455727089) that doesn't comply, and this is a minor adjustment to the parser to compensate.

# Testing

I'm hopeful that this PR can get in pretty easy; i think of it as a patch to the previous one. I propose an eye-ball test over the diff is enough. However, anyone who would like to do a more comprehensive test can follow the instructions in [PR #330](https://github.com/cityofaustin/atd-airflow/pull/300).

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
