### PR TITLE
Updating some docs and fixing imports

### DIFF
--- a/dags/atd_knack_artbox_signals.py
+++ b/dags/atd_knack_artbox_signals.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.models import DAG
+from airflow.sdk import DAG
 from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -7,6 +7,16 @@ from pendulum import datetime, duration
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert, slack_member_ids
 
+doc_md="""
+## Troubleshooting
+
+The most common error is when a new record is being added to the HR app but it is duplicating an existing email address.
+
+
+This can happen if an employee is rehired and they are issued a new employee ID or if a person with the same name as a previous employee is given the duplicate email address.
+For whatever reason, the recourse is to contact Diana to triage, contact TPW HR, then ammend records in Knack.
+"""
+
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
@@ -43,7 +53,8 @@ REQUIRED_SECRETS = {
 
 with DAG(
     dag_id=f"atd_knack_banner",
-    description="Update knack HR app based on records in Banner and CTM",
+    description="Update knack HR app based on records in Banner",
+    doc_md=doc_md,
     default_args=DEFAULT_ARGS,
     schedule="45 7 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     dagrun_timeout=duration(minutes=30),

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.models import DAG
+from airflow.sdk import DAG
 from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 

--- a/dags/atd_knack_data_collection_requests.py
+++ b/dags/atd_knack_data_collection_requests.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.models import DAG
+from airflow.sdk import DAG
 from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 

--- a/dags/atd_knack_dms.py
+++ b/dags/atd_knack_dms.py
@@ -2,7 +2,7 @@
 
 from os import getenv
 
-from airflow.models import DAG
+from airflow.sdk import DAG
 from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 

--- a/dags/atd_knack_markings_materials.py
+++ b/dags/atd_knack_markings_materials.py
@@ -1,7 +1,7 @@
 from os import getenv
 
-from airflow.models import DAG
-from airflow.operators.docker_operator import DockerOperator
+from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -50,26 +50,23 @@ REQUIRED_SECRETS = {
 
 
 with DAG(
-    dag_id="atd_knack_markings_specifications",
-    description="Loads markings specifications records from Knack to Postgrest to AGOL",
+    dag_id="atd_knack_markings_materials",
+    description="Loads markings materials records from Knack to Postgrest to AGOL",
     default_args=DEFAULT_ARGS,
-    # runs once at 1130a ct and again at 140pm ct
-    schedule_interval=(
-        "50 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
-    ),
+    schedule=("10 12,14 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None),
     tags=["repo:atd-knack-services", "knack", "agol", "signs-markings"],
     catchup=False,
 ) as dag:
     docker_image = "atddocker/atd-knack-services:production"
     app_name = "signs-markings"
-    container = "view_3103"
+    container = "view_3104"
 
     date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperator(
-        task_id="atd_knack_markings_specifications_to_postgrest",
+        task_id="atd_knack_markings_materials_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
@@ -81,14 +78,14 @@ with DAG(
     )
 
     t2 = DockerOperator(
-        task_id="atd_knack_markings_specifications_to_agol",
+        task_id="atd_knack_markings_materials_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
         command=f"./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
+        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_markings_specifications.py
+++ b/dags/atd_knack_markings_specifications.py
@@ -1,7 +1,7 @@
 from os import getenv
 
-from airflow.models import DAG
-from airflow.operators.docker_operator import DockerOperator
+from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -50,25 +50,24 @@ REQUIRED_SECRETS = {
 
 
 with DAG(
-    dag_id="atd_knack_markings_materials",
-    description="Loads markings materials records from Knack to Postgrest to AGOL",
+    dag_id="atd_knack_markings_specifications",
+    description="Loads markings specifications records from Knack to Postgrest to AGOL",
     default_args=DEFAULT_ARGS,
-    schedule_interval=(
-        "10 12,14 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None
-    ),
+    # runs once at 1150a ct and again at 150pm ct
+    schedule=("50 11,13 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None),
     tags=["repo:atd-knack-services", "knack", "agol", "signs-markings"],
     catchup=False,
 ) as dag:
     docker_image = "atddocker/atd-knack-services:production"
     app_name = "signs-markings"
-    container = "view_3104"
+    container = "view_3103"
 
     date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperator(
-        task_id="atd_knack_markings_materials_to_postgrest",
+        task_id="atd_knack_markings_specifications_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
@@ -80,14 +79,14 @@ with DAG(
     )
 
     t2 = DockerOperator(
-        task_id="atd_knack_markings_materials_to_agol",
+        task_id="atd_knack_markings_specifications_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
         command=f"./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
+        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_school_beacons.py
+++ b/dags/atd_knack_school_beacons.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.models import DAG
+from airflow.sdk import DAG
 from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 

--- a/dags/atd_knack_school_zone_beacon_zones.py
+++ b/dags/atd_knack_school_zone_beacon_zones.py
@@ -1,7 +1,7 @@
 from os import getenv
 
-from airflow.models import DAG
-from airflow.operators.docker_operator import DockerOperator
+from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -56,7 +56,7 @@ with DAG(
     dag_id="atd_knack_school_zone_beacon_zones",
     description="Load school zone beacon zones (view_4027) records from Knack to Postgrest to Socrata",
     default_args=DEFAULT_ARGS,
-    schedule_interval="25 5 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule="25 5 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-knack-services", "knack", "data-tracker", "socrata"],
     catchup=False,
 ) as dag:

--- a/dags/atd_knack_signal_cabinets.py
+++ b/dags/atd_knack_signal_cabinets.py
@@ -1,7 +1,7 @@
 from os import getenv
 
-from airflow.models import DAG
-from airflow.operators.docker_operator import DockerOperator
+from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -65,7 +65,7 @@ with DAG(
     dag_id="atd_knack_signal_cabinets",
     description="Load signal cabinets (view_1567) records from Knack to Postgrest to AGOL and Socrata",
     default_args=DEFAULT_ARGS,
-    schedule_interval="30 3 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule="30 3 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-knack-services", "knack", "socrata", "agol", "data-tracker"],
     catchup=False,
 ) as dag:

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -1,8 +1,7 @@
 from os import getenv
 from pendulum import datetime, duration
 
-from airflow.decorators import task
-from airflow.models import DAG
+from airflow.sdk import DAG
 from airflow.providers.docker.operators.docker import DockerOperator
 
 from utils.slack_operator import task_fail_slack_alert
@@ -59,4 +58,5 @@ with DAG(
         environment=env_vars,
         tty=True,
         force_pull=True,
+        mount_tmp_dir=False,
     )

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -8,7 +8,7 @@ from utils.slack_operator import task_fail_slack_alert
 from utils.onepassword import get_env_vars_task
 
 doc_md = """
-Issues labled 'Project Index' are updated in the Knack DTS Portal.
+Issues labeled 'Project Index' are updated in the Knack DTS Portal.
 
 
 These issues' evaluations are then referenced on the DTS website (austinmobility.io)

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -10,8 +10,8 @@ from utils.onepassword import get_env_vars_task
 doc_md = """
 Issues labled 'Project Index' are updated in the Knack DTS Portal.
 
-These issues' evaluations are then referenced on the DTS website (austinmobility.io)
 
+These issues' evaluations are then referenced on the DTS website (austinmobility.io)
 """
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
@@ -48,6 +48,7 @@ REQUIRED_SECRETS = {
 with DAG(
     dag_id=f"atd_service_bot_issues_to_dts_portal_{DEPLOYMENT_ENVIRONMENT}",
     default_args=DEFAULT_ARGS,
+    doc_md=doc_md,
     schedule="0 5 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-service-bot", "knack", "github"],
     catchup=False,

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -7,11 +7,18 @@ from airflow.providers.docker.operators.docker import DockerOperator
 from utils.slack_operator import task_fail_slack_alert
 from utils.onepassword import get_env_vars_task
 
+doc_md = """
+Issues labled 'Project Index' are updated in the Knack DTS Portal.
+
+These issues' evaluations are then referenced on the DTS website (austinmobility.io)
+
+"""
+
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
-    "description": "Create/update 'Index' issues in the DTS portal from Github.",
+    "description": "Create/update 'Project Index' issues in the Knack DTS portal from Github.",
     "depends_on_past": False,
     "start_date": datetime(2015, 12, 1, tz="America/Chicago"),
     "email_on_failure": False,

--- a/dags/atd_service_bot_intake.py
+++ b/dags/atd_service_bot_intake.py
@@ -12,7 +12,7 @@ DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 DEFAULT_ARGS = {
     "owner": "airflow",
-    "description": "Fetch new DTS service requests and create Github issues",
+    "description": "Fetch new DTS service requests from Knack DTS Portal and create Github issues",
     "depends_on_past": False,
     "start_date": datetime(2015, 12, 1, tz="America/Chicago"),
     "email_on_failure": False,

--- a/dags/atd_service_bot_intake.py
+++ b/dags/atd_service_bot_intake.py
@@ -1,8 +1,7 @@
 from os import getenv
 from pendulum import datetime, duration
 
-from airflow.decorators import task
-from airflow.models import DAG
+from airflow.sdk import DAG
 from airflow.providers.docker.operators.docker import DockerOperator
 
 from utils.slack_operator import task_fail_slack_alert

--- a/dags/atd_service_bot_intake.py
+++ b/dags/atd_service_bot_intake.py
@@ -67,4 +67,5 @@ with DAG(
         environment=env_vars,
         tty=True,
         force_pull=True,
+        mount_tmp_dir=False,
     )

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -7,6 +7,11 @@ from airflow.providers.docker.operators.docker import DockerOperator
 from utils.slack_operator import task_fail_slack_alert
 from utils.onepassword import get_env_vars_task
 
+doc_md="""
+Publishes issues from the atd-data-tech github repository to the open data portal: https://data.austintexas.gov/resource/rzwg-fyv8.json
+
+The DTS team site (austinmobility.io) uses the open data portal dataset, if you want to update the issues on the team site with the latest issues from github, trigger this dag.
+"""
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
@@ -54,6 +59,7 @@ REQUIRED_SECRETS = {
 
 with DAG(
     dag_id=f"atd_service_bot_github_to_socrata_{DEPLOYMENT_ENVIRONMENT}",
+    doc_md=doc_md,
     default_args=DEFAULT_ARGS,
     schedule="0 22 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-service-bot", "socrata", "github"],

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -72,4 +72,5 @@ with DAG(
         environment=env_vars,
         tty=True,
         force_pull=True,
+        mount_tmp_dir=False,
     )

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -10,7 +10,7 @@ from utils.onepassword import get_env_vars_task
 doc_md="""
 Publishes issues from the atd-data-tech github repository to the open data portal: https://data.austintexas.gov/resource/rzwg-fyv8.json
 
-
+---
 The DTS team site (austinmobility.io) uses the open data portal dataset, if you want to update the issues on the team site with the latest issues from github, trigger this dag.
 """
 
@@ -62,7 +62,7 @@ with DAG(
     dag_id=f"atd_service_bot_github_to_socrata_{DEPLOYMENT_ENVIRONMENT}",
     doc_md=doc_md,
     default_args=DEFAULT_ARGS,
-    schedule="0 22 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule="0 22 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-service-bot", "socrata", "github"],
     catchup=False,
 ) as dag:

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -1,8 +1,7 @@
 from os import getenv
 from pendulum import datetime, duration
 
-from airflow.decorators import task
-from airflow.models import DAG
+from airflow.sdk import DAG
 from airflow.providers.docker.operators.docker import DockerOperator
 
 from utils.slack_operator import task_fail_slack_alert

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -8,7 +8,7 @@ from utils.slack_operator import task_fail_slack_alert
 from utils.onepassword import get_env_vars_task
 
 doc_md="""
-Publishes issues from the atd-data-tech github repository to the open data portal: https://data.austintexas.gov/resource/rzwg-fyv8.json
+Publishes issues from the atd-data-tech github repository to the open data portal: https://data.austintexas.gov/d/rzwg-fyv8
 
 ---
 The DTS team site (austinmobility.io) uses the open data portal dataset, if you want to update the issues on the team site with the latest issues from github, trigger this dag.

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -10,6 +10,7 @@ from utils.onepassword import get_env_vars_task
 doc_md="""
 Publishes issues from the atd-data-tech github repository to the open data portal: https://data.austintexas.gov/resource/rzwg-fyv8.json
 
+
 The DTS team site (austinmobility.io) uses the open data portal dataset, if you want to update the issues on the team site with the latest issues from github, trigger this dag.
 """
 


### PR DESCRIPTION
I neglected to update the imports on a number of my dags, fixing that here. 

Moving over `atd_knack_school_zone_beacon_zones.py`
`atd_knack_signal_cabinets`
`atd_knack_markings_specifications`
`atd_knack_markings_materials`

I also added some docs to the service bot PRs and passed in `mount_tmp_dir` False because that was flagged in the logs. 

## Testing


The knack ones are fine to run, since there is no date supplied it will run with today's date. 


#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
