### PR TITLE
add PYTHONPATH environment variable to docker-compose for Airflow

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ x-airflow-common: &airflow-common
     AIRFLOW__API__BASE_URL: ${_AIRFLOW__API__BASE_URL:-http://localhost:8080}
 
     # Airflow stock suggested environment variables
+    PYTHONPATH: /opt/airflow/dags
     AIRFLOW__CORE__EXECUTOR: LocalExecutor
     AIRFLOW__CORE__AUTH_MANAGER: airflow.providers.fab.auth_manager.fab_auth_manager.FabAuthManager
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow


### PR DESCRIPTION
## Intent

This pull request makes a minor update to the Airflow service configuration in `docker-compose.yaml` by setting the `PYTHONPATH` environment variable to `/opt/airflow/dags`. This change ensures that custom Python modules in the `dags` directory can be imported by Airflow tasks.

## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/27358

## Associated repo

Airflow itself

## Testing

Spin up airflow locally and try something like this to kick off a DAG. This one is safe to run under any circumstances.

```
docker compose run --rm airflow-cli dags test log_last_run_time_development
```
## H/T 

Thank you @mddilley -- your instructions in the issue were just exactly the correct fix. I resized the issue down to a 1 from a 2. 

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
