### PR TITLE
Add test DAG and DockerOperatorWithFallback class

### DIFF
--- a/dags/test_docker_operator_wrapper.py
+++ b/dags/test_docker_operator_wrapper.py
@@ -29,6 +29,7 @@ def test_docker_operator_wrapper():
         auto_remove="force",
         tty=True,
         mount_tmp_dir=False,
+        force_pull=True,
     )
 
 

--- a/dags/test_docker_operator_wrapper.py
+++ b/dags/test_docker_operator_wrapper.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pendulum
+
+from airflow.sdk import dag
+
+from utils.docker_operator import DockerOperatorWithFallback
+
+
+@dag(
+    dag_id="test_docker_operator_wrapper",
+    schedule=None,
+    start_date=pendulum.datetime(2015, 1, 1, tz="America/Chicago"),
+    catchup=False,
+    tags=["repo:atd-airflow"],
+    default_args={
+        "owner": "airflow",
+        "retries": 0,
+        "execution_timeout": pendulum.duration(minutes=5),
+    },
+    doc_md="Hello world DAG using DockerOperatorWithFallback with the python3 image",
+)
+def test_docker_operator_wrapper():
+    DockerOperatorWithFallback(
+        task_id="hello_world",
+        image="python:3",
+        command=["python3", "-c", "print('hello world')"],
+        docker_conn_id="docker_default",
+        auto_remove="force",
+        tty=True,
+        mount_tmp_dir=False,
+    )
+
+
+test_docker_operator_wrapper()

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from airflow.providers.docker.operators.docker import DockerOperator
+
+
+class DockerOperatorWithFallback(DockerOperator):
+    """DockerOperator that attempts a force pull but falls back to a local image on failure."""
+
+    def execute(self, context):
+        self.log.info("Attempting to pull image %s", self.image)
+        try:
+            for output in self.cli.pull(self.image, stream=True, decode=True):
+                if isinstance(output, dict) and "status" in output:
+                    self.log.info("%s", output.get("status", ""))
+        except Exception as e:
+            self.log.warning(
+                "Could not pull image %s (%s). Using local image if available.",
+                self.image,
+                e,
+            )
+        return self._run_image()

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -7,15 +7,18 @@ class DockerOperatorWithFallback(DockerOperator):
     """DockerOperator that attempts a force pull but falls back to a local image on failure."""
 
     def execute(self, context):
+        original_force_pull = getattr(self, "force_pull", False)
         self.log.info("Attempting to pull image %s", self.image)
         try:
-            for output in self.cli.pull(self.image, stream=True, decode=True):
-                if isinstance(output, dict) and "status" in output:
-                    self.log.info("%s", output.get("status", ""))
+            self.force_pull = True
+            return super().execute(context)
         except Exception as e:
             self.log.warning(
                 "Could not pull image %s (%s). Using local image if available.",
                 self.image,
                 e,
             )
-        return self._run_image()
+            self.force_pull = False
+            return super().execute(context)
+        finally:
+            self.force_pull = original_force_pull

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -110,9 +110,11 @@ class DockerOperatorWithFallback(DockerOperator):
 
         self._require_run_image()
 
-        # Base DockerOperator would also pull inside _run_image when force_pull=True.
-        # We handle pull behavior here to provide fallback semantics and avoid a second pull.
-        should_pull = bool(self.force_pull)
+        # Upstream DockerOperator.execute() pulls when force_pull=True (or image is
+        # missing locally), then calls _run_image(). _run_image() itself does not read
+        # force_pull. We handle pull here to add fallback semantics, then call
+        # _run_image() directly instead of super().execute() to avoid a second pull.
+        should_pull = bool(self.force_pull or not self.cli.images(name=self.image))
 
         if should_pull:
             self.log.info("Attempting to pull image %s", self.image)
@@ -135,6 +137,9 @@ class DockerOperatorWithFallback(DockerOperator):
                 self.image,
             )
 
