### PR TITLE
Integration Day Issues for first V3 DAG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ db/*
 
 .vscode/*
 
+users/

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ _AIRFLOW_WWW_USER_PASSWORD=<Pick your initial admin password here>
 AIRFLOW_PROJ_DIR=<The absolute path of your Airflow repository checkout>
 # this fernet key is for testing purposes only
 _AIRFLOW__CORE__FERNET_KEY=PTkIRwL-c46jgnaohlkkXfVikC-roKa95ipXfqST7JM=
-_AIRFLOW__WEBSERVER__BASE_URL=http://localhost:8080
+_AIRFLOW__API__BASE_URL=http://localhost:8080
 OP_API_TOKEN=<Get from 1Password entry named "TPW DTS API Accessible Secrets 1Password Connect Server Access Token">
 OP_CONNECT=<Get from 1Password entry named "TPW DTS API Accessible Secrets 1Password Connect Server Access Token">
 OP_VAULT_ID=<Get from 1Password entry named "TPW DTS API Accessible Secrets 1Password Connect Server Access Token">

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -146,7 +146,7 @@ def task_fail_slack_alert(context):
     exceptions_text = build_exception_text(all_exceptions)
 
     byline = getattr(dag, "byline", "")
-    icon = getattr(dag, "icon", ":red_circle:")
+    icon = getattr(dag, "icon", ":three:")
 
     # Add deployment environment indication if not production
     env_indicator = ""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,8 @@ x-airflow-common: &airflow-common
     OP_CONNECT: ${OP_CONNECT}
     OP_VAULT_ID: ${OP_VAULT_ID}
     AIRFLOW_CONN_DOCKER_DEFAULT: "docker://${DOCKER_HUB_USERNAME}:${DOCKER_HUB_TOKEN}@https%3A%2F%2Findex.docker.io%2Fv1%2F:80"
+    ENVIRONMENT: ${ENVIRONMENT}
+    AIRFLOW__API__BASE_URL: ${_AIRFLOW__API__BASE_URL:-http://localhost:8080}
 
     # Airflow stock suggested environment variables
     AIRFLOW__CORE__EXECUTOR: LocalExecutor

--- a/toolbox/certbot/renew.sh
+++ b/toolbox/certbot/renew.sh
@@ -5,8 +5,7 @@ echo "$(date '+%Y-%m-%d %H:%M:%S')"
 echo "Renewing the certificates for the Airflow stack"
 
 
-/srv/atd-airflow/toolbox/certbot/renew_domain_with_certbot.sh airflow.austinmobility.io
-/srv/atd-airflow/toolbox/certbot/renew_domain_with_certbot.sh airflow-workers.austinmobility.io
+/srv/atd-airflow/toolbox/certbot/renew_domain_with_certbot.sh airflow-v3.austinmobility.io
 
 cd /srv/atd-airflow
 


### PR DESCRIPTION
# Integration Day Issues

## 🙏 

Thank you to @mddilley for being the first DAG stake holder to jump over to V3 and in doing so he discovered a handful of little integration-day gotchas that are addressed in this PR. You got us rolling.

## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/25197 & Mike amended it with the small fixes that were uncovered today.

This PR does a handful of small things:

* Change the default icon to 3️⃣ for slack alerts
* Fix the link to the task log that failed for slack alerts by adopting a renamed environment variable and also update the `README.md` about it
* Pass the deployment stage designation, `ENVIRONMENT`, into the airflow containers
* Fix the script intended to be `cron`'d to use our v3 FQDN 
* Add `users/` to the .gitignore, something I've been looking to tag-along in a PR for a minute.

## Associated repo

Airflow itself

## Testing

🙈 In order to get stuff fixed and working correctly now that we had a real-deal DAG on V3, I fixed this stuff in-situ. This PR is intended to catch the repo up with what is running in production. 

The upside is that testing is real easy:

* Take a look at [this alert](https://austininnovation.slack.com/archives/C013G4RNJ01/p1773349270802999) and observe the correct URL in the link and the little 3️⃣ as a default icon. 
* Is [Airflow V3](https://airflow-v3.austinmobility.io) running? If yes, ✅ 

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
