### PR TITLE
Add EMS person matcher to cris import dag

### DIFF
--- a/dags/vz_cris_import.py
+++ b/dags/vz_cris_import.py
@@ -65,7 +65,7 @@ REQUIRED_SECRETS = {
 }
 
 docker_image_cris_import = f"atddocker/vz-cris-import:{'production' if DEPLOYMENT_ENVIRONMENT == 'production' else 'latest'}"
-docker_image_ems_match = f"atddocker/vz-ems-person-match:{'production' if DEPLOYMENT_ENVIRONMENT == 'production' else 'latest'}"
+docker_image_ems_match = f"atddocker/vz-ems-person-match:{'production' if DEPLOYMENT_ENVIRONMENT == 'production' else 'development'}"
 
 DEFAULT_ARGS = {
     "depends_on_past": False,
@@ -73,7 +73,9 @@ DEFAULT_ARGS = {
     "email_on_retry": False,
     "retries": 0,
     "execution_timeout": duration(minutes=60),
-    "on_failure_callback": task_fail_slack_alert,
+    "on_failure_callback": (
+        task_fail_slack_alert if DEPLOYMENT_ENVIRONMENT != "development" else None
+    ),
 }
 
 
@@ -119,6 +121,7 @@ with DAG(
         environment=env_vars,
         auto_remove="force",
         tty=True,
+        mount_tmp_dir=False, 
     )
 
-    cris_import >> ocr_crash_narratives >> match_ems_to_people
+    match_ems_to_people

--- a/dags/vz_cris_import.py
+++ b/dags/vz_cris_import.py
@@ -117,11 +117,11 @@ with DAG(
         task_id="match_ems_to_people",
         docker_conn_id="docker_default",
         image=docker_image_ems_match,
-        command=f"./match_ems_to_people.py",
+        command=f"python match_ems_to_people.py",
         environment=env_vars,
         auto_remove="force",
         tty=True,
-        mount_tmp_dir=False, 
+        force_pull=True,
     )
 
-    match_ems_to_people
+    cris_import >> ocr_crash_narratives >> match_ems_to_people

--- a/dags/vz_cris_import.py
+++ b/dags/vz_cris_import.py
@@ -64,8 +64,8 @@ REQUIRED_SECRETS = {
     },
 }
 
-docker_image = f"atddocker/vz-cris-import:{'production' if DEPLOYMENT_ENVIRONMENT == 'production' else 'latest'}"
-
+docker_image_cris_import = f"atddocker/vz-cris-import:{'production' if DEPLOYMENT_ENVIRONMENT == 'production' else 'latest'}"
+docker_image_ems_match = f"atddocker/vz-ems-person-match:{'production' if DEPLOYMENT_ENVIRONMENT == 'production' else 'latest'}"
 
 DEFAULT_ARGS = {
     "depends_on_past": False,
@@ -93,7 +93,7 @@ with DAG(
     cris_import = DockerOperator(
         task_id="run_cris_import",
         docker_conn_id="docker_default",
-        image=docker_image,
+        image=docker_image_cris_import,
         command=f"./cris_import.py --csv --pdf --s3-download --s3-upload --s3-archive --workers 2",
         environment=env_vars,
         auto_remove="force",
@@ -104,11 +104,21 @@ with DAG(
     ocr_crash_narratives = DockerOperator(
         task_id="ocr_crash_narratives",
         docker_conn_id="docker_default",
-        image=docker_image,
+        image=docker_image_cris_import,
         command=f"./cr3_ocr_narrative.py --workers 2",
         environment=env_vars,
         auto_remove="force",
         tty=True,
     )
 
-    cris_import >> ocr_crash_narratives
+    match_ems_to_people = DockerOperator(
+        task_id="match_ems_to_people",
+        docker_conn_id="docker_default",
+        image=docker_image_ems_match,
+        command=f"./match_ems_to_people.py",
+        environment=env_vars,
+        auto_remove="force",
+        tty=True,
+    )
+
+    cris_import >> ocr_crash_narratives >> match_ems_to_people


### PR DESCRIPTION
## Associated issues

Deploys the ETL developed in https://github.com/cityofaustin/atd-data-tech/issues/25004

## Associated repo

- `vision-zero`

## Testing

**Steps to test:**

1. Start your local VZ and apply migrations and metadata
2. Start airflow
3. Edit this DAG by commenting out the task invocation at the bottom of the file so that we only test this new task. If you'd like to test the CRIS import you will need to move an extract zip into the dev s3 bucket

```python
    # cris_import >> ocr_crash_narratives >> match_ems_to_people
    match_ems_to_people
```

4. Trigger the CRIS import DAG. It will take 10 minutes or so to run—feel free to cancel the DAG once you see the log output churning through the backlog


---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