+        # Start the container via upstream _run_image(). Clear force_pull first as a
+        # guard: current providers only honor it in execute(), but this prevents an
+        # accidental double-pull if that logic ever moves or we delegate to super().
         original_force_pull = self.force_pull
         try:
             self.force_pull = False

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -44,8 +44,8 @@ class _DockerHookWithLoginFallback(DockerHook):
 
 class DockerOperatorWithFallback(DockerOperator):
     """
-    DockerOperator that attempts a force pull but falls back to a local image on failure.
-    All other functionality is the same as DockerOperator, `force_pull` is ignored.
+    DockerOperator that can force pull with fallback to local image on pull failures.
+    All other functionality is the same as DockerOperator.
     """
 
     _RUN_IMAGE_METHOD = "_run_image"
@@ -109,21 +109,38 @@ class DockerOperatorWithFallback(DockerOperator):
         """
 
         self._require_run_image()
-        self.log.info("Attempting to pull image %s", self.image)
-        try:
-            for output in self.cli.pull(self.image, stream=True, decode=True):
-                if isinstance(output, dict) and "status" in output:
-                    self.log.info("%s", output.get("status", ""))
-        except Exception as e:
-            if not self._should_fallback_to_local_image(e):
-                raise
 
-            self.log.warning(
-                "Could not pull image %s (%s). Using local image if available.",
+        # Base DockerOperator would also pull inside _run_image when force_pull=True.
+        # We handle pull behavior here to provide fallback semantics and avoid a second pull.
+        should_pull = bool(self.force_pull)
+
+        if should_pull:
+            self.log.info("Attempting to pull image %s", self.image)
+            try:
+                for output in self.cli.pull(self.image, stream=True, decode=True):
+                    if isinstance(output, dict) and "status" in output:
+                        self.log.info("%s", output.get("status", ""))
+            except Exception as e:
+                if not self._should_fallback_to_local_image(e):
+                    raise
+
+                self.log.warning(
+                    "Could not pull image %s (%s). Using local image if available.",
+                    self.image,
+                    e,
+                )
+        else:
+            self.log.info(
+                "Skipping image pull for %s because force_pull is disabled.",
                 self.image,
-                e,
             )
-        return self._run_image()
+
+        original_force_pull = self.force_pull
+        try:
+            self.force_pull = False
+            return self._run_image()
+        finally:
+            self.force_pull = original_force_pull
 
 
 DockerOperatorWithFallback._require_run_image()

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -7,18 +7,15 @@ class DockerOperatorWithFallback(DockerOperator):
     """DockerOperator that attempts a force pull but falls back to a local image on failure."""
 
     def execute(self, context):
-        original_force_pull = getattr(self, "force_pull", False)
         self.log.info("Attempting to pull image %s", self.image)
         try:
-            self.force_pull = True
-            return super().execute(context)
+            for output in self.cli.pull(self.image, stream=True, decode=True):
+                if isinstance(output, dict) and "status" in output:
+                    self.log.info("%s", output.get("status", ""))
         except Exception as e:
             self.log.warning(
                 "Could not pull image %s (%s). Using local image if available.",
                 self.image,
                 e,
             )
-            self.force_pull = False
-            return super().execute(context)
-        finally:
-            self.force_pull = original_force_pull
+        return self._run_image()

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -33,7 +33,10 @@ class _DockerHookWithLoginFallback(DockerHook):
 
 
 class DockerOperatorWithFallback(DockerOperator):
-    """DockerOperator that attempts a force pull but falls back to a local image on failure."""
+    """
+    DockerOperator that attempts a force pull but falls back to a local image on failure.
+    All other functionality is the same as DockerOperator, `force_pull` is ignored.
+    """
 
     @cached_property
     def hook(self) -> _DockerHookWithLoginFallback:

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -48,6 +48,19 @@ class DockerOperatorWithFallback(DockerOperator):
     All other functionality is the same as DockerOperator, `force_pull` is ignored.
     """
 
+    _RUN_IMAGE_METHOD = "_run_image"
+
+    @classmethod
+    def _require_run_image(cls):
+        method = getattr(DockerOperator, cls._RUN_IMAGE_METHOD, None)
+        if not callable(method):
+            raise RuntimeError(
+                "Docker provider internals changed: "
+                f"`DockerOperator.{cls._RUN_IMAGE_METHOD}` is missing or not callable. "
+                "Update DockerOperatorWithFallback to match the provider implementation."
+            )
+        return method
+
     @staticmethod
     def _extract_status_code(exc: Exception):
         status_code = getattr(exc, "status_code", None)
