### PR TITLE
Configure ETL for data collection requests ODP dataset

### DIFF
--- a/dags/atd_knack_data_collection_requests.py
+++ b/dags/atd_knack_data_collection_requests.py
@@ -1,0 +1,95 @@
+from os import getenv
+
+from airflow.models import DAG
+from airflow.operators.docker_operator import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.knack import get_date_filter_arg
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2026, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=30),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "KNACK_APP_ID": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.appId",
+    },
+    "KNACK_API_KEY": {
+        "opitem": "Knack AMD Data Tracker",
+        "opfield": f"production.apiKey",
+    },
+    "SOCRATA_API_KEY_ID": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SOCRATA_API_KEY_SECRET": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SOCRATA_APP_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "PGREST_ENDPOINT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.endpoint",
+    },
+    "PGREST_JWT": {
+        "opitem": "atd-knack-services PostgREST",
+        "opfield": "production.jwt",
+    },
+}
+
+
+with DAG(
+    dag_id="atd_knack_inventory_transactions",
+    description="Updates a socrata dataset of TED traffic count and data collection requests",
+    default_args=DEFAULT_ARGS,
+    schedule_interval="44 22 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:atd-knack-services", "knack", "socrata"],
+    catchup=False,
+) as dag:
+    docker_image = "atddocker/atd-knack-services:production"
+    app_name = "data-tracker"
+    container = "view_4620"
+
+    date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="atd_knack_data_collection_requests_to_postgrest",
+        image=docker_image,
+        docker_conn_id="docker_default",
+        auto_remove="force",
+        command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+    )
+
+    t2 = DockerOperator(
+        task_id="atd_knack_inventory_transactions_to_socrata",
+        image=docker_image,
+        docker_conn_id="docker_default",
+        auto_remove="force",
+        command=f"./atd-knack-services/services/records_to_socrata.py -a {app_name} -c {container} {date_filter_arg}",
+        environment=env_vars,
+        tty=True,
+        mount_tmp_dir=False,
+    )
+
+    date_filter_arg >> t1 >> t2

--- a/dags/atd_knack_data_collection_requests.py
+++ b/dags/atd_knack_data_collection_requests.py
@@ -54,7 +54,7 @@ REQUIRED_SECRETS = {
 
 
 with DAG(
-    dag_id="atd_knack_inventory_transactions",
+    dag_id="atd_knack_data_collection_requests",
     description="Updates a socrata dataset of TED traffic count and data collection requests",
     default_args=DEFAULT_ARGS,
     schedule_interval="44 22 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
@@ -82,7 +82,7 @@ with DAG(
     )
 
     t2 = DockerOperator(
-        task_id="atd_knack_inventory_transactions_to_socrata",
+        task_id="atd_knack_data_collection_requests_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/22497

## Associated repo

https://github.com/cityofaustin/atd-knack-services/pull/152

I pushed up the changes in the knack-services PR to docker hub and used the image tagged `latest`
That will be overwritten when the PR is merged.

## Testing

**Steps to test:**

Change L64 in the dag to use the docker_image tagged as `:latest`

`docker_image = "atddocker/atd-knack-services:latest"`

Kick off the dag. 

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
