### PR TITLE
Update README to replace `stop` with `down` for Docker stack command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ git pull;
 # pull the fresh production image
 docker compose pull;
 
-# stop the Docker stack
-docker compose stop;
+# down the Docker stack
+docker compose down;
 
 # start the Docker stack
 docker compose -f docker-compose.yaml -f docker-compose-production.yaml up -d;

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ git pull;
 # pull the fresh production image
 docker compose pull;
 
-# down the Docker stack
+# tear down the docker stack
 docker compose down;
 
 # start the Docker stack


### PR DESCRIPTION
## Associated issues

_none_

## Intent

I noticed an issue with the airflow restart instructions. In the section where a new image is pulled from the upstream registry, we need to `docker compose down` instead of `stop`ing because stopping keeps the container around in a paused state (which can be restarted, for example), and we want to start a whole new container from the updated image.

## Associated repo

Airflow itself

## Testing

📖 👀 Just give the diff a quick look-over, it's a two-liner.

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