@@ -95,6 +108,7 @@ class DockerOperatorWithFallback(DockerOperator):
         Original Method: https://github.com/apache/airflow/blob/dc939331f4cd90892fd201931c466dffff977a4f/providers/docker/src/airflow/providers/docker/operators/docker.py#L487
         """
 
+        self._require_run_image()
         self.log.info("Attempting to pull image %s", self.image)
         try:
             for output in self.cli.pull(self.image, stream=True, decode=True):
@@ -110,3 +124,6 @@ class DockerOperatorWithFallback(DockerOperator):
                 e,
             )
         return self._run_image()
+
+
+DockerOperatorWithFallback._require_run_image()

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -40,6 +40,10 @@ class DockerOperatorWithFallback(DockerOperator):
 
     @cached_property
     def hook(self) -> _DockerHookWithLoginFallback:
+        """
+        Original Method:https://github.com/apache/airflow/blob/dc939331f4cd90892fd201931c466dffff977a4f/providers/docker/src/airflow/providers/docker/operators/docker.py#L343
+        """
+        
         tls_config = DockerHook.construct_tls_config(
             ca_cert=self.tls_ca_cert,
             client_cert=self.tls_client_cert,
@@ -57,6 +61,10 @@ class DockerOperatorWithFallback(DockerOperator):
         )
 
     def execute(self, context):
+        """
+        Original Method: https://github.com/apache/airflow/blob/dc939331f4cd90892fd201931c466dffff977a4f/providers/docker/src/airflow/providers/docker/operators/docker.py#L487
+        """
+
         self.log.info("Attempting to pull image %s", self.image)
         try:
             for output in self.cli.pull(self.image, stream=True, decode=True):

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -9,9 +9,23 @@ from airflow.providers.docker.operators.docker import DockerOperator
 class _DockerHookWithLoginFallback(DockerHook):
     """DockerHook that warns instead of raising when registry login fails."""
 
+    _BASE_LOGIN_METHOD = "_DockerHook__login"
+
+    @classmethod
+    def _require_base_login_method(cls):
+        method = getattr(DockerHook, cls._BASE_LOGIN_METHOD, None)
+        if not callable(method):
+            raise RuntimeError(
+                "Docker provider internals changed: "
+                f"`DockerHook.{cls._BASE_LOGIN_METHOD}` is missing or not callable. "
+                "Update _DockerHookWithLoginFallback to match the provider implementation."
+            )
+        return method
+
     def _DockerHook__login(self, client, conn):
+        base_login = self._require_base_login_method()
         try:
-            DockerHook._DockerHook__login(self, client, conn)
+            base_login(self, client, conn)
         except Exception as e:
             self.log.warning(
                 "Registry login failed (%s). Proceeding without authentication.", e

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -1,10 +1,43 @@
 from __future__ import annotations
 
+from functools import cached_property
+
+from airflow.providers.docker.hooks.docker import DockerHook
 from airflow.providers.docker.operators.docker import DockerOperator
+
+
+class _DockerHookWithLoginFallback(DockerHook):
+    """DockerHook that warns instead of raising when registry login fails."""
+
+    def _DockerHook__login(self, client, conn):
+        try:
+            DockerHook._DockerHook__login(self, client, conn)
+        except Exception as e:
+            self.log.warning(
+                "Registry login failed (%s). Proceeding without authentication.", e
+            )
 
 
 class DockerOperatorWithFallback(DockerOperator):
     """DockerOperator that attempts a force pull but falls back to a local image on failure."""
+
+    @cached_property
+    def hook(self) -> _DockerHookWithLoginFallback:
+        tls_config = DockerHook.construct_tls_config(
+            ca_cert=self.tls_ca_cert,
+            client_cert=self.tls_client_cert,
+            client_key=self.tls_client_key,
+            verify=self.tls_verify,
+            assert_hostname=self.tls_hostname,
+            ssl_version=self.tls_ssl_version,
+        )
+        return _DockerHookWithLoginFallback(
+            docker_conn_id=self.docker_conn_id,
+            base_url=self.docker_url,
+            version=self.api_version,
+            tls=tls_config,
+            timeout=self.timeout,
+        )
 
     def execute(self, context):
         self.log.info("Attempting to pull image %s", self.image)

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -48,6 +48,39 @@ class DockerOperatorWithFallback(DockerOperator):
     All other functionality is the same as DockerOperator, `force_pull` is ignored.
     """
 
