### PR TITLE
Open311 Scraping DAG

### DIFF
--- a/dags/dts_311_report_publishing.py
+++ b/dags/dts_311_report_publishing.py
@@ -1,4 +1,4 @@
-# test locally with: docker compose run --rm airflow-cli dags test dts_csr_report_publishing
+# test locally with: docker compose run --rm airflow-cli dags test dts_311_report_publishing
 
 from os import getenv
 
@@ -142,14 +142,14 @@ PREV_YEAR_SECRETS.update(OTHER_SECRETS)
 TWO_YEARS_AGO_SECRETS.update(OTHER_SECRETS)
 
 with DAG(
-    dag_id="dts_csr_report_publishing",
+    dag_id="dts_311_report_publishing",
     description="Downloads reports of 311 service requests for TPW and publishes it in a Socrata dataset.",
     default_args=default_args,
     schedule_interval=(
         "36 2,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
     ),
     dagrun_timeout=timedelta(minutes=60),
-    tags=["repo:dts-311-reporting", "socrata", "csr"],
+    tags=["repo:dts-311-reporting", "socrata", "311"],
     catchup=False,
 ) as dag:
     docker_image = "atddocker/dts-311-reporting:production"
@@ -164,7 +164,7 @@ with DAG(
         docker_conn_id="docker_default",
         api_version="auto",
         auto_remove="force",
-        command="python -m etl.csv_reporting.csr_to_socrata",
+        command="python -m etl.csv_reporting.requests_to_socrata",
         environment=cur_year_env,
         tty=True,
         force_pull=True,
@@ -198,7 +198,7 @@ with DAG(
         docker_conn_id="docker_default",
         api_version="auto",
         auto_remove="force",
-        command="python -m etl.csv_reporting.csr_to_socrata",
+        command="python -m etl.csv_reporting.requests_to_socrata",
         environment=prev_year_env,
         tty=True,
     )
@@ -231,7 +231,7 @@ with DAG(
         docker_conn_id="docker_default",
         api_version="auto",
         auto_remove="force",
-        command="python -m etl.csv_reporting.csr_to_socrata",
+        command="python -m etl.csv_reporting.requests_to_socrata",
         environment=two_years_env,
         tty=True,
     )

--- a/dags/dts_311_report_publishing.py
+++ b/dags/dts_311_report_publishing.py
@@ -49,7 +49,7 @@ OTHER_SECRETS = {
         "opitem": "Executive Dashboard",
         "opfield": "datasets.Revenue",
     },
-    "CSR_DATASET": {
+    "REQUESTS_DATASET": {
         "opitem": "Executive Dashboard",
         "opfield": "datasets.CSR",
     },
@@ -92,7 +92,7 @@ OTHER_SECRETS = {
 }
 
 CUR_YEAR_SECRETS = {
-    "CSR_ENDPOINT": {
+    "REQUESTS_ENDPOINT": {
         "opitem": "Executive Dashboard",
         "opfield": "csr.Current FY Endpoint",
     },
@@ -107,7 +107,7 @@ CUR_YEAR_SECRETS = {
 }
 
 PREV_YEAR_SECRETS = {
-    "CSR_ENDPOINT": {
+    "REQUESTS_ENDPOINT": {
         "opitem": "Executive Dashboard",
         "opfield": "csr.Previous FY Endpoint",
     },
@@ -122,7 +122,7 @@ PREV_YEAR_SECRETS = {
 }
 
 TWO_YEARS_AGO_SECRETS = {
-    "CSR_ENDPOINT": {
+    "REQUESTS_ENDPOINT": {
         "opitem": "Executive Dashboard",
         "opfield": "csr.Two Years Ago FY Endpoint",
     },
@@ -159,7 +159,7 @@ with DAG(
     two_years_env = get_env_vars_task(TWO_YEARS_AGO_SECRETS)
 
     t1 = DockerOperator(
-        task_id="cur_year_csr_report_to_socrata",
+        task_id="cur_year_requests_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
         api_version="auto",
@@ -193,7 +193,7 @@ with DAG(
     )
 
     t4 = DockerOperator(
-        task_id="prev_year_csr_report_to_socrata",
+        task_id="prev_year_requests_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
         api_version="auto",
@@ -226,7 +226,7 @@ with DAG(
     )
 
     t7 = DockerOperator(
-        task_id="two_years_ago_csr_report_to_socrata",
+        task_id="two_years_ago_requests_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
         api_version="auto",

--- a/dags/dts_csr_report_publishing.py
+++ b/dags/dts_csr_report_publishing.py
@@ -164,7 +164,7 @@ with DAG(
         docker_conn_id="docker_default",
         api_version="auto",
         auto_remove="force",
-        command=f"python etl/csr_to_socrata.py",
+        command="python -m etl.csv_reporting.csr_to_socrata",
         environment=cur_year_env,
         tty=True,
         force_pull=True,
@@ -176,7 +176,7 @@ with DAG(
         docker_conn_id="docker_default",
         api_version="auto",
         auto_remove="force",
-        command=f"python etl/flex_notes_to_socrata.py",
+        command="python -m etl.csv_reporting.flex_notes_to_socrata",
         environment=cur_year_env,
         tty=True,
     )
@@ -187,7 +187,7 @@ with DAG(
         docker_conn_id="docker_default",
         api_version="auto",
         auto_remove="force",
-        command=f"python etl/activities_to_socrata.py",
+        command="python -m etl.csv_reporting.activities_to_socrata",
         environment=cur_year_env,
         tty=True,
     )
@@ -198,7 +198,7 @@ with DAG(
         docker_conn_id="docker_default",
         api_version="auto",
         auto_remove="force",
-        command=f"python etl/csr_to_socrata.py",
+        command="python -m etl.csv_reporting.csr_to_socrata",
         environment=prev_year_env,
         tty=True,
     )
@@ -209,7 +209,7 @@ with DAG(
         docker_conn_id="docker_default",
         api_version="auto",
         auto_remove="force",
-        command=f"python etl/flex_notes_to_socrata.py",
+        command="python -m etl.csv_reporting.flex_notes_to_socrata",
         environment=prev_year_env,
         tty=True,
     )
@@ -220,7 +220,7 @@ with DAG(
         docker_conn_id="docker_default",
         api_version="auto",
         auto_remove="force",
-        command=f"python etl/activities_to_socrata.py",
+        command="python -m etl.csv_reporting.activities_to_socrata",
         environment=prev_year_env,
         tty=True,
     )
@@ -231,7 +231,7 @@ with DAG(
         docker_conn_id="docker_default",
         api_version="auto",
         auto_remove="force",
-        command=f"python etl/csr_to_socrata.py",
+        command="python -m etl.csv_reporting.csr_to_socrata",
         environment=two_years_env,
         tty=True,
     )
@@ -242,7 +242,7 @@ with DAG(
         docker_conn_id="docker_default",
         api_version="auto",
         auto_remove="force",
-        command=f"python etl/flex_notes_to_socrata.py",
+        command="python -m etl.csv_reporting.flex_notes_to_socrata",
         environment=two_years_env,
         tty=True,
     )
@@ -253,7 +253,7 @@ with DAG(
         docker_conn_id="docker_default",
         api_version="auto",
         auto_remove="force",
-        command=f"python etl/activities_to_socrata.py",
+        command="python -m etl.csv_reporting.activities_to_socrata",
         environment=two_years_env,
         tty=True,
     )

--- a/dags/dts_open_311_scrape.py
+++ b/dags/dts_open_311_scrape.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from airflow.decorators import task
 from airflow.models import DAG
 from airflow.operators.docker_operator import DockerOperator
-from pendulum import datetime, duration
+from pendulum import datetime, duration, now
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
@@ -71,7 +71,8 @@ with DAG(
     docker_image = "atddocker/dts-311-reporting:production"
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
-    date_arg = get_previous_run_date(fallback_date="2025-10-22")
+    one_day_ago = now("America/Chicago").subtract(days=1)
+    date_arg = get_previous_run_date(fallback_date=one_day_ago.to_iso8601_string())
 
     t1 = DockerOperator(
         task_id="open311_to_socrata",

--- a/dags/dts_open_311_scrape.py
+++ b/dags/dts_open_311_scrape.py
@@ -65,7 +65,7 @@ with DAG(
         "*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
     ),
     dagrun_timeout=timedelta(minutes=5),
-    tags=["repo:dts-311-reporting", "socrata", "csr", "open311"],
+    tags=["repo:dts-311-reporting", "socrata", "311", "open311"],
     catchup=False,
 ) as dag:
     docker_image = "atddocker/dts-311-reporting:production"

--- a/dags/dts_open_311_scrape.py
+++ b/dags/dts_open_311_scrape.py
@@ -1,0 +1,88 @@
+# test locally with: docker compose run --rm airflow-cli dags test dts_open_311_scrape
+
+from os import getenv
+
+from datetime import timedelta
+
+from airflow.decorators import task
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+from utils.time import get_previous_run_date
+
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 12, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "SO_WEB": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.endpoint",
+    },
+    "SO_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "SO_SECRET": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SO_KEY": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "REALTIME_DATASET": {
+        "opitem": "Executive Dashboard",
+        "opfield": "datasets.Realtime",
+    },
+    "OPEN_311_API_KEY": {
+        "opitem": "Austin Open 311 API key",
+        "opfield": "production.API key",
+    },
+    "OPEN_311_API_BASE_URL": {
+        "opitem": "Austin Open 311 API key",
+        "opfield": "production.Base URL",
+    },
+}
+
+
+with DAG(
+    dag_id="dts_open_311_scrape",
+    description="Downloads CSRs from Open311 API and publishes them in a Socrata dataset",
+    default_args=default_args,
+    schedule_interval=(
+        "*/5 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
+    ),
+    dagrun_timeout=timedelta(minutes=5),
+    tags=["repo:dts-311-reporting", "socrata", "csr", "open311"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/dts-311-reporting:production"
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+    date_arg = get_previous_run_date(fallback_date="2025-10-13")
+
+    t1 = DockerOperator(
+        task_id="open311_to_socrata",
+        image=docker_image,
+        docker_conn_id="docker_default",
+        api_version="auto",
+        auto_remove="force",
+        command=f"python -m etl.open311.open311_to_socrata -d {date_arg["last_run_datetime_iso"]}",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+    )
+
+    t1

--- a/dags/dts_open_311_scrape.py
+++ b/dags/dts_open_311_scrape.py
@@ -71,7 +71,7 @@ with DAG(
     docker_image = "atddocker/dts-311-reporting:production"
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
-    date_arg = get_previous_run_date(fallback_date="2025-10-13")
+    date_arg = get_previous_run_date(fallback_date="2025-10-22")
 
     t1 = DockerOperator(
         task_id="open311_to_socrata",

--- a/dags/utils/time.py
+++ b/dags/utils/time.py
@@ -6,7 +6,7 @@ from pendulum import now, parse
     task_id="get_previous_run_date",
     multiple_outputs=True,
 )
-def get_previous_run_date(**context):
+def get_previous_run_date(fallback_date="1970-01-01", **context):
     """Task to return the last successful run date in UTC datetime format.
 
     Args:
@@ -16,9 +16,10 @@ def get_previous_run_date(**context):
     Returns:
         Dict: dict containing the last run datetime and other future formats
     """
-    last_run_datetime = context.get("prev_start_date_success") or parse("1970-01-01")
+    last_run_datetime = context.get("prev_start_date_success") or parse(fallback_date)
 
     return {
         "last_run_datetime": last_run_datetime,
-        # add other formats here
+        "last_run_datetime_iso": last_run_datetime.isoformat(),
     }
+

--- a/dags/utils/time.py
+++ b/dags/utils/time.py
@@ -22,4 +22,3 @@ def get_previous_run_date(fallback_date="1970-01-01", **context):
         "last_run_datetime": last_run_datetime,
         "last_run_datetime_iso": last_run_datetime.isoformat(),
     }
-


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/25051

## Associated repo
Related PR: https://github.com/cityofaustin/dts-311-reporting/pull/5

## Testing

**Steps to test:**
1. You DO need to be on VPN if you want to test `dts_csr_report_publishing.py` you do NOT need to be for `dts_open_311_scrape.py`
2. Use the above PR to create a docker image: `docker build . -t atddocker/dts-311-reporting:local`
3. Edit both DAGs to use the your local tag (`atddocker/dts-311-reporting:local`): Line 71 of `dts_open_311_scrape.py` and Line 155 of `dts_csr_report_publishing.py`
4. Comment out `force_pull=True` in both DAGs: Line 85 of `dts_open_311_scrape.py` and Line 170 of `dts_csr_report_publishing.py`
5. Trigger both DAGs and check that that they complete.
6. Retrigger `dts_open_311_scrape.py` and check that it completes and uses the previous successful run date (the script will subtract 10 minutes from this time and retrieve data as normal.)

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
