### PR TITLE
Bump AFD/EMS import DAG from 7:00a to 7:45a 

### DIFF
--- a/dags/vz_afd_ems_import.py
+++ b/dags/vz_afd_ems_import.py
@@ -53,7 +53,7 @@ REQUIRED_SECRETS = {
 @dag(
     dag_id="vz-afd-ems-incident-import",
     description="A DAG which imports EMS and AFD data into the Vision Zero database.",
-    schedule="0 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule="45 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     start_date=datetime(2023, 1, 1, tz="America/Chicago"),
     catchup=False,
     tags=["repo:atd-vz-data", "vision-zero", "ems", "afd", "import"],


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/21712
* [slack discussion](https://austininnovation.slack.com/archives/C013G4RNJ01/p1763384499312479)

We need to bump this ETL to give Xavier time to manually forward the email to SES (until we fix the underlying issue).

## Associated repo

- `vision-zero`



---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
