### PR TITLE
Adjust VZ import timing to kick off at 5:30AM local

### DIFF
--- a/dags/vz_cris_import.py
+++ b/dags/vz_cris_import.py
@@ -84,7 +84,7 @@ with DAG(
     dag_id="vz-cris-import",
     description="Import TxDOT CRIS CSVs and PDFs into the Vision Zero database",
     default_args=DEFAULT_ARGS,
-    schedule="0 5 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule="30 5 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     start_date=datetime(2024, 8, 1, tz="America/Chicago"),
     tags=["vision-zero", "cris", "repo:atd-vz-data"],
 ) as dag:


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/26525

## Associated repo

https://github.com/cityofaustin/vision-zero

## Testing

No testing needed, but please do review the updated cron expression in the diff. Here's it in a cron decoder if it's helpful: [crontab.guru](https://crontab.guru/#30_5_*_*_*)

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