+    @staticmethod
+    def _extract_status_code(exc: Exception):
+        status_code = getattr(exc, "status_code", None)
+        if status_code is not None:
+            return status_code
+
+        response = getattr(exc, "response", None)
+        return getattr(response, "status_code", None)
+
+    @classmethod
+    def _should_fallback_to_local_image(cls, exc: Exception) -> bool:
+        status_code = cls._extract_status_code(exc)
+        if isinstance(status_code, int):
+            return 500 <= status_code < 600
+
+        if isinstance(exc, (TimeoutError, ConnectionError)):
+            return True
+
+        transient_error_names = {
+            "ConnectTimeout",
+            "ConnectionError",
+            "MaxRetryError",
+            "ProtocolError",
+            "ReadTimeout",
+            "Timeout",
+        }
+        current = exc
+        while current is not None:
+            if current.__class__.__name__ in transient_error_names:
+                return True
+            current = current.__cause__ or current.__context__
+        return False
+
     @cached_property
     def hook(self) -> _DockerHookWithLoginFallback:
         """
@@ -81,6 +114,9 @@ class DockerOperatorWithFallback(DockerOperator):
                 if isinstance(output, dict) and "status" in output:
                     self.log.info("%s", output.get("status", ""))
         except Exception as e:
+            if not self._should_fallback_to_local_image(e):
+                raise
+
             self.log.warning(
                 "Could not pull image %s (%s). Using local image if available.",
                 self.image,

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -27,8 +27,18 @@ class _DockerHookWithLoginFallback(DockerHook):
         try:
             base_login(self, client, conn)
         except Exception as e:
+            status_code = getattr(e, "status_code", None)
+            if status_code is None:
+                response = getattr(e, "response", None)
+                status_code = getattr(response, "status_code", None)
+
+            if not isinstance(status_code, int) or status_code < 500 or status_code >= 600:
+                raise
+
             self.log.warning(
-                "Registry login failed (%s). Proceeding without authentication.", e
+                "Registry login failed with server error %s (%s). Proceeding without authentication.",
+                status_code,
+                e,
             )
 
 

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -66,19 +66,6 @@ class DockerOperatorWithFallback(DockerOperator):
         if isinstance(exc, (TimeoutError, ConnectionError)):
             return True
 
-        transient_error_names = {
-            "ConnectTimeout",
-            "ConnectionError",
-            "MaxRetryError",
-            "ProtocolError",
-            "ReadTimeout",
-            "Timeout",
-        }
-        current = exc
-        while current is not None:
-            if current.__class__.__name__ in transient_error_names:
-                return True
-            current = current.__cause__ or current.__context__
         return False
 
     @cached_property

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -127,10 +127,8 @@ services:
     healthcheck:
       # We run our stack as root, so we need to use gosu to run the airflow jobs check command as the airflow user.
       test:
-        [
-          "CMD-SHELL",
-          'gosu airflow airflow jobs check --job-type DagProcessorJob --hostname "$${HOSTNAME}"',
-        ]
+        - CMD-SHELL
+        - 'gosu airflow airflow jobs check --job-type DagProcessorJob --hostname "$${HOSTNAME}"'
       interval: 30s
       timeout: 10s
       retries: 5
@@ -147,10 +145,8 @@ services:
     healthcheck:
       # We run our stack as root, so we need to use gosu to run the airflow jobs check command as the airflow user.
       test:
-        [
-          "CMD-SHELL",
-          'gosu airflow airflow jobs check --job-type TriggererJob --hostname "$${HOSTNAME}"',
-        ]
+        - CMD-SHELL
+        - 'gosu airflow airflow jobs check --job-type TriggererJob --hostname "$${HOSTNAME}"'
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Note

This PR contains just the enhanced Docker Operator. A PR merges all the DAG refactoring into this, found in #342.

Introduce a new DAG 'test_docker_operator_wrapper' that utilizes the DockerOperatorWithFallback class. This class attempts to pull a Docker image and falls back to a local image if the pull fails. The new files enhance the Airflow setup for testing related Docker operations with a new test fixture.

## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/25196

## Associated repo

Airflow itself

## Testing

Spin up the stack and kick off the test DAG in this PR. 

---

#### Ship list

- [x] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
