### PR TITLE
Ignore date filter arg SMO signals

### DIFF
--- a/dags/atd_knack_artbox_signals.py
+++ b/dags/atd_knack_artbox_signals.py
@@ -97,7 +97,7 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name_dest} -c {container_dest} {date_filter_arg}",
+        command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name_dest} -c {container_dest}",
         environment=env_vars_t1,
         tty=True,
         force_pull=True,


### PR DESCRIPTION
Discovered that new/updated records can sometimes slip through the cracks and not get updated in Postgrest, which can [cause errors](https://austininnovation.slack.com/archives/C013G4RNJ01/p1756099913053879). Removing the date filter arg from the records_to_postgrest task here fixed it for me, and only took a few seconds longer to run.

## Associated issues

## Associated repo
https://github.com/cityofaustin/atd-knack-services/blob/production/services/records_to_knack.py

## Testing

**Steps to test:**

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
