### PR TITLE
Add new secrets for work zone data feed DAG

### DIFF
--- a/dags/dts_work_zone_data_feed.py
+++ b/dags/dts_work_zone_data_feed.py
@@ -81,6 +81,19 @@ REQUIRED_SECRETS = {
         "opitem": "Work Zone Data Feed",
         "opfield": "production.contact email",
     },
+    # Coordinate
+    "COORDINATE_USER": {
+        "opitem": "Work Zone Data Feed",
+        "opfield": "coordinate.coordinate username",
+    },
+    "COORDINATE_BASE_URL": {
+        "opitem": "Work Zone Data Feed",
+        "opfield": "coordinate.base url",
+    },
+    "COORDINATE_PASSWORD": {
+        "opitem": "Work Zone Data Feed",
+        "opfield": "coordinate.coordinate password",
+    },
 }
 
 with DAG(

--- a/dags/dts_work_zone_data_feed.py
+++ b/dags/dts_work_zone_data_feed.py
@@ -51,6 +51,10 @@ REQUIRED_SECRETS = {
         "opitem": "Work Zone Data Feed",
         "opfield": "production.flat dataset ID",
     },
+    "SEGMENT_DATASET": {
+        "opitem": "Work Zone Data Feed",
+        "opfield": "production.segment dataset ID",
+    },
     # AMANDA
     "HOST": {
         "opitem": "Amanda Read-Only (RO) replica database",


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/25465

## Associated repo
https://github.com/cityofaustin/dts-work-zone-data-feed/pull/5

## Testing

**Steps to test:**

If you want to test the code I would recommend following the steps [here](https://github.com/cityofaustin/dts-work-zone-data-feed/pull/5). This is just getting the new secrets in the DAG. 

If you want to test these new secrets are being retrieved correctly you can just trigger this DAG locally and check the output of the get_env_vars task is returning something all for of the items. Also check the env_template for names matching.

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
