### PR TITLE
Allow modules to have an `_` as the first letter of their name

### DIFF
--- a/dags/utils/log_parsing.py
+++ b/dags/utils/log_parsing.py
@@ -182,7 +182,7 @@ def _is_exception_line(line):
         return False
 
     # Allow optional lowercase/dotted module path segments before a capitalized class name
-    exception_pattern = r"^(?:[a-z][a-z0-9_]*\.)*[A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning|Timeout)?(?::\s|$)"
+    exception_pattern = r"^(?:[a-z_][a-z0-9_]*\.)*[A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning|Timeout)?(?::\s|$)"
     return re.match(exception_pattern, line) is not None
 
 
@@ -195,7 +195,7 @@ def _parse_exception_line(line):
     # Pattern for optional module path + ExceptionType: message
     # Capture only the bare class name as the type
     match = re.match(
-        r"^(?:[a-z][a-z0-9_]*\.)*([A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning|Timeout)?)\s*:\s*(.*)",
+        r"^(?:[a-z_][a-z0-9_]*\.)*([A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning|Timeout)?)\s*:\s*(.*)",
         line,
     )
     if match:
@@ -203,7 +203,7 @@ def _parse_exception_line(line):
 
     # Pattern for optional module path + just ExceptionType (no colon/message)
     match = re.match(
-        r"^(?:[a-z][a-z0-9_]*\.)*([A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning|Timeout)?)$",
+        r"^(?:[a-z_][a-z0-9_]*\.)*([A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning|Timeout)?)$",
         line,
     )
     if match:


### PR DESCRIPTION
# Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/25653, and please see https://austininnovation.slack.com/archives/CHZE6BC6L/p1763564754514629



# Associated repo

`atd-airflow` itself

# Testing

🤔 I'll return to these testing instructions; I'm not sure what to suggest. Is it just an eyeball review?

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
