### PR TITLE
Migrate one Moped and more Knack services DAGs

### DIFF
--- a/dags/atd_knack_markings_attachments.py
+++ b/dags/atd_knack_markings_attachments.py
@@ -19,8 +19,7 @@ Trigger the DAG again (as long as there is a previous successful run to pick bac
 ## Testing
 **Need VPN access or addition to security group allow list to reach Postgrest**
 
-To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
-
+To insert a previous successful DAG run, see the "Inserting a previous DAG run to resume incremental runs using a look-back window" section in the README
 """
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")

--- a/dags/atd_knack_markings_work_orders_jobs.py
+++ b/dags/atd_knack_markings_work_orders_jobs.py
@@ -17,7 +17,7 @@ Trigger the DAG again (as long as there is a previous successful run to pick bac
 ## Testing
 **Need VPN access or addition to security group allow list to reach Postgrest**
 
-To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
+To insert a previous successful DAG run, see the "Inserting a previous DAG run to resume incremental runs using a look-back window" section in the README
 """
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")

--- a/dags/atd_knack_markings_work_orders_jobs.py
+++ b/dags/atd_knack_markings_work_orders_jobs.py
@@ -1,12 +1,24 @@
 from os import getenv
 
-from airflow.models import DAG
-from airflow.operators.docker_operator import DockerOperator
+from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
+
+doc_md = """
+⚠️ Warning: Running this DAG with no previous run history is not recommended since it will replace thousands of records!
+
+## Troubleshooting
+Trigger the DAG again (as long as there is a previous successful run to pick back up on incremental updates) to address any connection errors or timeouts
+
+## Testing
+**Need VPN access or addition to security group allow list to reach Postgrest**
+
+To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
+"""
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
@@ -66,9 +78,7 @@ with DAG(
     description="Load work orders markings jobs (view_3100) records from Knack to Postgrest to AGOL, Socrata",
     default_args=DEFAULT_ARGS,
     # runs once at 1130a ct and again at 140pm ct
-    schedule_interval=(
-        "40 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
-    ),
+    schedule=("40 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None),
     tags=["repo:atd-knack-services", "knack", "socrata", "agol", "signs-markings"],
     catchup=False,
 ) as dag:

--- a/dags/atd_knack_markings_work_orders_jobs.py
+++ b/dags/atd_knack_markings_work_orders_jobs.py
@@ -76,6 +76,7 @@ REQUIRED_SECRETS = {
 with DAG(
     dag_id="atd_knack_markings_work_orders_jobs",
     description="Load work orders markings jobs (view_3100) records from Knack to Postgrest to AGOL, Socrata",
+    doc_md=doc_md,
     default_args=DEFAULT_ARGS,
     # runs once at 1130a ct and again at 140pm ct
     schedule=("40 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None),

--- a/dags/atd_knack_signs_markings_reimbursements.py
+++ b/dags/atd_knack_signs_markings_reimbursements.py
@@ -17,8 +17,7 @@ Trigger the DAG again (as long as there is a previous successful run to pick bac
 ## Testing
 **Need VPN access or addition to security group allow list to reach Postgrest**
 
-To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
-
+To insert a previous successful DAG run, see the "Inserting a previous DAG run to resume incremental runs using a look-back window" section in the README
 """
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")

--- a/dags/atd_knack_signs_markings_time_logs.py
+++ b/dags/atd_knack_signs_markings_time_logs.py
@@ -17,8 +17,7 @@ Trigger the DAG again (as long as there is a previous successful run to pick bac
 ## Testing
 **Need VPN access or addition to security group allow list to reach Postgrest**
 
-To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
-
+To insert a previous successful DAG run, see the "Inserting a previous DAG run to resume incremental runs using a look-back window" section in the README
 """
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")

--- a/dags/atd_knack_signs_materials.py
+++ b/dags/atd_knack_signs_materials.py
@@ -17,8 +17,7 @@ Trigger the DAG again (as long as there is a previous successful run to pick bac
 ## Testing
 **Need VPN access or addition to security group allow list to reach Postgrest**
 
-To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
-
+To insert a previous successful DAG run, see the "Inserting a previous DAG run to resume incremental runs using a look-back window" section in the README
 """
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")

--- a/dags/atd_knack_signs_work_order_attachments.py
+++ b/dags/atd_knack_signs_work_order_attachments.py
@@ -17,8 +17,7 @@ Trigger the DAG again (as long as there is a previous successful run to pick bac
 ## Testing
 **Need VPN access or addition to security group allow list to reach Postgrest**
 
-To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
-
+To insert a previous successful DAG run, see the "Inserting a previous DAG run to resume incremental runs using a look-back window" section in the README
 """
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")

--- a/dags/atd_knack_signs_work_order_specifications.py
+++ b/dags/atd_knack_signs_work_order_specifications.py
@@ -17,8 +17,7 @@ Trigger the DAG again (as long as there is a previous successful run to pick bac
 ## Testing
 **Need VPN access or addition to security group allow list to reach Postgrest**
 
-To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
-
+To insert a previous successful DAG run, see the "Inserting a previous DAG run to resume incremental runs using a look-back window" section in the README
 """
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")

--- a/dags/atd_knack_signs_work_orders.py
+++ b/dags/atd_knack_signs_work_orders.py
@@ -19,8 +19,7 @@ Trigger the DAG again (as long as there is a previous successful run to pick bac
 ## Testing
 **Need VPN access or addition to security group allow list to reach Postgrest**
 
-To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
-
+To insert a previous successful DAG run, see the "Inserting a previous DAG run to resume incremental runs using a look-back window" section in the README
 """
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")

--- a/dags/atd_knack_work_orders_markings.py
+++ b/dags/atd_knack_work_orders_markings.py
@@ -1,12 +1,24 @@
 from os import getenv
 
-from airflow.models import DAG
-from airflow.operators.docker_operator import DockerOperator
+from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
+
+doc_md = """
+⚠️ Warning: Running this DAG with no previous run history is not recommended since it will replace thousands of records!
+
+## Troubleshooting
+Trigger the DAG again (as long as there is a previous successful run to pick back up on incremental updates) to address any connection errors or timeouts
+
+## Testing
+**Need VPN access or addition to security group allow list to reach Postgrest**
+
+To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
+"""
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
@@ -62,24 +74,24 @@ REQUIRED_SECRETS = {
 
 
 with DAG(
-    dag_id="atd_knack_work_orders_markings_contractors",
-    description="Load markings contractor work orders records from Knack to Postgrest to AGOL, Socrata",
+    dag_id="atd_knack_work_orders_markings",
+    description="Load work orders markings (view_3099) records from Knack to Postgrest to AGOL, Socrata",
     default_args=DEFAULT_ARGS,
     # runs once at 1130a ct and again at 140pm ct
-    schedule_interval="5 2 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule=("30 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None),
     tags=["repo:atd-knack-services", "knack", "socrata", "agol", "signs-markings"],
     catchup=False,
 ) as dag:
     docker_image = "atddocker/atd-knack-services:production"
     app_name = "signs-markings"
-    container = "view_3628"
+    container = "view_3099"
 
     date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperator(
-        task_id="atd_knack_markings_contractor_work_orders_to_postgrest",
+        task_id="atd_knack_markings_work_orders_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
@@ -103,7 +115,7 @@ with DAG(
     )
 
     t3 = DockerOperator(
-        task_id="atd_knack_markings_contractor_work_orders_agol_build_markings_segment_geometries",
+        task_id="atd_knack_markings_work_orders_agol_build_markings_segment_geometries",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
@@ -114,7 +126,7 @@ with DAG(
     )
 
     t4 = DockerOperator(
-        task_id="atd_knack_markings_contractor_work_orders_to_socrata",
+        task_id="atd_knack_markings_work_orders_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",

--- a/dags/atd_knack_work_orders_markings.py
+++ b/dags/atd_knack_work_orders_markings.py
@@ -17,7 +17,7 @@ Trigger the DAG again (as long as there is a previous successful run to pick bac
 ## Testing
 **Need VPN access or addition to security group allow list to reach Postgrest**
 
-To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
+To insert a previous successful DAG run, see the "Inserting a previous DAG run to resume incremental runs using a look-back window" section in the README
 """
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")

--- a/dags/atd_knack_work_orders_markings.py
+++ b/dags/atd_knack_work_orders_markings.py
@@ -76,6 +76,7 @@ REQUIRED_SECRETS = {
 with DAG(
     dag_id="atd_knack_work_orders_markings",
     description="Load work orders markings (view_3099) records from Knack to Postgrest to AGOL, Socrata",
+    doc_md=doc_md,
     default_args=DEFAULT_ARGS,
     # runs once at 1130a ct and again at 140pm ct
     schedule=("30 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None),

--- a/dags/atd_knack_work_orders_markings_contractors.py
+++ b/dags/atd_knack_work_orders_markings_contractors.py
@@ -1,12 +1,24 @@
 from os import getenv
 
-from airflow.models import DAG
-from airflow.operators.docker_operator import DockerOperator
+from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
 from utils.knack import get_date_filter_arg
 from utils.slack_operator import task_fail_slack_alert
+
+doc_md = """
+⚠️ Warning: Running this DAG with no previous run history is not recommended since it will replace thousands of records!
+
+## Troubleshooting
+Trigger the DAG again (as long as there is a previous successful run to pick back up on incremental updates) to address any connection errors or timeouts
+
+## Testing
+**Need VPN access or addition to security group allow list to reach Postgrest**
+
+To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
+"""
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
@@ -62,26 +74,24 @@ REQUIRED_SECRETS = {
 
 
 with DAG(
-    dag_id="atd_knack_work_orders_markings",
-    description="Load work orders markings (view_3099) records from Knack to Postgrest to AGOL, Socrata",
+    dag_id="atd_knack_work_orders_markings_contractors",
+    description="Load markings contractor work orders records from Knack to Postgrest to AGOL, Socrata",
     default_args=DEFAULT_ARGS,
     # runs once at 1130a ct and again at 140pm ct
-    schedule_interval=(
-        "30 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
-    ),
+    schedule="5 2 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-knack-services", "knack", "socrata", "agol", "signs-markings"],
     catchup=False,
 ) as dag:
     docker_image = "atddocker/atd-knack-services:production"
     app_name = "signs-markings"
-    container = "view_3099"
+    container = "view_3628"
 
     date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperator(
-        task_id="atd_knack_markings_work_orders_to_postgrest",
+        task_id="atd_knack_markings_contractor_work_orders_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
@@ -105,7 +115,7 @@ with DAG(
     )
 
     t3 = DockerOperator(
-        task_id="atd_knack_markings_work_orders_agol_build_markings_segment_geometries",
+        task_id="atd_knack_markings_contractor_work_orders_agol_build_markings_segment_geometries",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
@@ -116,7 +126,7 @@ with DAG(
     )
 
     t4 = DockerOperator(
-        task_id="atd_knack_markings_work_orders_to_socrata",
+        task_id="atd_knack_markings_contractor_work_orders_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",

--- a/dags/atd_knack_work_orders_markings_contractors.py
+++ b/dags/atd_knack_work_orders_markings_contractors.py
@@ -17,7 +17,7 @@ Trigger the DAG again (as long as there is a previous successful run to pick bac
 ## Testing
 **Need VPN access or addition to security group allow list to reach Postgrest**
 
-To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
+To insert a previous successful DAG run, see the "Inserting a previous DAG run to resume incremental runs using a look-back window" section in the README
 """
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")

--- a/dags/atd_knack_work_orders_markings_contractors.py
+++ b/dags/atd_knack_work_orders_markings_contractors.py
@@ -76,6 +76,7 @@ REQUIRED_SECRETS = {
 with DAG(
     dag_id="atd_knack_work_orders_markings_contractors",
     description="Load markings contractor work orders records from Knack to Postgrest to AGOL, Socrata",
+    doc_md=doc_md,
     default_args=DEFAULT_ARGS,
     # runs once at 1130a ct and again at 140pm ct
     schedule="5 2 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,

--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -2,10 +2,8 @@
 
 from os import getenv
 
-from airflow.models import DAG
+from airflow.sdk import DAG, task, Param
 from airflow.providers.docker.operators.docker import DockerOperator
-from airflow.decorators import task
-from airflow.models import Param
 from pendulum import datetime, duration, parse
 
 from utils.onepassword import get_env_vars_task

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -17,7 +17,7 @@ doc_md = """
 Trigger the DAG again (as long as there is a previous successful run to pick back up on incremental updates) to address any connection errors or timeouts
 
 ## Testing
-To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
+To insert a previous successful DAG run, see the "Inserting a previous DAG run to resume incremental runs using a look-back window" section in the README
 """
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -56,6 +56,7 @@ REQUIRED_SECRETS = {
 with DAG(
     dag_id="atd_moped_data_tracker_sync",
     description="sync Moped project data to Knack Data Tracker projects table",
+    doc_md=doc_md,
     default_args=DEFAULT_ARGS,
     schedule="0 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=30),

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -2,7 +2,7 @@
 
 from os import getenv
 
-from airflow.models import DAG
+from airflow.sdk import DAG
 from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 
@@ -11,7 +11,7 @@ from utils.slack_operator import task_fail_slack_alert
 from utils.knack import get_date_filter_arg
 
 doc_md = """
-⚠️ Warning: Running this DAG with no previous run history is not recommended since it will process many of records!
+⚠️ Warning: Running this DAG with no previous run history is not recommended since it will process many records!
 
 ## Troubleshooting
 Trigger the DAG again (as long as there is a previous successful run to pick back up on incremental updates) to address any connection errors or timeouts

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -3,12 +3,22 @@
 from os import getenv
 
 from airflow.models import DAG
-from airflow.operators.docker_operator import DockerOperator
+from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 from utils.knack import get_date_filter_arg
+
+doc_md = """
+⚠️ Warning: Running this DAG with no previous run history is not recommended since it will process many of records!
+
+## Troubleshooting
+Trigger the DAG again (as long as there is a previous successful run to pick back up on incremental updates) to address any connection errors or timeouts
+
+## Testing
+To insert a previous successful DAG run, see [README](./README.md#inserting-a-previous-dag-run-to-resume-incremental-runs-using-a-look-back-window)
+"""
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
@@ -47,7 +57,7 @@ with DAG(
     dag_id="atd_moped_data_tracker_sync",
     description="sync Moped project data to Knack Data Tracker projects table",
     default_args=DEFAULT_ARGS,
-    schedule_interval="0 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule="0 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=30),
     tags=["repo:atd-moped", "moped", "data-tracker", "knack"],
     catchup=False,


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/25457

Moves:
- atd_moped_data_tracker_sync
- atd_knack_work_orders_markings
- atd_knack_work_orders_markings_contractors
- atd_knack_markings_work_orders_jobs

## Associated repo

## Testing

**Steps to test:**
1. Start the local Airflow v3 stack and connect to the VPN which you need to be on to reach the Postgrest endpoint 
2. Get into a psql shell in the Airflow v3 container
```shell
docker compose exec --user airflow airflow-dag-processor airflow db shell;
```
3. Run the following statement on the Airflow v3 DB to backfill successful run dates for the DAGs that I migrated in this PR:
```sql
-- Insert successful DAG runs by ids that completed one hour ago
-- We probably can remove some of the columns in this insert but this works well enough
INSERT INTO dag_run (
  dag_id,
  run_id,
  logical_date,
  data_interval_start,
  data_interval_end,
  run_after,
  queued_at,
  start_date,
  end_date,
  state,
  run_type,
  triggered_by,
  triggering_user_name,
  conf,
  context_carrier,
  span_status
)
SELECT
  dag_id,
  'manual__' || to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"+00:00"'),
  (now() AT TIME ZONE 'UTC') - interval '1 hour',
  (now() AT TIME ZONE 'UTC') - interval '1 hour',
  (now() AT TIME ZONE 'UTC') - interval '1 hour',
  (now() AT TIME ZONE 'UTC') - interval '1 hour',
  (now() AT TIME ZONE 'UTC'),
  (now() AT TIME ZONE 'UTC') - interval '1 hour',
  (now() AT TIME ZONE 'UTC') - interval '1 hour',
  'success',
  'manual',
  'UI',
  'admin',
  '{}'::jsonb,
  '{"__var": {}, "__type": "dict"}'::jsonb,
  'ended'
FROM unnest(ARRAY[
  'atd_moped_data_tracker_sync',
  'atd_knack_work_orders_markings',
  'atd_knack_work_orders_markings_contractors',
  'atd_knack_markings_work_orders_jobs'
]) AS dag_id;
```
4. Go to http://localhost:8080/dag_runs and you should see the top 4 most recent dag runs match the 4 DAG ids in the insert statement and are all marked as successful
5. Go through the list of DAGs above and you can test one by one by manually triggering them in the Airflow dashboard

---

#### Ship list

- [x] Code reviewed
- [x] Product manager approved
- ~[ ] Add note to 1PW secrets moved to API vault and check for duplicates~
