### PR TITLE
Refactor DAGs to use DockerOperatorWithFallback

### DIFF
--- a/dags/atd_cost_of_service_fees.py
+++ b/dags/atd_cost_of_service_fees.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -81,7 +81,6 @@ def atd_cost_of_service_fees():
         environment=env_vars,
         tty=True,
         docker_conn_id="docker_default",
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_cost_of_service_fees.py
+++ b/dags/atd_cost_of_service_fees.py
@@ -72,7 +72,7 @@ def atd_cost_of_service_fees():
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    load_fees_to_knack = DockerOperator(
+    load_fees_to_knack = DockerOperatorWithFallback(
         task_id="atd_cost_of_service_fees_to_knack",
         image="atddocker/atd-cost-of-service:production",
         auto_remove="force",

--- a/dags/atd_cost_of_service_fees.py
+++ b/dags/atd_cost_of_service_fees.py
@@ -73,6 +73,7 @@ def atd_cost_of_service_fees():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     load_fees_to_knack = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_cost_of_service_fees_to_knack",
         image="atddocker/atd-cost-of-service:production",
         auto_remove="force",

--- a/dags/atd_finance_data_fdu_program_tagging.py
+++ b/dags/atd_finance_data_fdu_program_tagging.py
@@ -116,7 +116,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="tagging_fdus",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_fdu_program_tagging.py
+++ b/dags/atd_finance_data_fdu_program_tagging.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -113,7 +113,6 @@ with DAG(
         command="python3 upload_to_s3.py fdu_expenses_obligated",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -125,7 +124,6 @@ with DAG(
         command="python3 fdu_program_tagging.py",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_finance_data_fdu_program_tagging.py
+++ b/dags/atd_finance_data_fdu_program_tagging.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -106,7 +105,8 @@ with DAG(
 ) as dag:
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    fdus_to_s3 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="fdus_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -117,7 +117,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    tagging_fdus = DockerOperatorWithFallback(
         task_id="tagging_fdus",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -128,4 +128,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t1 >> t2
+    fdus_to_s3 >> tagging_fdus

--- a/dags/atd_finance_data_fdu_program_tagging.py
+++ b/dags/atd_finance_data_fdu_program_tagging.py
@@ -105,7 +105,7 @@ with DAG(
 ) as dag:
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="fdus_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -116,7 +116,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="tagging_fdus",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_fdu_program_tagging.py
+++ b/dags/atd_finance_data_fdu_program_tagging.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 

--- a/dags/atd_finance_data_fdus.py
+++ b/dags/atd_finance_data_fdus.py
@@ -153,7 +153,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="fdus_to_socrata",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_fdus.py
+++ b/dags/atd_finance_data_fdus.py
@@ -142,7 +142,7 @@ with DAG(
     data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="fdus_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -153,7 +153,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="fdus_to_socrata",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_fdus.py
+++ b/dags/atd_finance_data_fdus.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -150,7 +150,6 @@ with DAG(
         command="python3 upload_to_s3.py fdus",
         environment=data_tracker_env,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -162,7 +161,6 @@ with DAG(
         command="python3 s3_to_socrata.py --dataset fdus",
         environment=finance_purchasing_env,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_finance_data_fdus.py
+++ b/dags/atd_finance_data_fdus.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -143,7 +142,8 @@ with DAG(
     data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    fdus_to_s3 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="fdus_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -154,7 +154,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    fdus_to_socrata = DockerOperatorWithFallback(
         task_id="fdus_to_socrata",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -165,4 +165,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t1 >> t2
+    fdus_to_s3 >> fdus_to_socrata

--- a/dags/atd_finance_data_fdus.py
+++ b/dags/atd_finance_data_fdus.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 

--- a/dags/atd_finance_data_master_agreements.py
+++ b/dags/atd_finance_data_master_agreements.py
@@ -142,7 +142,7 @@ with DAG(
     data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="master_agreements_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -153,7 +153,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="master_agreements_to_finance_purchasing",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_master_agreements.py
+++ b/dags/atd_finance_data_master_agreements.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -143,7 +142,8 @@ with DAG(
     data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    master_agreements_to_s3 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="master_agreements_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -154,7 +154,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    master_agreements_to_finance_purchasing = DockerOperatorWithFallback(
         task_id="master_agreements_to_finance_purchasing",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -165,4 +165,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t1 >> t2
+    master_agreements_to_s3 >> master_agreements_to_finance_purchasing

--- a/dags/atd_finance_data_master_agreements.py
+++ b/dags/atd_finance_data_master_agreements.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -153,7 +154,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="master_agreements_to_finance_purchasing",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_master_agreements.py
+++ b/dags/atd_finance_data_master_agreements.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -150,7 +150,6 @@ with DAG(
         command="python3 upload_to_s3.py master_agreements",
         environment=data_tracker_env,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -162,7 +161,6 @@ with DAG(
         command="python3 s3_to_knack.py master_agreements finance-purchasing",
         environment=finance_purchasing_env,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_finance_data_objects.py
+++ b/dags/atd_finance_data_objects.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -143,7 +142,8 @@ with DAG(
     data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    objects_to_s3 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="objects_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -154,7 +154,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    objects_to_finance_purchasing = DockerOperatorWithFallback(
         task_id="objects_to_finance_purchasing",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -165,4 +165,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t1 >> t2
+    objects_to_s3 >> objects_to_finance_purchasing

--- a/dags/atd_finance_data_objects.py
+++ b/dags/atd_finance_data_objects.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -153,7 +154,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="objects_to_finance_purchasing",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_objects.py
+++ b/dags/atd_finance_data_objects.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -150,7 +150,6 @@ with DAG(
         command="python3 upload_to_s3.py objects",
         environment=data_tracker_env,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -162,7 +161,6 @@ with DAG(
         command="python3 s3_to_knack.py objects finance-purchasing",
         environment=finance_purchasing_env,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_finance_data_objects.py
+++ b/dags/atd_finance_data_objects.py
@@ -142,7 +142,7 @@ with DAG(
     data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="objects_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -153,7 +153,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="objects_to_finance_purchasing",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_subprojects.py
+++ b/dags/atd_finance_data_subprojects.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -150,7 +150,6 @@ with DAG(
         command="python3 upload_to_s3.py subprojects",
         environment=data_tracker_env,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -162,7 +161,6 @@ with DAG(
         command="python3 s3_to_knack.py subprojects finance-purchasing",
         environment=finance_purchasing_env,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -174,7 +172,6 @@ with DAG(
         command="python3 s3_to_socrata.py --dataset subprojects",
         environment=finance_purchasing_env,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_finance_data_subprojects.py
+++ b/dags/atd_finance_data_subprojects.py
@@ -142,7 +142,7 @@ with DAG(
     data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="subprojects_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -153,7 +153,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="subprojects_to_data_tracker",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -164,7 +164,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="subprojects_to_socrata",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_subprojects.py
+++ b/dags/atd_finance_data_subprojects.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -153,7 +154,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="subprojects_to_data_tracker",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -164,7 +165,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperatorWithFallback(
+    t3 = DockerOperator(
         task_id="subprojects_to_socrata",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_subprojects.py
+++ b/dags/atd_finance_data_subprojects.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -143,7 +142,8 @@ with DAG(
     data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    subprojects_to_s3 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="subprojects_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -154,7 +154,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    subprojects_to_data_tracker = DockerOperatorWithFallback(
         task_id="subprojects_to_data_tracker",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -165,7 +165,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    subprojects_to_socrata = DockerOperatorWithFallback(
         task_id="subprojects_to_socrata",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -176,4 +176,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t1 >> t2 >> t3
+    subprojects_to_s3 >> subprojects_to_data_tracker >> subprojects_to_socrata

--- a/dags/atd_finance_data_task_orders.py
+++ b/dags/atd_finance_data_task_orders.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -142,7 +143,7 @@ with DAG(
     data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    task_orders_s3 = DockerOperatorWithFallback(
         task_id="task_orders_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -153,7 +154,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    task_orders_data_tracker = DockerOperator(
         task_id="task_orders_to_data_tracker",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -164,7 +165,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperatorWithFallback(
+    task_orders_finance_purchasing = DockerOperator(
         task_id="task_orders_to_finance_purchasing",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -175,7 +176,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperatorWithFallback(
+    task_orders_socrata = DockerOperator(
         task_id="task_orders_to_socrata",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -186,4 +187,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t1 >> t2 >> t3 >> t4
+    task_orders_s3 >> task_orders_data_tracker >> task_orders_finance_purchasing >> task_orders_socrata

--- a/dags/atd_finance_data_task_orders.py
+++ b/dags/atd_finance_data_task_orders.py
@@ -187,4 +187,9 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    task_orders_s3 >> task_orders_data_tracker >> task_orders_finance_purchasing >> task_orders_socrata
+    (
+        task_orders_s3
+        >> task_orders_data_tracker
+        >> task_orders_finance_purchasing
+        >> task_orders_socrata
+    )

--- a/dags/atd_finance_data_task_orders.py
+++ b/dags/atd_finance_data_task_orders.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -144,6 +143,7 @@ with DAG(
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
     task_orders_s3 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="task_orders_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -154,7 +154,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    task_orders_data_tracker = DockerOperator(
+    task_orders_data_tracker = DockerOperatorWithFallback(
         task_id="task_orders_to_data_tracker",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -165,7 +165,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    task_orders_finance_purchasing = DockerOperator(
+    task_orders_finance_purchasing = DockerOperatorWithFallback(
         task_id="task_orders_to_finance_purchasing",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -176,7 +176,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    task_orders_socrata = DockerOperator(
+    task_orders_socrata = DockerOperatorWithFallback(
         task_id="task_orders_to_socrata",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_task_orders.py
+++ b/dags/atd_finance_data_task_orders.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -150,7 +150,6 @@ with DAG(
         command="python3 upload_to_s3.py task_orders",
         environment=data_tracker_env,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -162,7 +161,6 @@ with DAG(
         command="python3 s3_to_knack.py task_orders data-tracker",
         environment=data_tracker_env,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -174,7 +172,6 @@ with DAG(
         command="python3 s3_to_knack.py task_orders finance-purchasing",
         environment=finance_purchasing_env,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -186,7 +183,6 @@ with DAG(
         command="python3 s3_to_socrata.py --dataset task_orders",
         environment=finance_purchasing_env,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_finance_data_task_orders.py
+++ b/dags/atd_finance_data_task_orders.py
@@ -142,7 +142,7 @@ with DAG(
     data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="task_orders_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -153,7 +153,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="task_orders_to_data_tracker",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -164,7 +164,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="task_orders_to_finance_purchasing",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -175,7 +175,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperator(
+    t4 = DockerOperatorWithFallback(
         task_id="task_orders_to_socrata",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_units.py
+++ b/dags/atd_finance_data_units.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -153,7 +154,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="units_to_data_tracker",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -164,7 +165,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperatorWithFallback(
+    t3 = DockerOperator(
         task_id="units_to_socrata",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -175,7 +176,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperatorWithFallback(
+    t4 = DockerOperator(
         task_id="units_to_finance_purchasing",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_units.py
+++ b/dags/atd_finance_data_units.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -143,7 +142,8 @@ with DAG(
     data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    units_to_s3 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="units_orders_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -154,7 +154,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    units_to_data_tracker = DockerOperatorWithFallback(
         task_id="units_to_data_tracker",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -165,7 +165,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    units_to_socrata = DockerOperatorWithFallback(
         task_id="units_to_socrata",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -176,7 +176,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperator(
+    units_to_finance_purchasing = DockerOperatorWithFallback(
         task_id="units_to_finance_purchasing",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -187,4 +187,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t1 >> t2 >> t3 >> t4
+    units_to_s3 >> units_to_data_tracker >> units_to_socrata >> units_to_finance_purchasing

--- a/dags/atd_finance_data_units.py
+++ b/dags/atd_finance_data_units.py
@@ -142,7 +142,7 @@ with DAG(
     data_tracker_env = get_env_vars_task(DATA_TRACKER_SECRETS)
     finance_purchasing_env = get_env_vars_task(FINANCE_PURCHASING_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="units_orders_to_s3",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -153,7 +153,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="units_to_data_tracker",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -164,7 +164,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="units_to_socrata",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",
@@ -175,7 +175,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperator(
+    t4 = DockerOperatorWithFallback(
         task_id="units_to_finance_purchasing",
         image="atddocker/atd-finance-data:production",
         docker_conn_id="docker_default",

--- a/dags/atd_finance_data_units.py
+++ b/dags/atd_finance_data_units.py
@@ -187,4 +187,9 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    units_to_s3 >> units_to_data_tracker >> units_to_socrata >> units_to_finance_purchasing
+    (
+        units_to_s3
+        >> units_to_data_tracker
+        >> units_to_socrata
+        >> units_to_finance_purchasing
+    )

--- a/dags/atd_finance_data_units.py
+++ b/dags/atd_finance_data_units.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -150,7 +150,6 @@ with DAG(
         command="python3 upload_to_s3.py units",
         environment=data_tracker_env,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -162,7 +161,6 @@ with DAG(
         command="python3 s3_to_knack.py units data-tracker",
         environment=data_tracker_env,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -174,7 +172,6 @@ with DAG(
         command="python3 s3_to_socrata.py --dataset dept_units",
         environment=finance_purchasing_env,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -186,7 +183,6 @@ with DAG(
         command="python3 s3_to_knack.py units finance-purchasing",
         environment=finance_purchasing_env,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_kits_dms_message.py
+++ b/dags/atd_kits_dms_message.py
@@ -62,7 +62,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="update_knack_dms_message",
         docker_conn_id="docker_default",
         image=docker_image,

--- a/dags/atd_kits_dms_message.py
+++ b/dags/atd_kits_dms_message.py
@@ -63,6 +63,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="update_knack_dms_message",
         docker_conn_id="docker_default",
         image=docker_image,

--- a/dags/atd_kits_dms_message.py
+++ b/dags/atd_kits_dms_message.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -70,7 +70,6 @@ with DAG(
         command="python ./atd-kits/atd-kits/dms_message_pub.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_kits_sig_stat_pub.py
+++ b/dags/atd_kits_sig_stat_pub.py
@@ -65,6 +65,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_kits_sig_status_to_socrata",
         image="atddocker/atd-kits:production",
         docker_conn_id="docker_default",

--- a/dags/atd_kits_sig_stat_pub.py
+++ b/dags/atd_kits_sig_stat_pub.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -72,7 +72,6 @@ with DAG(
         command="./atd-kits/atd-kits/signal_status_publisher.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
         network_mode="bridge",
     )

--- a/dags/atd_kits_sig_stat_pub.py
+++ b/dags/atd_kits_sig_stat_pub.py
@@ -64,7 +64,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_kits_sig_status_to_socrata",
         image="atddocker/atd-kits:production",
         docker_conn_id="docker_default",

--- a/dags/atd_knack_amd_preventative_maintenance.py
+++ b/dags/atd_knack_amd_preventative_maintenance.py
@@ -71,7 +71,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_preventative_maintenance_copy",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -82,7 +82,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_amd_pm_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -93,7 +93,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_amd_pm_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_amd_preventative_maintenance.py
+++ b/dags/atd_knack_amd_preventative_maintenance.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -73,6 +72,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_preventative_maintenance_copy",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -83,7 +83,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_amd_pm_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -94,7 +94,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_amd_pm_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_amd_preventative_maintenance.py
+++ b/dags/atd_knack_amd_preventative_maintenance.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -82,7 +83,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="atd_knack_amd_pm_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -93,7 +94,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperatorWithFallback(
+    t3 = DockerOperator(
         task_id="atd_knack_amd_pm_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_amd_preventative_maintenance.py
+++ b/dags/atd_knack_amd_preventative_maintenance.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -79,7 +79,6 @@ with DAG(
         command=f"./atd-knack-services/services/signal_pm_copier.py -a {app_name} -c {copy_to_secondary_view}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_artbox_signals.py
+++ b/dags/atd_knack_artbox_signals.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -100,7 +100,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name_dest} -c {container_dest}",
         environment=env_vars_t1,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -112,7 +111,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_knack.py -a {app_name_src} -c {container_src} {date_filter_arg} -dest {app_name_dest}",
         environment=env_vars_t2,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
     date_filter_arg >> t1 >> t2

--- a/dags/atd_knack_artbox_signals.py
+++ b/dags/atd_knack_artbox_signals.py
@@ -92,7 +92,7 @@ with DAG(
     env_vars_t1 = get_env_vars_task(REQUIRED_SECRETS_ARTBOX_POSTGREST)
     env_vars_t2 = get_env_vars_task(REQUIRED_SECRETS_SIGNALS_TO_SMO)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_artbox_signals_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -103,7 +103,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_data_tracker_signals_to_smo",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_artbox_signals.py
+++ b/dags/atd_knack_artbox_signals.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -94,6 +93,7 @@ with DAG(
     env_vars_t2 = get_env_vars_task(REQUIRED_SECRETS_SIGNALS_TO_SMO)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_artbox_signals_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -104,7 +104,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_data_tracker_signals_to_smo",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_artbox_signals.py
+++ b/dags/atd_knack_artbox_signals.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -103,7 +104,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="atd_knack_data_tracker_signals_to_smo",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_arterial_managment_locations.py
+++ b/dags/atd_knack_arterial_managment_locations.py
@@ -66,7 +66,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_arterial_managment_locations_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -77,7 +77,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_arterial_managment_locations_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_arterial_managment_locations.py
+++ b/dags/atd_knack_arterial_managment_locations.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -68,6 +67,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     to_postgrest = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_arterial_management_locations_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -78,7 +78,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    to_agol = DockerOperator(
+    to_agol = DockerOperatorWithFallback(
         task_id="atd_knack_arterial_management_locations_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_arterial_managment_locations.py
+++ b/dags/atd_knack_arterial_managment_locations.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -50,7 +51,7 @@ REQUIRED_SECRETS = {
 
 
 with DAG(
-    dag_id="atd_knack_arterial_managment_locations",
+    dag_id="atd_knack_arterial_management_locations",
     description="Publishes AMD location records to AGOL",
     doc_md="**Need VPN access or addition to security group allow list to reach Postgrest**",
     default_args=DEFAULT_ARGS,
@@ -66,8 +67,8 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
-        task_id="atd_knack_arterial_managment_locations_to_postgrest",
+    to_postgrest = DockerOperatorWithFallback(
+        task_id="atd_knack_arterial_management_locations_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
@@ -77,8 +78,8 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
-        task_id="atd_knack_arterial_managment_locations_to_agol",
+    to_agol = DockerOperator(
+        task_id="atd_knack_arterial_management_locations_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
@@ -88,4 +89,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    date_filter_arg >> t1 >> t2
+    date_filter_arg >> to_postgrest >> to_agol

--- a/dags/atd_knack_arterial_managment_locations.py
+++ b/dags/atd_knack_arterial_managment_locations.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -74,7 +74,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -67,6 +67,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     update_employees = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="update_employees",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -66,7 +66,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    update_employees = DockerOperator(
+    update_employees = DockerOperatorWithFallback(
         task_id="update_employees",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_banner.py
+++ b/dags/atd_knack_banner.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -74,7 +74,6 @@ with DAG(
         command=f"./atd-knack-banner/update_employees.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_cctv_cameras.py
+++ b/dags/atd_knack_cctv_cameras.py
@@ -94,7 +94,7 @@ def atd_knack_cctv_cameras():
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    to_postgrest = DockerOperator(
+    to_postgrest = DockerOperatorWithFallback(
         task_id="atd_knack_cctv_cameras_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -105,7 +105,7 @@ def atd_knack_cctv_cameras():
         mount_tmp_dir=False,
     )
 
-    to_socrata = DockerOperator(
+    to_socrata = DockerOperatorWithFallback(
         task_id="atd_knack_cctv_cameras_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -116,7 +116,7 @@ def atd_knack_cctv_cameras():
         mount_tmp_dir=False,
     )
 
-    to_agol = DockerOperator(
+    to_agol = DockerOperatorWithFallback(
         task_id="atd_knack_cctv_cameras_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_cctv_cameras.py
+++ b/dags/atd_knack_cctv_cameras.py
@@ -1,6 +1,5 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
@@ -96,6 +95,7 @@ def atd_knack_cctv_cameras():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     to_postgrest = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_cctv_cameras_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -106,7 +106,7 @@ def atd_knack_cctv_cameras():
         mount_tmp_dir=False,
     )
 
-    to_socrata = DockerOperator(
+    to_socrata = DockerOperatorWithFallback(
         task_id="atd_knack_cctv_cameras_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -117,7 +117,7 @@ def atd_knack_cctv_cameras():
         mount_tmp_dir=False,
     )
 
-    to_agol = DockerOperator(
+    to_agol = DockerOperatorWithFallback(
         task_id="atd_knack_cctv_cameras_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_cctv_cameras.py
+++ b/dags/atd_knack_cctv_cameras.py
@@ -1,5 +1,6 @@
 from os import getenv
 
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
@@ -105,7 +106,7 @@ def atd_knack_cctv_cameras():
         mount_tmp_dir=False,
     )
 
-    to_socrata = DockerOperatorWithFallback(
+    to_socrata = DockerOperator(
         task_id="atd_knack_cctv_cameras_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -116,7 +117,7 @@ def atd_knack_cctv_cameras():
         mount_tmp_dir=False,
     )
 
-    to_agol = DockerOperatorWithFallback(
+    to_agol = DockerOperator(
         task_id="atd_knack_cctv_cameras_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_cctv_cameras.py
+++ b/dags/atd_knack_cctv_cameras.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -102,7 +102,6 @@ def atd_knack_cctv_cameras():
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_corridor_retiming.py
+++ b/dags/atd_knack_corridor_retiming.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -72,6 +71,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_corridor_retiming_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -82,7 +82,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_corridor_retiming_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_corridor_retiming.py
+++ b/dags/atd_knack_corridor_retiming.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -81,7 +82,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="atd_knack_corridor_retiming_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_corridor_retiming.py
+++ b/dags/atd_knack_corridor_retiming.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -78,7 +78,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_corridor_retiming.py
+++ b/dags/atd_knack_corridor_retiming.py
@@ -70,7 +70,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_corridor_retiming_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -81,7 +81,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_corridor_retiming_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_data_collection_requests.py
+++ b/dags/atd_knack_data_collection_requests.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -77,7 +77,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_data_collection_requests.py
+++ b/dags/atd_knack_data_collection_requests.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -69,7 +70,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    to_postgrest = DockerOperatorWithFallback(
         task_id="atd_knack_data_collection_requests_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -80,7 +81,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    to_socrata = DockerOperator(
         task_id="atd_knack_data_collection_requests_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -91,4 +92,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    date_filter_arg >> t1 >> t2
+    date_filter_arg >> to_postgrest >> to_socrata

--- a/dags/atd_knack_data_collection_requests.py
+++ b/dags/atd_knack_data_collection_requests.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -71,6 +70,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     to_postgrest = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_data_collection_requests_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -81,7 +81,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    to_socrata = DockerOperator(
+    to_socrata = DockerOperatorWithFallback(
         task_id="atd_knack_data_collection_requests_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_data_collection_requests.py
+++ b/dags/atd_knack_data_collection_requests.py
@@ -69,7 +69,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_data_collection_requests_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -80,7 +80,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_data_collection_requests_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_data_tracker_location_updater.py
+++ b/dags/atd_knack_data_tracker_location_updater.py
@@ -60,6 +60,7 @@ def atd_knack_data_tracker_location_updater():
     date_filter_arg = get_date_filter_arg()
 
     update_locations_task = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="update_locations",
         image="atddocker/atd-knack-services:production",
         docker_conn_id="docker_default",

--- a/dags/atd_knack_data_tracker_location_updater.py
+++ b/dags/atd_knack_data_tracker_location_updater.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -67,7 +67,6 @@ def atd_knack_data_tracker_location_updater():
         command=f"./atd-knack-services/services/knack_location_updater.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_data_tracker_location_updater.py
+++ b/dags/atd_knack_data_tracker_location_updater.py
@@ -59,7 +59,7 @@ def atd_knack_data_tracker_location_updater():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
     date_filter_arg = get_date_filter_arg()
 
-    update_locations_task = DockerOperator(
+    update_locations_task = DockerOperatorWithFallback(
         task_id="update_locations",
         image="atddocker/atd-knack-services:production",
         docker_conn_id="docker_default",

--- a/dags/atd_knack_data_tracker_sr_asset_assign.py
+++ b/dags/atd_knack_data_tracker_sr_asset_assign.py
@@ -66,6 +66,7 @@ def atd_knack_data_tracker_sr_asset_assign():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     service_request_asset_assign_task = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="service_request_asset_assign",
         image="atddocker/atd-knack-services:production",
         docker_conn_id="docker_default",

--- a/dags/atd_knack_data_tracker_sr_asset_assign.py
+++ b/dags/atd_knack_data_tracker_sr_asset_assign.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -73,7 +73,6 @@ def atd_knack_data_tracker_sr_asset_assign():
         command=f"./atd-knack-services/services/sr_asset_assign.py -a data-tracker -c view_2362 -s signals",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_data_tracker_sr_asset_assign.py
+++ b/dags/atd_knack_data_tracker_sr_asset_assign.py
@@ -65,7 +65,7 @@ This DAG assigns signal records to service request issues in the AMD Data Tracke
 def atd_knack_data_tracker_sr_asset_assign():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    service_request_asset_assign_task = DockerOperator(
+    service_request_asset_assign_task = DockerOperatorWithFallback(
         task_id="service_request_asset_assign",
         image="atddocker/atd-knack-services:production",
         docker_conn_id="docker_default",

--- a/dags/atd_knack_data_tracker_street_segment_updater.py
+++ b/dags/atd_knack_data_tracker_street_segment_updater.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -68,7 +68,6 @@ def atd_knack_data_tracker_street_segment_updater():
         command=f"./atd-knack-services/services/knack_street_seg_updater.py -a data-tracker -c view_1198 {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_data_tracker_street_segment_updater.py
+++ b/dags/atd_knack_data_tracker_street_segment_updater.py
@@ -61,6 +61,7 @@ def atd_knack_data_tracker_street_segment_updater():
     date_filter_arg = get_date_filter_arg()
 
     update_street_segments_task = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="update_street_segments",
         image="atddocker/atd-knack-services:production",
         docker_conn_id="docker_default",

--- a/dags/atd_knack_data_tracker_street_segment_updater.py
+++ b/dags/atd_knack_data_tracker_street_segment_updater.py
@@ -60,7 +60,7 @@ def atd_knack_data_tracker_street_segment_updater():
 
     date_filter_arg = get_date_filter_arg()
 
-    update_street_segments_task = DockerOperator(
+    update_street_segments_task = DockerOperatorWithFallback(
         task_id="update_street_segments",
         image="atddocker/atd-knack-services:production",
         docker_conn_id="docker_default",

--- a/dags/atd_knack_detectors.py
+++ b/dags/atd_knack_detectors.py
@@ -1,6 +1,5 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
@@ -80,6 +79,7 @@ def atd_knack_detectors():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     load_detectors_to_postgrest = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_detectors_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -90,7 +90,7 @@ def atd_knack_detectors():
         mount_tmp_dir=False,
     )
 
-    load_detectors_to_socrata = DockerOperator(
+    load_detectors_to_socrata = DockerOperatorWithFallback(
         task_id="atd_knack_detectors_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -101,7 +101,7 @@ def atd_knack_detectors():
         mount_tmp_dir=False,
     )
 
-    load_detectors_to_agol = DockerOperator(
+    load_detectors_to_agol = DockerOperatorWithFallback(
         task_id="atd_knack_detectors_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_detectors.py
+++ b/dags/atd_knack_detectors.py
@@ -78,7 +78,7 @@ def atd_knack_detectors():
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    load_detectors_to_postgrest = DockerOperator(
+    load_detectors_to_postgrest = DockerOperatorWithFallback(
         task_id="atd_knack_detectors_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -89,7 +89,7 @@ def atd_knack_detectors():
         mount_tmp_dir=False,
     )
 
-    load_detectors_to_socrata = DockerOperator(
+    load_detectors_to_socrata = DockerOperatorWithFallback(
         task_id="atd_knack_detectors_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -100,7 +100,7 @@ def atd_knack_detectors():
         mount_tmp_dir=False,
     )
 
-    load_detectors_to_agol = DockerOperator(
+    load_detectors_to_agol = DockerOperatorWithFallback(
         task_id="atd_knack_detectors_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_detectors.py
+++ b/dags/atd_knack_detectors.py
@@ -1,5 +1,6 @@
 from os import getenv
 
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
@@ -89,7 +90,7 @@ def atd_knack_detectors():
         mount_tmp_dir=False,
     )
 
-    load_detectors_to_socrata = DockerOperatorWithFallback(
+    load_detectors_to_socrata = DockerOperator(
         task_id="atd_knack_detectors_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -100,7 +101,7 @@ def atd_knack_detectors():
         mount_tmp_dir=False,
     )
 
-    load_detectors_to_agol = DockerOperatorWithFallback(
+    load_detectors_to_agol = DockerOperator(
         task_id="atd_knack_detectors_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_detectors.py
+++ b/dags/atd_knack_detectors.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -86,7 +86,6 @@ def atd_knack_detectors():
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_development_services.py
+++ b/dags/atd_knack_development_services.py
@@ -2,7 +2,7 @@
 
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag, chain
 from pendulum import datetime, duration
 
@@ -55,7 +55,7 @@ REQUIRED_SECRETS = {
 }
 
 
-def knack_services_task_template(task_id, image, command, env_vars, pull=False):
+def knack_services_task_template(task_id, image, command, env_vars):
     return DockerOperator(
         task_id=task_id,
         image=image,
@@ -64,7 +64,6 @@ def knack_services_task_template(task_id, image, command, env_vars, pull=False):
         command=command,
         environment=env_vars,
         tty=True,
-        force_pull=pull,
         mount_tmp_dir=False,
         trigger_rule="all_done",
     )
@@ -172,18 +171,12 @@ def atd_knack_development_services():
     tasks = []
 
     for cmd in commands:
-        # We want the first task to pull the latest docker image
-        if len(tasks) == 0:
-            pull = True
-        else:
-            pull = False
         tasks.append(
             knack_services_task_template(
                 task_id=cmd["task_id"],
                 image=docker_image,
                 command=cmd["command"],
                 env_vars=env_vars,
-                pull=pull,
             )
         )
 

--- a/dags/atd_knack_development_services.py
+++ b/dags/atd_knack_development_services.py
@@ -56,7 +56,9 @@ REQUIRED_SECRETS = {
 }
 
 
-def knack_services_task_template(task_id, image, command, env_vars, operator_cls=DockerOperator):
+def knack_services_task_template(
+    task_id, image, command, env_vars, operator_cls=DockerOperator, force_pull=False
+):
     return operator_cls(
         task_id=task_id,
         image=image,
@@ -67,6 +69,7 @@ def knack_services_task_template(task_id, image, command, env_vars, operator_cls
         tty=True,
         mount_tmp_dir=False,
         trigger_rule="all_done",
+        force_pull=force_pull,
     )
 
 
@@ -178,7 +181,8 @@ def atd_knack_development_services():
                 image=docker_image,
                 command=cmd["command"],
                 env_vars=env_vars,
-                operator_cls=DockerOperatorWithFallback if i == 0 else DockerOperator,
+                operator_cls=DockerOperatorWithFallback,
+                force_pull=True if i == 0 else False,
             )
         )
 

--- a/dags/atd_knack_development_services.py
+++ b/dags/atd_knack_development_services.py
@@ -2,6 +2,7 @@
 
 from os import getenv
 
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag, chain
 from pendulum import datetime, duration
@@ -55,8 +56,8 @@ REQUIRED_SECRETS = {
 }
 
 
-def knack_services_task_template(task_id, image, command, env_vars):
-    return DockerOperatorWithFallback(
+def knack_services_task_template(task_id, image, command, env_vars, operator_cls=DockerOperator):
+    return operator_cls(
         task_id=task_id,
         image=image,
         docker_conn_id="docker_default",
@@ -170,13 +171,14 @@ def atd_knack_development_services():
 
     tasks = []
 
-    for cmd in commands:
+    for i, cmd in enumerate(commands):
         tasks.append(
             knack_services_task_template(
                 task_id=cmd["task_id"],
                 image=docker_image,
                 command=cmd["command"],
                 env_vars=env_vars,
+                operator_cls=DockerOperatorWithFallback if i == 0 else DockerOperator,
             )
         )
 

--- a/dags/atd_knack_development_services.py
+++ b/dags/atd_knack_development_services.py
@@ -56,7 +56,7 @@ REQUIRED_SECRETS = {
 
 
 def knack_services_task_template(task_id, image, command, env_vars):
-    return DockerOperator(
+    return DockerOperatorWithFallback(
         task_id=task_id,
         image=image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_dms.py
+++ b/dags/atd_knack_dms.py
@@ -3,6 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -87,7 +88,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="atd_knack_dms_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -98,7 +99,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperatorWithFallback(
+    t3 = DockerOperator(
         task_id="atd_knack_dms_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_dms.py
+++ b/dags/atd_knack_dms.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -84,7 +84,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_dms.py
+++ b/dags/atd_knack_dms.py
@@ -76,7 +76,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_dms_to_postgrest",
         docker_conn_id="docker_default",
         image=docker_image,
@@ -87,7 +87,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_dms_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -98,7 +98,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_dms_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_dms.py
+++ b/dags/atd_knack_dms.py
@@ -3,7 +3,6 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -78,6 +77,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_dms_to_postgrest",
         docker_conn_id="docker_default",
         image=docker_image,
@@ -88,7 +88,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_dms_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -99,7 +99,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_dms_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_employees_tpw_hire.py
+++ b/dags/atd_knack_employees_tpw_hire.py
@@ -2,7 +2,6 @@
 
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
@@ -97,6 +96,7 @@ def atd_knack_employees_tpw_hire():
     env_vars_knack_to_knack = get_env_vars_task(REQUIRED_SECRETS_KNACK_TO_KNACK)
 
     hr_accounts_to_postgrest = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="hr_accounts_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -107,7 +107,7 @@ def atd_knack_employees_tpw_hire():
         mount_tmp_dir=False,
     )
 
-    tpw_hire_employees_to_postgrest = DockerOperator(
+    tpw_hire_employees_to_postgrest = DockerOperatorWithFallback(
         task_id="tpw_hire_employees_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -118,7 +118,7 @@ def atd_knack_employees_tpw_hire():
         mount_tmp_dir=False,
     )
 
-    hr_accounts_to_tpw_hire = DockerOperator(
+    hr_accounts_to_tpw_hire = DockerOperatorWithFallback(
         task_id="hr_accounts_to_tpw_hire",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_employees_tpw_hire.py
+++ b/dags/atd_knack_employees_tpw_hire.py
@@ -2,6 +2,7 @@
 
 from os import getenv
 
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
@@ -106,7 +107,7 @@ def atd_knack_employees_tpw_hire():
         mount_tmp_dir=False,
     )
 
-    tpw_hire_employees_to_postgrest = DockerOperatorWithFallback(
+    tpw_hire_employees_to_postgrest = DockerOperator(
         task_id="tpw_hire_employees_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -117,7 +118,7 @@ def atd_knack_employees_tpw_hire():
         mount_tmp_dir=False,
     )
 
-    hr_accounts_to_tpw_hire = DockerOperatorWithFallback(
+    hr_accounts_to_tpw_hire = DockerOperator(
         task_id="hr_accounts_to_tpw_hire",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_employees_tpw_hire.py
+++ b/dags/atd_knack_employees_tpw_hire.py
@@ -2,7 +2,7 @@
 
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -103,7 +103,6 @@ def atd_knack_employees_tpw_hire():
         command=f"python ./atd-knack-services/services/records_to_postgrest.py -a {app_name_src} -c {container_src} {date_filter_task}",
         environment=env_vars_hr_manager,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_employees_tpw_hire.py
+++ b/dags/atd_knack_employees_tpw_hire.py
@@ -95,7 +95,7 @@ def atd_knack_employees_tpw_hire():
     env_vars_tpw_hire = get_env_vars_task(REQUIRED_SECRETS_TPW_HIRE)
     env_vars_knack_to_knack = get_env_vars_task(REQUIRED_SECRETS_KNACK_TO_KNACK)
 
-    hr_accounts_to_postgrest = DockerOperator(
+    hr_accounts_to_postgrest = DockerOperatorWithFallback(
         task_id="hr_accounts_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -106,7 +106,7 @@ def atd_knack_employees_tpw_hire():
         mount_tmp_dir=False,
     )
 
-    tpw_hire_employees_to_postgrest = DockerOperator(
+    tpw_hire_employees_to_postgrest = DockerOperatorWithFallback(
         task_id="tpw_hire_employees_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -117,7 +117,7 @@ def atd_knack_employees_tpw_hire():
         mount_tmp_dir=False,
     )
 
-    hr_accounts_to_tpw_hire = DockerOperator(
+    hr_accounts_to_tpw_hire = DockerOperatorWithFallback(
         task_id="hr_accounts_to_tpw_hire",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_esb_311.py
+++ b/dags/atd_knack_esb_311.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from docker.types import Mount
 from pendulum import datetime, duration
@@ -93,7 +93,6 @@ def atd_knack_esb_311():
         command="./atd-knack-311/send_knack_messages_to_esb.py data-tracker",
         environment=env_vars_data_tracker,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
         network_mode="bridge",
         mounts=[cert_mount],
@@ -107,7 +106,6 @@ def atd_knack_esb_311():
         command="./atd-knack-311/send_knack_messages_to_esb.py signs-markings",
         environment=env_vars_signs_markings,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
         network_mode="bridge",
         mounts=[cert_mount],

--- a/dags/atd_knack_esb_311.py
+++ b/dags/atd_knack_esb_311.py
@@ -85,7 +85,7 @@ def atd_knack_esb_311():
         type="volume",
     )
 
-    data_tracker_activities_to_311 = DockerOperator(
+    data_tracker_activities_to_311 = DockerOperatorWithFallback(
         task_id="knack_amd_data_tracker_activities_to_311",
         image=DOCKER_IMAGE,
         docker_conn_id="docker_default",
@@ -98,7 +98,7 @@ def atd_knack_esb_311():
         mounts=[cert_mount],
     )
 
-    signs_markings_activities_to_311 = DockerOperator(
+    signs_markings_activities_to_311 = DockerOperatorWithFallback(
         task_id="knack_amd_signs_markings_activities_to_311",
         image=DOCKER_IMAGE,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_esb_311.py
+++ b/dags/atd_knack_esb_311.py
@@ -1,6 +1,5 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from docker.types import Mount
@@ -87,6 +86,7 @@ def atd_knack_esb_311():
     )
 
     data_tracker_activities_to_311 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="knack_amd_data_tracker_activities_to_311",
         image=DOCKER_IMAGE,
         docker_conn_id="docker_default",
@@ -99,7 +99,7 @@ def atd_knack_esb_311():
         mounts=[cert_mount],
     )
 
-    signs_markings_activities_to_311 = DockerOperator(
+    signs_markings_activities_to_311 = DockerOperatorWithFallback(
         task_id="knack_amd_signs_markings_activities_to_311",
         image=DOCKER_IMAGE,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_esb_311.py
+++ b/dags/atd_knack_esb_311.py
@@ -1,5 +1,6 @@
 from os import getenv
 
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from docker.types import Mount
@@ -98,7 +99,7 @@ def atd_knack_esb_311():
         mounts=[cert_mount],
     )
 
-    signs_markings_activities_to_311 = DockerOperatorWithFallback(
+    signs_markings_activities_to_311 = DockerOperator(
         task_id="knack_amd_signs_markings_activities_to_311",
         image=DOCKER_IMAGE,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_flashing_beacons.py
+++ b/dags/atd_knack_flashing_beacons.py
@@ -85,7 +85,7 @@ def atd_knack_flashing_beacons():
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    load_postgrest_task = DockerOperator(
+    load_postgrest_task = DockerOperatorWithFallback(
         task_id="atd_knack_flashing_beacons_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -96,7 +96,7 @@ def atd_knack_flashing_beacons():
         mount_tmp_dir=False,
     )
 
-    load_socrata_task = DockerOperator(
+    load_socrata_task = DockerOperatorWithFallback(
         task_id="atd_knack_flashing_beacons_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -107,7 +107,7 @@ def atd_knack_flashing_beacons():
         mount_tmp_dir=False,
     )
 
-    load_agol_task = DockerOperator(
+    load_agol_task = DockerOperatorWithFallback(
         task_id="atd_knack_flashing_beacons_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_flashing_beacons.py
+++ b/dags/atd_knack_flashing_beacons.py
@@ -1,5 +1,6 @@
 from os import getenv
 
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
@@ -96,7 +97,7 @@ def atd_knack_flashing_beacons():
         mount_tmp_dir=False,
     )
 
-    load_socrata_task = DockerOperatorWithFallback(
+    load_socrata_task = DockerOperator(
         task_id="atd_knack_flashing_beacons_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -107,7 +108,7 @@ def atd_knack_flashing_beacons():
         mount_tmp_dir=False,
     )
 
-    load_agol_task = DockerOperatorWithFallback(
+    load_agol_task = DockerOperator(
         task_id="atd_knack_flashing_beacons_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_flashing_beacons.py
+++ b/dags/atd_knack_flashing_beacons.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -93,7 +93,6 @@ def atd_knack_flashing_beacons():
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_flashing_beacons.py
+++ b/dags/atd_knack_flashing_beacons.py
@@ -1,6 +1,5 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
@@ -87,6 +86,7 @@ def atd_knack_flashing_beacons():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     load_postgrest_task = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_flashing_beacons_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -97,7 +97,7 @@ def atd_knack_flashing_beacons():
         mount_tmp_dir=False,
     )
 
-    load_socrata_task = DockerOperator(
+    load_socrata_task = DockerOperatorWithFallback(
         task_id="atd_knack_flashing_beacons_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -108,7 +108,7 @@ def atd_knack_flashing_beacons():
         mount_tmp_dir=False,
     )
 
-    load_agol_task = DockerOperator(
+    load_agol_task = DockerOperatorWithFallback(
         task_id="atd_knack_flashing_beacons_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_inventory_items_finance_to_data_tracker.py
+++ b/dags/atd_knack_inventory_items_finance_to_data_tracker.py
@@ -1,5 +1,6 @@
 from os import getenv
 
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
@@ -141,7 +142,7 @@ def atd_knack_inventory_items_finance_to_data_tracker():
         mount_tmp_dir=False,
     )
 
-    load_data_tracker_inventory_to_postgrest_task = DockerOperatorWithFallback(
+    load_data_tracker_inventory_to_postgrest_task = DockerOperator(
         task_id="atd_knack_data_tracker_inventory_items_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -152,7 +153,7 @@ def atd_knack_inventory_items_finance_to_data_tracker():
         mount_tmp_dir=False,
     )
 
-    sync_finance_inventory_to_data_tracker_task = DockerOperatorWithFallback(
+    sync_finance_inventory_to_data_tracker_task = DockerOperator(
         task_id="atd_knack_update_data_tracker_inventory_items_from_finance_inventory",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_inventory_items_finance_to_data_tracker.py
+++ b/dags/atd_knack_inventory_items_finance_to_data_tracker.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -138,7 +138,6 @@ def atd_knack_inventory_items_finance_to_data_tracker():
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name_src} -c {container_src} {date_filter_arg}",
         environment=finance_inventory_postgrest_env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_inventory_items_finance_to_data_tracker.py
+++ b/dags/atd_knack_inventory_items_finance_to_data_tracker.py
@@ -130,7 +130,7 @@ def atd_knack_inventory_items_finance_to_data_tracker():
     )
     date_filter_arg = get_date_filter_arg(should_replace_monthly=False)
 
-    load_finance_inventory_to_postgrest_task = DockerOperator(
+    load_finance_inventory_to_postgrest_task = DockerOperatorWithFallback(
         task_id="atd_knack_finance_inventory_items_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -141,7 +141,7 @@ def atd_knack_inventory_items_finance_to_data_tracker():
         mount_tmp_dir=False,
     )
 
-    load_data_tracker_inventory_to_postgrest_task = DockerOperator(
+    load_data_tracker_inventory_to_postgrest_task = DockerOperatorWithFallback(
         task_id="atd_knack_data_tracker_inventory_items_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -152,7 +152,7 @@ def atd_knack_inventory_items_finance_to_data_tracker():
         mount_tmp_dir=False,
     )
 
-    sync_finance_inventory_to_data_tracker_task = DockerOperator(
+    sync_finance_inventory_to_data_tracker_task = DockerOperatorWithFallback(
         task_id="atd_knack_update_data_tracker_inventory_items_from_finance_inventory",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_inventory_items_finance_to_data_tracker.py
+++ b/dags/atd_knack_inventory_items_finance_to_data_tracker.py
@@ -1,6 +1,5 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
@@ -132,6 +131,7 @@ def atd_knack_inventory_items_finance_to_data_tracker():
     date_filter_arg = get_date_filter_arg(should_replace_monthly=False)
 
     load_finance_inventory_to_postgrest_task = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_finance_inventory_items_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -142,7 +142,7 @@ def atd_knack_inventory_items_finance_to_data_tracker():
         mount_tmp_dir=False,
     )
 
-    load_data_tracker_inventory_to_postgrest_task = DockerOperator(
+    load_data_tracker_inventory_to_postgrest_task = DockerOperatorWithFallback(
         task_id="atd_knack_data_tracker_inventory_items_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -153,7 +153,7 @@ def atd_knack_inventory_items_finance_to_data_tracker():
         mount_tmp_dir=False,
     )
 
-    sync_finance_inventory_to_data_tracker_task = DockerOperator(
+    sync_finance_inventory_to_data_tracker_task = DockerOperatorWithFallback(
         task_id="atd_knack_update_data_tracker_inventory_items_from_finance_inventory",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_inventory_items_nightly_snapshot.py
+++ b/dags/atd_knack_inventory_items_nightly_snapshot.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -99,7 +99,6 @@ def atd_knack_inventory_items_nightly_snapshot():
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_inventory_items_nightly_snapshot.py
+++ b/dags/atd_knack_inventory_items_nightly_snapshot.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from utils.docker_operator import DockerOperatorWithFallback
+from airflow.providers.docker.operators.docker import DockerOperator
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -102,7 +103,7 @@ def atd_knack_inventory_items_nightly_snapshot():
         mount_tmp_dir=False,
     )
 
-    load_inventory_items_to_socrata_task = DockerOperatorWithFallback(
+    load_inventory_items_to_socrata_task = DockerOperator(
         task_id="atd_knack_inventory_items_nightly_snapshot_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -113,7 +114,7 @@ def atd_knack_inventory_items_nightly_snapshot():
         mount_tmp_dir=False,
     )
 
-    backup_inventory_items_socrata_task = DockerOperatorWithFallback(
+    backup_inventory_items_socrata_task = DockerOperator(
         task_id="atd_knack_inventory_items_nightly_snapshot_socrata_backup",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_inventory_items_nightly_snapshot.py
+++ b/dags/atd_knack_inventory_items_nightly_snapshot.py
@@ -91,7 +91,7 @@ def atd_knack_inventory_items_nightly_snapshot():
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    load_inventory_items_to_postgrest_task = DockerOperator(
+    load_inventory_items_to_postgrest_task = DockerOperatorWithFallback(
         task_id="atd_knack_inventory_items_nightly_snapshot_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -102,7 +102,7 @@ def atd_knack_inventory_items_nightly_snapshot():
         mount_tmp_dir=False,
     )
 
-    load_inventory_items_to_socrata_task = DockerOperator(
+    load_inventory_items_to_socrata_task = DockerOperatorWithFallback(
         task_id="atd_knack_inventory_items_nightly_snapshot_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -113,7 +113,7 @@ def atd_knack_inventory_items_nightly_snapshot():
         mount_tmp_dir=False,
     )
 
-    backup_inventory_items_socrata_task = DockerOperator(
+    backup_inventory_items_socrata_task = DockerOperatorWithFallback(
         task_id="atd_knack_inventory_items_nightly_snapshot_socrata_backup",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_inventory_items_nightly_snapshot.py
+++ b/dags/atd_knack_inventory_items_nightly_snapshot.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from utils.docker_operator import DockerOperatorWithFallback
-from airflow.providers.docker.operators.docker import DockerOperator
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -93,6 +92,7 @@ def atd_knack_inventory_items_nightly_snapshot():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     load_inventory_items_to_postgrest_task = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_inventory_items_nightly_snapshot_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -103,7 +103,7 @@ def atd_knack_inventory_items_nightly_snapshot():
         mount_tmp_dir=False,
     )
 
-    load_inventory_items_to_socrata_task = DockerOperator(
+    load_inventory_items_to_socrata_task = DockerOperatorWithFallback(
         task_id="atd_knack_inventory_items_nightly_snapshot_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -114,7 +114,7 @@ def atd_knack_inventory_items_nightly_snapshot():
         mount_tmp_dir=False,
     )
 
-    backup_inventory_items_socrata_task = DockerOperator(
+    backup_inventory_items_socrata_task = DockerOperatorWithFallback(
         task_id="atd_knack_inventory_items_nightly_snapshot_socrata_backup",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_inventory_transactions.py
+++ b/dags/atd_knack_inventory_transactions.py
@@ -3,7 +3,6 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -89,6 +88,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_inventory_transactions_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -99,7 +99,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_inventory_transactions_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_inventory_transactions.py
+++ b/dags/atd_knack_inventory_transactions.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -95,7 +95,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_inventory_transactions.py
+++ b/dags/atd_knack_inventory_transactions.py
@@ -87,7 +87,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_inventory_transactions_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -98,7 +98,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_inventory_transactions_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_inventory_transactions.py
+++ b/dags/atd_knack_inventory_transactions.py
@@ -3,6 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -98,7 +99,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="atd_knack_inventory_transactions_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_markings_attachments.py
+++ b/dags/atd_knack_markings_attachments.py
@@ -4,6 +4,7 @@ from os import getenv
 
 from airflow.sdk import DAG
 from utils.docker_operator import DockerOperatorWithFallback
+from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -79,7 +80,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="atd_knack_markings_attachments_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_markings_attachments.py
+++ b/dags/atd_knack_markings_attachments.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -76,7 +76,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_markings_attachments.py
+++ b/dags/atd_knack_markings_attachments.py
@@ -4,7 +4,6 @@ from os import getenv
 
 from airflow.sdk import DAG
 from utils.docker_operator import DockerOperatorWithFallback
-from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -70,6 +69,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_markings_attachments_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -80,7 +80,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_attachments_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_markings_attachments.py
+++ b/dags/atd_knack_markings_attachments.py
@@ -68,7 +68,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_attachments_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -79,7 +79,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_attachments_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_markings_materials.py
+++ b/dags/atd_knack_markings_materials.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -67,6 +66,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     to_postgrest = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_markings_materials_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -77,7 +77,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    to_agol = DockerOperator(
+    to_agol = DockerOperatorWithFallback(
         task_id="atd_knack_markings_materials_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_markings_materials.py
+++ b/dags/atd_knack_markings_materials.py
@@ -65,7 +65,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_materials_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -76,7 +76,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_materials_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_markings_materials.py
+++ b/dags/atd_knack_markings_materials.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -65,7 +66,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    to_postgrest = DockerOperatorWithFallback(
         task_id="atd_knack_markings_materials_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -76,7 +77,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    to_agol = DockerOperator(
         task_id="atd_knack_markings_materials_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -87,4 +88,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    date_filter_arg >> t1 >> t2
+    date_filter_arg >> to_postgrest >> to_agol

--- a/dags/atd_knack_markings_materials.py
+++ b/dags/atd_knack_markings_materials.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -73,7 +73,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -85,7 +84,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_markings_specifications.py
+++ b/dags/atd_knack_markings_specifications.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -68,6 +67,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_markings_specifications_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -78,7 +78,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_specifications_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_markings_specifications.py
+++ b/dags/atd_knack_markings_specifications.py
@@ -66,7 +66,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_specifications_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -77,7 +77,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_specifications_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_markings_specifications.py
+++ b/dags/atd_knack_markings_specifications.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -77,7 +78,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="atd_knack_markings_specifications_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_markings_specifications.py
+++ b/dags/atd_knack_markings_specifications.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -74,7 +74,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -86,7 +85,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_markings_work_orders_jobs.py
+++ b/dags/atd_knack_markings_work_orders_jobs.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -87,7 +87,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -99,7 +98,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_markings_work_orders_jobs.py
+++ b/dags/atd_knack_markings_work_orders_jobs.py
@@ -79,7 +79,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_work_orders_jobs_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -90,7 +90,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_work_orders_jobs_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -101,7 +101,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_jobs_agol_build_markings_segment_geometries",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -112,7 +112,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperator(
+    t4 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_work_orders_jobs_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_markings_work_orders_jobs.py
+++ b/dags/atd_knack_markings_work_orders_jobs.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -81,6 +80,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_markings_work_orders_jobs_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -91,7 +91,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_work_orders_jobs_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -102,7 +102,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_jobs_agol_build_markings_segment_geometries",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -113,7 +113,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperator(
+    t4 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_work_orders_jobs_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_markings_work_orders_jobs.py
+++ b/dags/atd_knack_markings_work_orders_jobs.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
@@ -90,7 +91,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    t2 = DockerOperator(
         task_id="atd_knack_markings_work_orders_jobs_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -101,7 +102,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperatorWithFallback(
+    t3 = DockerOperator(
         task_id="atd_knack_markings_jobs_agol_build_markings_segment_geometries",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -112,7 +113,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperatorWithFallback(
+    t4 = DockerOperator(
         task_id="atd_knack_markings_work_orders_jobs_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_mmc_activities_to_socrata.py
+++ b/dags/atd_knack_mmc_activities_to_socrata.py
@@ -86,7 +86,7 @@ def atd_knack_mmc_activities_to_socrata():
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    to_postgrest = DockerOperator(
+    to_postgrest = DockerOperatorWithFallback(
         task_id="atd_knack_mmc_activities_to_socrata_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -97,7 +97,7 @@ def atd_knack_mmc_activities_to_socrata():
         mount_tmp_dir=False,
     )
 
-    to_socrata = DockerOperator(
+    to_socrata = DockerOperatorWithFallback(
         task_id="atd_knack_mmc_activities_to_socrata_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_mmc_activities_to_socrata.py
+++ b/dags/atd_knack_mmc_activities_to_socrata.py
@@ -1,7 +1,6 @@
 from os import getenv
 
 from utils.docker_operator import DockerOperatorWithFallback
-from airflow.providers.docker.operators.docker import DockerOperator
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -88,6 +87,7 @@ def atd_knack_mmc_activities_to_socrata():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     to_postgrest = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_mmc_activities_to_socrata_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -98,7 +98,7 @@ def atd_knack_mmc_activities_to_socrata():
         mount_tmp_dir=False,
     )
 
-    to_socrata = DockerOperator(
+    to_socrata = DockerOperatorWithFallback(
         task_id="atd_knack_mmc_activities_to_socrata_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_mmc_activities_to_socrata.py
+++ b/dags/atd_knack_mmc_activities_to_socrata.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -94,7 +94,6 @@ def atd_knack_mmc_activities_to_socrata():
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_mmc_activities_to_socrata.py
+++ b/dags/atd_knack_mmc_activities_to_socrata.py
@@ -1,6 +1,7 @@
 from os import getenv
 
 from utils.docker_operator import DockerOperatorWithFallback
+from airflow.providers.docker.operators.docker import DockerOperator
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -97,7 +98,7 @@ def atd_knack_mmc_activities_to_socrata():
         mount_tmp_dir=False,
     )
 
-    to_socrata = DockerOperatorWithFallback(
+    to_socrata = DockerOperator(
         task_id="atd_knack_mmc_activities_to_socrata_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_mmc_issues.py
+++ b/dags/atd_knack_mmc_issues.py
@@ -1,5 +1,6 @@
 from os import getenv
 
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
@@ -98,7 +99,7 @@ def atd_knack_mmc_issues():
         mount_tmp_dir=False,
     )
 
-    to_socrata = DockerOperatorWithFallback(
+    to_socrata = DockerOperator(
         task_id="atd_knack_mmc_issues_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_mmc_issues.py
+++ b/dags/atd_knack_mmc_issues.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -95,7 +95,6 @@ def atd_knack_mmc_issues():
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_mmc_issues.py
+++ b/dags/atd_knack_mmc_issues.py
@@ -87,7 +87,7 @@ def atd_knack_mmc_issues():
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    to_postgrest = DockerOperator(
+    to_postgrest = DockerOperatorWithFallback(
         task_id="atd_knack_mmc_issues_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -98,7 +98,7 @@ def atd_knack_mmc_issues():
         mount_tmp_dir=False,
     )
 
-    to_socrata = DockerOperator(
+    to_socrata = DockerOperatorWithFallback(
         task_id="atd_knack_mmc_issues_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_mmc_issues.py
+++ b/dags/atd_knack_mmc_issues.py
@@ -1,6 +1,5 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
@@ -89,6 +88,7 @@ def atd_knack_mmc_issues():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     to_postgrest = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_mmc_issues_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -99,7 +99,7 @@ def atd_knack_mmc_issues():
         mount_tmp_dir=False,
     )
 
-    to_socrata = DockerOperator(
+    to_socrata = DockerOperatorWithFallback(
         task_id="atd_knack_mmc_issues_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_purchase_request_copier.py
+++ b/dags/atd_knack_purchase_request_copier.py
@@ -70,8 +70,8 @@ with DAG(
         command=f"./atd-knack-services/services/purchase_request_copier.py -a {app_name} -c {container}",
         environment=env_vars,
         tty=True,
+        force_pull=False, # atd_knack_signals pulls this image every 5 minutes
         mount_tmp_dir=False,
-        force_pull=False,
     )
 
     t1

--- a/dags/atd_knack_purchase_request_copier.py
+++ b/dags/atd_knack_purchase_request_copier.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -70,7 +70,6 @@ with DAG(
         command=f"./atd-knack-services/services/purchase_request_copier.py -a {app_name} -c {container}",
         environment=env_vars,
         tty=True,
-        force_pull=False,  # atd_knack_signals pulls this image every 5 minutes
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_purchase_request_copier.py
+++ b/dags/atd_knack_purchase_request_copier.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -62,7 +62,8 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
+        force_pull=False,  # atd_knack_signals pulls this image every 5 minutes
         task_id="purchase_request_copier",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -70,7 +71,6 @@ with DAG(
         command=f"./atd-knack-services/services/purchase_request_copier.py -a {app_name} -c {container}",
         environment=env_vars,
         tty=True,
-        force_pull=False, # atd_knack_signals pulls this image every 5 minutes
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_purchase_request_copier.py
+++ b/dags/atd_knack_purchase_request_copier.py
@@ -62,7 +62,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="purchase_request_copier",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_purchase_request_copier.py
+++ b/dags/atd_knack_purchase_request_copier.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from utils.docker_operator import DockerOperatorWithFallback
+from airflow.providers.docker.operators.docker import DockerOperator
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -62,7 +62,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    t1 = DockerOperator(
         task_id="purchase_request_copier",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -71,6 +71,7 @@ with DAG(
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,
+        force_pull=False,
     )
 
     t1

--- a/dags/atd_knack_school_beacons.py
+++ b/dags/atd_knack_school_beacons.py
@@ -78,6 +78,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_school_beacons_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_school_beacons.py
+++ b/dags/atd_knack_school_beacons.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -85,7 +85,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_school_beacons.py
+++ b/dags/atd_knack_school_beacons.py
@@ -77,7 +77,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_school_beacons_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -88,7 +88,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_school_beacons_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -99,7 +99,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_school_beacons_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_school_zone_beacon_zones.py
+++ b/dags/atd_knack_school_zone_beacon_zones.py
@@ -67,6 +67,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_school_zone_beacon_zones_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_school_zone_beacon_zones.py
+++ b/dags/atd_knack_school_zone_beacon_zones.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -74,7 +74,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_school_zone_beacon_zones.py
+++ b/dags/atd_knack_school_zone_beacon_zones.py
@@ -66,7 +66,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_school_zone_beacon_zones_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -77,7 +77,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_school_zone_beacon_zones_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_secondary_signals.py
+++ b/dags/atd_knack_secondary_signals.py
@@ -59,6 +59,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="update_secondary_signals",
         image="atddocker/atd-knack-services:production",
         docker_conn_id="docker_default",

--- a/dags/atd_knack_secondary_signals.py
+++ b/dags/atd_knack_secondary_signals.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -66,7 +66,6 @@ with DAG(
         command=f"./atd-knack-services/services/secondary_signals_updater.py -a data-tracker -c view_197",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_secondary_signals.py
+++ b/dags/atd_knack_secondary_signals.py
@@ -58,7 +58,7 @@ with DAG(
 ) as dag:
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="update_secondary_signals",
         image="atddocker/atd-knack-services:production",
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signal_cabinets.py
+++ b/dags/atd_knack_signal_cabinets.py
@@ -78,6 +78,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_signal_cabinets_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signal_cabinets.py
+++ b/dags/atd_knack_signal_cabinets.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -85,7 +85,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_signal_cabinets.py
+++ b/dags/atd_knack_signal_cabinets.py
@@ -77,7 +77,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_signal_cabinets_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -88,7 +88,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_signal_cabinets_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -99,7 +99,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_signal_cabinets_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signal_detection_status_log.py
+++ b/dags/atd_knack_signal_detection_status_log.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -95,7 +95,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_signal_detection_status_log.py
+++ b/dags/atd_knack_signal_detection_status_log.py
@@ -88,6 +88,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_traffic_signal_detection_status_log_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signal_detection_status_log.py
+++ b/dags/atd_knack_signal_detection_status_log.py
@@ -87,7 +87,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_traffic_signal_detection_status_log_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -98,7 +98,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_traffic_signal_detection_status_log_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signal_requests.py
+++ b/dags/atd_knack_signal_requests.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.knack import get_date_filter_arg
@@ -93,7 +93,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_signal_requests.py
+++ b/dags/atd_knack_signal_requests.py
@@ -84,7 +84,7 @@ with DAG(
 
     date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="signal_requests_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -96,7 +96,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="signal_requests_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signal_requests.py
+++ b/dags/atd_knack_signal_requests.py
@@ -85,6 +85,7 @@ with DAG(
     date_filter_arg = get_date_filter_arg(should_replace_monthly=True)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="signal_requests_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signal_studies.py
+++ b/dags/atd_knack_signal_studies.py
@@ -93,7 +93,7 @@ with DAG(
 
     env_vars = get_env_vars()
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_signal_studies_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -105,7 +105,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_signal_studies_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signal_studies.py
+++ b/dags/atd_knack_signal_studies.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.slack_operator import task_fail_slack_alert
@@ -102,7 +102,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_signal_studies.py
+++ b/dags/atd_knack_signal_studies.py
@@ -94,6 +94,7 @@ with DAG(
     env_vars = get_env_vars()
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_signal_studies_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signal_work_orders.py
+++ b/dags/atd_knack_signal_work_orders.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -96,7 +96,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_signal_work_orders.py
+++ b/dags/atd_knack_signal_work_orders.py
@@ -88,7 +88,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_signal_work_orders_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -99,7 +99,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_signal_work_orders_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signal_work_orders.py
+++ b/dags/atd_knack_signal_work_orders.py
@@ -89,6 +89,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_signal_work_orders_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signals.py
+++ b/dags/atd_knack_signals.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -104,7 +104,6 @@ def atd_knack_signals():
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_signals.py
+++ b/dags/atd_knack_signals.py
@@ -96,7 +96,7 @@ def atd_knack_signals():
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    to_postgrest = DockerOperator(
+    to_postgrest = DockerOperatorWithFallback(
         task_id="atd_knack_signals_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -107,7 +107,7 @@ def atd_knack_signals():
         mount_tmp_dir=False,
     )
 
-    to_socrata = DockerOperator(
+    to_socrata = DockerOperatorWithFallback(
         task_id="atd_knack_signals_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -118,7 +118,7 @@ def atd_knack_signals():
         mount_tmp_dir=False,
     )
 
-    to_agol = DockerOperator(
+    to_agol = DockerOperatorWithFallback(
         task_id="atd_knack_signals_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signals.py
+++ b/dags/atd_knack_signals.py
@@ -97,6 +97,7 @@ def atd_knack_signals():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     to_postgrest = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_signals_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signs_markings_reimbursements.py
+++ b/dags/atd_knack_signs_markings_reimbursements.py
@@ -71,6 +71,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_signs_markings_reimbursements_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signs_markings_reimbursements.py
+++ b/dags/atd_knack_signs_markings_reimbursements.py
@@ -70,7 +70,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_signs_markings_reimbursements_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -81,7 +81,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_signs_markings_reimbursements_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signs_markings_reimbursements.py
+++ b/dags/atd_knack_signs_markings_reimbursements.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -78,7 +78,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_signs_markings_time_logs.py
+++ b/dags/atd_knack_signs_markings_time_logs.py
@@ -73,6 +73,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_signs_time_logs_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signs_markings_time_logs.py
+++ b/dags/atd_knack_signs_markings_time_logs.py
@@ -72,7 +72,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_signs_time_logs_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -83,7 +83,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_time_logs_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -94,7 +94,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_signs_time_logs_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -105,7 +105,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperator(
+    t4 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_time_logs_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signs_markings_time_logs.py
+++ b/dags/atd_knack_signs_markings_time_logs.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -80,7 +80,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container_signs} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_signs_materials.py
+++ b/dags/atd_knack_signs_materials.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -74,7 +74,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_signs_materials.py
+++ b/dags/atd_knack_signs_materials.py
@@ -66,7 +66,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="signs_materials_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -77,7 +77,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="signs_materials_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signs_materials.py
+++ b/dags/atd_knack_signs_materials.py
@@ -67,6 +67,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="signs_materials_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signs_work_order_attachments.py
+++ b/dags/atd_knack_signs_work_order_attachments.py
@@ -66,7 +66,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="signs_attachment_specs_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -77,7 +77,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="signs_attachments_specs_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signs_work_order_attachments.py
+++ b/dags/atd_knack_signs_work_order_attachments.py
@@ -67,6 +67,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="signs_attachment_specs_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signs_work_order_attachments.py
+++ b/dags/atd_knack_signs_work_order_attachments.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -74,7 +74,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_signs_work_order_specifications.py
+++ b/dags/atd_knack_signs_work_order_specifications.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -86,7 +86,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_signs_work_order_specifications.py
+++ b/dags/atd_knack_signs_work_order_specifications.py
@@ -79,6 +79,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="signs_asset_specs_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signs_work_order_specifications.py
+++ b/dags/atd_knack_signs_work_order_specifications.py
@@ -78,7 +78,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="signs_asset_specs_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -89,7 +89,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="signs_asset_specs_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -100,7 +100,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="signs_asset_specs_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signs_work_orders.py
+++ b/dags/atd_knack_signs_work_orders.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -87,7 +87,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -99,7 +98,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_signs_work_orders.py
+++ b/dags/atd_knack_signs_work_orders.py
@@ -79,7 +79,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_signs_work_orders_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -90,7 +90,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_signs_work_orders_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -101,7 +101,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_work_orders_signs_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_signs_work_orders.py
+++ b/dags/atd_knack_signs_work_orders.py
@@ -80,6 +80,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_signs_work_orders_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_smd_311_csr.py
+++ b/dags/atd_knack_smd_311_csr.py
@@ -90,6 +90,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="smd_311_csrs_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_smd_311_csr.py
+++ b/dags/atd_knack_smd_311_csr.py
@@ -89,7 +89,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="smd_311_csrs_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -100,7 +100,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="smd_311_csrs_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_smd_311_csr.py
+++ b/dags/atd_knack_smd_311_csr.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -97,7 +97,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_tcp_submissions.py
+++ b/dags/atd_knack_tcp_submissions.py
@@ -89,6 +89,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_tcp_submissions_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_tcp_submissions.py
+++ b/dags/atd_knack_tcp_submissions.py
@@ -88,7 +88,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_tcp_submissions_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -99,7 +99,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_tcp_submissions_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_tcp_submissions.py
+++ b/dags/atd_knack_tcp_submissions.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration, now
 
 from utils.onepassword import get_env_vars_task
@@ -96,7 +96,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_traffic_detectors_weekly_snapshot.py
+++ b/dags/atd_knack_traffic_detectors_weekly_snapshot.py
@@ -102,6 +102,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_traffic_detectors_weekly_snapshot_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_traffic_detectors_weekly_snapshot.py
+++ b/dags/atd_knack_traffic_detectors_weekly_snapshot.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -109,7 +109,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_traffic_detectors_weekly_snapshot.py
+++ b/dags/atd_knack_traffic_detectors_weekly_snapshot.py
@@ -101,7 +101,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_traffic_detectors_weekly_snapshot_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -112,7 +112,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_traffic_detectors_weekly_snapshot_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -123,7 +123,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_traffic_detectors_weekly_snapshot_socrata_backup",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_work_orders_markings.py
+++ b/dags/atd_knack_work_orders_markings.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -87,7 +87,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -99,7 +98,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_work_orders_markings.py
+++ b/dags/atd_knack_work_orders_markings.py
@@ -80,6 +80,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_markings_work_orders_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_work_orders_markings.py
+++ b/dags/atd_knack_work_orders_markings.py
@@ -79,7 +79,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_work_orders_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -90,7 +90,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_work_orders_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -101,7 +101,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_work_orders_agol_build_markings_segment_geometries",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -112,7 +112,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperator(
+    t4 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_work_orders_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_work_orders_markings_contractors.py
+++ b/dags/atd_knack_work_orders_markings_contractors.py
@@ -79,7 +79,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_contractor_work_orders_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -90,7 +90,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_work_orders_to_agol",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -101,7 +101,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_contractor_work_orders_agol_build_markings_segment_geometries",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -112,7 +112,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperator(
+    t4 = DockerOperatorWithFallback(
         task_id="atd_knack_markings_contractor_work_orders_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_knack_work_orders_markings_contractors.py
+++ b/dags/atd_knack_work_orders_markings_contractors.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -87,7 +87,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_postgrest.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -99,7 +98,6 @@ with DAG(
         command=f"./atd-knack-services/services/records_to_agol.py -a {app_name} -c {container} {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_knack_work_orders_markings_contractors.py
+++ b/dags/atd_knack_work_orders_markings_contractors.py
@@ -80,6 +80,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="atd_knack_markings_contractor_work_orders_to_postgrest",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -115,7 +115,7 @@ with DAG(
 
     branch = branch()
 
-    full = DockerOperator(
+    full = DockerOperatorWithFallback(
         task_id="moped_components_to_agol_full",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -127,7 +127,7 @@ with DAG(
         execution_timeout=duration(minutes=30),
     )
 
-    incremental = DockerOperator(
+    incremental = DockerOperatorWithFallback(
         task_id="moped_components_to_agol_incremental",
         image=docker_image,
         auto_remove="force",

--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG, task, Param
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration, parse
 
 from utils.onepassword import get_env_vars_task
@@ -123,7 +123,6 @@ with DAG(
         command=f"python components_to_agol.py {args}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
         execution_timeout=duration(minutes=30),
     )
@@ -135,7 +134,6 @@ with DAG(
         command=f"python components_to_agol.py {args}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
         execution_timeout=duration(minutes=5),
     )

--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -116,6 +116,7 @@ with DAG(
     branch = branch()
 
     full = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="moped_components_to_agol_full",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -3,7 +3,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -77,7 +77,6 @@ with DAG(
         command=f"python data_tracker_sync.py {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -69,7 +69,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="data_tracker_sync",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_moped_data_tracker_sync.py
+++ b/dags/atd_moped_data_tracker_sync.py
@@ -69,7 +69,8 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    data_tracker_sync = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="data_tracker_sync",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -80,4 +81,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    date_filter_arg >> t1
+    date_filter_arg >> data_tracker_sync

--- a/dags/atd_moped_ecapris_funding_sync.py
+++ b/dags/atd_moped_ecapris_funding_sync.py
@@ -2,7 +2,7 @@
 
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag, Param, task
 from pendulum import datetime, duration
 
@@ -127,7 +127,6 @@ def sync_ecapris_funding():
         "auto_remove": "force",
         "environment": env_vars,
         "tty": True,
-        "force_pull": True,
         "mount_tmp_dir": False,
     }
 

--- a/dags/atd_moped_ecapris_funding_sync.py
+++ b/dags/atd_moped_ecapris_funding_sync.py
@@ -130,13 +130,13 @@ def sync_ecapris_funding():
         "mount_tmp_dir": False,
     }
 
-    ecapris_funding_sync_dry_run = DockerOperator(
+    ecapris_funding_sync_dry_run = DockerOperatorWithFallback(
         task_id="ecapris_funding_sync_dry_run",
         command="python3.14 ecapris_funding_sync.py -n",
         **common_docker_config,
     )
 
-    ecapris_funding_sync = DockerOperator(
+    ecapris_funding_sync = DockerOperatorWithFallback(
         task_id="ecapris_funding_sync",
         command=f"python3.14 ecapris_funding_sync.py",
         **common_docker_config,

--- a/dags/atd_moped_ecapris_funding_sync.py
+++ b/dags/atd_moped_ecapris_funding_sync.py
@@ -131,6 +131,7 @@ def sync_ecapris_funding():
     }
 
     ecapris_funding_sync_dry_run = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="ecapris_funding_sync_dry_run",
         command="python3.14 ecapris_funding_sync.py -n",
         **common_docker_config,

--- a/dags/atd_moped_ecapris_status_sync.py
+++ b/dags/atd_moped_ecapris_status_sync.py
@@ -98,6 +98,7 @@ def sync_ecapris_statuses():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     ecapris_statuses_to_moped = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="ecapris_statuses_to_moped",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_moped_ecapris_status_sync.py
+++ b/dags/atd_moped_ecapris_status_sync.py
@@ -2,7 +2,7 @@
 
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag, Param, task
 from pendulum import datetime, duration
 
@@ -105,7 +105,6 @@ def sync_ecapris_statuses():
         command=f"python3.12 ecapris_statuses_sync.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_moped_ecapris_status_sync.py
+++ b/dags/atd_moped_ecapris_status_sync.py
@@ -97,7 +97,7 @@ def sync_ecapris_statuses():
     REQUIRED_SECRETS = get_required_secrets()
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    ecapris_statuses_to_moped = DockerOperator(
+    ecapris_statuses_to_moped = DockerOperatorWithFallback(
         task_id="ecapris_statuses_to_moped",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_parking_data.py
+++ b/dags/atd_parking_data.py
@@ -147,7 +147,7 @@ with DAG(
 
     docker_tasks = []
     docker_tasks.append(
-        DockerOperator(
+        DockerOperatorWithFallback(
             task_id="smartfolio_transactions",
             image=docker_image,
             docker_conn_id="docker_default",
@@ -162,7 +162,7 @@ with DAG(
     )
 
     docker_tasks.append(
-        DockerOperator(
+        DockerOperatorWithFallback(
             task_id="process_smartfolio_transactions",
             image=docker_image,
             docker_conn_id="docker_default",
@@ -177,7 +177,7 @@ with DAG(
     )
 
     docker_tasks.append(
-        DockerOperator(
+        DockerOperatorWithFallback(
             task_id="transactions_to_socrata",
             image=docker_image,
             docker_conn_id="docker_default",

--- a/dags/atd_parking_data.py
+++ b/dags/atd_parking_data.py
@@ -148,6 +148,7 @@ with DAG(
     docker_tasks = []
     docker_tasks.append(
         DockerOperatorWithFallback(
+            force_pull=True,
             task_id="smartfolio_transactions",
             image=docker_image,
             docker_conn_id="docker_default",

--- a/dags/atd_parking_data.py
+++ b/dags/atd_parking_data.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from airflow.sdk import task, DAG, Param
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration, parse, now
 
 from utils.onepassword import get_env_vars_task
@@ -156,7 +156,6 @@ with DAG(
             auto_remove="force",
             environment=env_vars,
             tty=True,
-            force_pull=True,
             retries=3,
             retry_delay=duration(seconds=60),
         )
@@ -172,7 +171,6 @@ with DAG(
             auto_remove="force",
             environment=env_vars,
             tty=True,
-            force_pull=False,
             retries=3,
             retry_delay=duration(seconds=60),
         )
@@ -188,7 +186,6 @@ with DAG(
             auto_remove="force",
             environment=env_vars,
             tty=True,
-            force_pull=False,
             retries=3,
             retry_delay=duration(seconds=60),
         )

--- a/dags/atd_road_conditions_socrata.py
+++ b/dags/atd_road_conditions_socrata.py
@@ -67,6 +67,7 @@ def road_conditions_socrata():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     publish_road_conditions_to_socrata = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="road_conditions_socrata",
         image="atddocker/atd-road-conditions:production",
         docker_conn_id="docker_default",

--- a/dags/atd_road_conditions_socrata.py
+++ b/dags/atd_road_conditions_socrata.py
@@ -66,7 +66,7 @@ def road_conditions_socrata():
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    publish_road_conditions_to_socrata = DockerOperator(
+    publish_road_conditions_to_socrata = DockerOperatorWithFallback(
         task_id="road_conditions_socrata",
         image="atddocker/atd-road-conditions:production",
         docker_conn_id="docker_default",

--- a/dags/atd_road_conditions_socrata.py
+++ b/dags/atd_road_conditions_socrata.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag
 from pendulum import datetime, duration
 
@@ -74,7 +74,6 @@ def road_conditions_socrata():
         command=f"./atd-road-conditions/socrata.py {date_filter_arg}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -56,7 +56,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    DockerOperator(
+    DockerOperatorWithFallback(
         task_id="github_to_dts_portal",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -57,6 +57,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     DockerOperatorWithFallback(
+        force_pull=True,
         task_id="github_to_dts_portal",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_service_bot_index_issues_to_dts_portal.py
+++ b/dags/atd_service_bot_index_issues_to_dts_portal.py
@@ -2,7 +2,7 @@ from os import getenv
 from pendulum import datetime, duration
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 
 from utils.slack_operator import task_fail_slack_alert
 from utils.onepassword import get_env_vars_task
@@ -65,6 +65,5 @@ with DAG(
         command="./atd-service-bot/gh_index_issues_to_dts_portal.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )

--- a/dags/atd_service_bot_intake.py
+++ b/dags/atd_service_bot_intake.py
@@ -2,7 +2,7 @@ from os import getenv
 from pendulum import datetime, duration
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 
 from utils.slack_operator import task_fail_slack_alert
 from utils.onepassword import get_env_vars_task
@@ -65,6 +65,5 @@ with DAG(
         command="./atd-service-bot/intake.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )

--- a/dags/atd_service_bot_intake.py
+++ b/dags/atd_service_bot_intake.py
@@ -56,7 +56,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    DockerOperator(
+    DockerOperatorWithFallback(
         task_id="dts_sr_to_github",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_service_bot_intake.py
+++ b/dags/atd_service_bot_intake.py
@@ -57,6 +57,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     DockerOperatorWithFallback(
+        force_pull=True,
         task_id="dts_sr_to_github",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -2,7 +2,7 @@ from os import getenv
 from pendulum import datetime, duration
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 
 from utils.slack_operator import task_fail_slack_alert
 from utils.onepassword import get_env_vars_task
@@ -78,6 +78,5 @@ with DAG(
         command="./atd-service-bot/issues_to_socrata.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -69,7 +69,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    DockerOperator(
+    DockerOperatorWithFallback(
         task_id="dts_github_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_service_bot_issues_to_socrata.py
+++ b/dags/atd_service_bot_issues_to_socrata.py
@@ -70,6 +70,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     DockerOperatorWithFallback(
+        force_pull=True,
         task_id="dts_github_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_signal_comms.py
+++ b/dags/atd_signal_comms.py
@@ -1,5 +1,6 @@
 from os import getenv
 
+from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag, task
 from pendulum import datetime, duration
@@ -122,7 +123,7 @@ def atd_signal_comms():
         network_mode="bridge",
     )
 
-    detectors_s3 = DockerOperatorWithFallback(
+    detectors_s3 = DockerOperator(
         task_id="run_comm_check_detectors",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -132,9 +133,10 @@ def atd_signal_comms():
         tty=True,
         mount_tmp_dir=False,
         network_mode="bridge",
+        force_pull=False,
     )
 
-    dms_s3 = DockerOperatorWithFallback(
+    dms_s3 = DockerOperator(
         task_id="run_comm_check_dms",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -144,9 +146,10 @@ def atd_signal_comms():
         tty=True,
         mount_tmp_dir=False,
         network_mode="bridge",
+        force_pull=False,
     )
 
-    battery_backup_s3 = DockerOperatorWithFallback(
+    battery_backup_s3 = DockerOperator(
         task_id="run_comm_check_battery_backup",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -156,9 +159,10 @@ def atd_signal_comms():
         tty=True,
         mount_tmp_dir=False,
         network_mode="bridge",
+        force_pull=False,
     )
 
-    signal_monitors_s3 = DockerOperatorWithFallback(
+    signal_monitors_s3 = DockerOperator(
         task_id="run_comm_check_signal_monitors",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -168,9 +172,10 @@ def atd_signal_comms():
         tty=True,
         mount_tmp_dir=False,
         network_mode="bridge",
+        force_pull=False,
     )
 
-    cameras_socrata = DockerOperatorWithFallback(
+    cameras_socrata = DockerOperator(
         task_id="socrata_pub_cameras",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -180,9 +185,10 @@ def atd_signal_comms():
         tty=True,
         mount_tmp_dir=False,
         network_mode="bridge",
+        force_pull=False,
     )
 
-    detectors_socrata = DockerOperatorWithFallback(
+    detectors_socrata = DockerOperator(
         task_id="socrata_pub_detectors",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -192,9 +198,10 @@ def atd_signal_comms():
         tty=True,
         mount_tmp_dir=False,
         network_mode="bridge",
+        force_pull=False,
     )
 
-    dms_socrata = DockerOperatorWithFallback(
+    dms_socrata = DockerOperator(
         task_id="socrata_pub_dms",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -204,9 +211,10 @@ def atd_signal_comms():
         tty=True,
         mount_tmp_dir=False,
         network_mode="bridge",
+        force_pull=False,
     )
 
-    battery_backup_socrata = DockerOperatorWithFallback(
+    battery_backup_socrata = DockerOperator(
         task_id="socrata_pub_battery_backup",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -216,9 +224,10 @@ def atd_signal_comms():
         tty=True,
         mount_tmp_dir=False,
         network_mode="bridge",
+        force_pull=False,
     )
 
-    signal_monitors_socrata = DockerOperatorWithFallback(
+    signal_monitors_socrata = DockerOperator(
         task_id="socrata_pub_signal_monitors",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -228,6 +237,7 @@ def atd_signal_comms():
         tty=True,
         mount_tmp_dir=False,
         network_mode="bridge",
+        force_pull=False,
     )
 
     (

--- a/dags/atd_signal_comms.py
+++ b/dags/atd_signal_comms.py
@@ -110,7 +110,7 @@ def atd_signal_comms():
     start_date = get_start_date()
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    cameras_s3 = DockerOperator(
+    cameras_s3 = DockerOperatorWithFallback(
         task_id="run_comm_check_cameras",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -122,7 +122,7 @@ def atd_signal_comms():
         network_mode="bridge",
     )
 
-    detectors_s3 = DockerOperator(
+    detectors_s3 = DockerOperatorWithFallback(
         task_id="run_comm_check_detectors",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -134,7 +134,7 @@ def atd_signal_comms():
         network_mode="bridge",
     )
 
-    dms_s3 = DockerOperator(
+    dms_s3 = DockerOperatorWithFallback(
         task_id="run_comm_check_dms",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -146,7 +146,7 @@ def atd_signal_comms():
         network_mode="bridge",
     )
 
-    battery_backup_s3 = DockerOperator(
+    battery_backup_s3 = DockerOperatorWithFallback(
         task_id="run_comm_check_battery_backup",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -158,7 +158,7 @@ def atd_signal_comms():
         network_mode="bridge",
     )
 
-    signal_monitors_s3 = DockerOperator(
+    signal_monitors_s3 = DockerOperatorWithFallback(
         task_id="run_comm_check_signal_monitors",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -170,7 +170,7 @@ def atd_signal_comms():
         network_mode="bridge",
     )
 
-    cameras_socrata = DockerOperator(
+    cameras_socrata = DockerOperatorWithFallback(
         task_id="socrata_pub_cameras",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -182,7 +182,7 @@ def atd_signal_comms():
         network_mode="bridge",
     )
 
-    detectors_socrata = DockerOperator(
+    detectors_socrata = DockerOperatorWithFallback(
         task_id="socrata_pub_detectors",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -194,7 +194,7 @@ def atd_signal_comms():
         network_mode="bridge",
     )
 
-    dms_socrata = DockerOperator(
+    dms_socrata = DockerOperatorWithFallback(
         task_id="socrata_pub_dms",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -206,7 +206,7 @@ def atd_signal_comms():
         network_mode="bridge",
     )
 
-    battery_backup_socrata = DockerOperator(
+    battery_backup_socrata = DockerOperatorWithFallback(
         task_id="socrata_pub_battery_backup",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -218,7 +218,7 @@ def atd_signal_comms():
         network_mode="bridge",
     )
 
-    signal_monitors_socrata = DockerOperator(
+    signal_monitors_socrata = DockerOperatorWithFallback(
         task_id="socrata_pub_signal_monitors",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_signal_comms.py
+++ b/dags/atd_signal_comms.py
@@ -1,6 +1,5 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
 from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag, task
 from pendulum import datetime, duration
@@ -123,7 +122,7 @@ def atd_signal_comms():
         network_mode="bridge",
     )
 
-    detectors_s3 = DockerOperator(
+    detectors_s3 = DockerOperatorWithFallback(
         task_id="run_comm_check_detectors",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -136,7 +135,7 @@ def atd_signal_comms():
         force_pull=False,
     )
 
-    dms_s3 = DockerOperator(
+    dms_s3 = DockerOperatorWithFallback(
         task_id="run_comm_check_dms",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -149,7 +148,7 @@ def atd_signal_comms():
         force_pull=False,
     )
 
-    battery_backup_s3 = DockerOperator(
+    battery_backup_s3 = DockerOperatorWithFallback(
         task_id="run_comm_check_battery_backup",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -162,7 +161,7 @@ def atd_signal_comms():
         force_pull=False,
     )
 
-    signal_monitors_s3 = DockerOperator(
+    signal_monitors_s3 = DockerOperatorWithFallback(
         task_id="run_comm_check_signal_monitors",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -175,7 +174,7 @@ def atd_signal_comms():
         force_pull=False,
     )
 
-    cameras_socrata = DockerOperator(
+    cameras_socrata = DockerOperatorWithFallback(
         task_id="socrata_pub_cameras",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -188,7 +187,7 @@ def atd_signal_comms():
         force_pull=False,
     )
 
-    detectors_socrata = DockerOperator(
+    detectors_socrata = DockerOperatorWithFallback(
         task_id="socrata_pub_detectors",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -201,7 +200,7 @@ def atd_signal_comms():
         force_pull=False,
     )
 
-    dms_socrata = DockerOperator(
+    dms_socrata = DockerOperatorWithFallback(
         task_id="socrata_pub_dms",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -214,7 +213,7 @@ def atd_signal_comms():
         force_pull=False,
     )
 
-    battery_backup_socrata = DockerOperator(
+    battery_backup_socrata = DockerOperatorWithFallback(
         task_id="socrata_pub_battery_backup",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -227,7 +226,7 @@ def atd_signal_comms():
         force_pull=False,
     )
 
-    signal_monitors_socrata = DockerOperator(
+    signal_monitors_socrata = DockerOperatorWithFallback(
         task_id="socrata_pub_signal_monitors",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/atd_signal_comms.py
+++ b/dags/atd_signal_comms.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag, task
 from pendulum import datetime, duration
 
@@ -118,7 +118,6 @@ def atd_signal_comms():
         command=f"python atd-signal-comms/run_comm_check.py camera --env {deployment_stage_abbreviation}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
         network_mode="bridge",
     )
@@ -131,7 +130,6 @@ def atd_signal_comms():
         command=f"python atd-signal-comms/run_comm_check.py detector --env {deployment_stage_abbreviation}",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
         network_mode="bridge",
     )
@@ -144,7 +142,6 @@ def atd_signal_comms():
         command=f"python atd-signal-comms/run_comm_check.py digital_message_sign --env {deployment_stage_abbreviation}",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
         network_mode="bridge",
     )
@@ -157,7 +154,6 @@ def atd_signal_comms():
         command=f"python atd-signal-comms/run_comm_check.py cabinet_battery_backup --env {deployment_stage_abbreviation}",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
         network_mode="bridge",
     )
@@ -170,7 +166,6 @@ def atd_signal_comms():
         command=f"python atd-signal-comms/run_comm_check.py signal_monitor --env {deployment_stage_abbreviation}",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
         network_mode="bridge",
     )
@@ -183,7 +178,6 @@ def atd_signal_comms():
         command=f"python atd-signal-comms/socrata_pub.py camera --start {start_date} -v --env {deployment_stage_abbreviation}",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
         network_mode="bridge",
     )
@@ -196,7 +190,6 @@ def atd_signal_comms():
         command=f"python atd-signal-comms/socrata_pub.py detector --start {start_date} -v --env {deployment_stage_abbreviation}",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
         network_mode="bridge",
     )
@@ -209,7 +202,6 @@ def atd_signal_comms():
         command=f"python atd-signal-comms/socrata_pub.py digital_message_sign --start {start_date} -v --env {deployment_stage_abbreviation}",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
         network_mode="bridge",
     )
@@ -222,7 +214,6 @@ def atd_signal_comms():
         command=f"python atd-signal-comms/socrata_pub.py cabinet_battery_backup --start {start_date} -v --env {deployment_stage_abbreviation}",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
         network_mode="bridge",
     )
@@ -235,7 +226,6 @@ def atd_signal_comms():
         command=f"python atd-signal-comms/socrata_pub.py signal_monitor --start {start_date} -v --env {deployment_stage_abbreviation}",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
         network_mode="bridge",
     )

--- a/dags/dts_311_report_publishing.py
+++ b/dags/dts_311_report_publishing.py
@@ -3,7 +3,7 @@ from os import getenv
 from datetime import timedelta
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -184,7 +184,6 @@ with DAG(
         command="python -m etl.csv_reporting.requests_to_socrata",
         environment=cur_year_env,
         tty=True,
-        force_pull=True,
     )
 
     t2 = DockerOperator(

--- a/dags/dts_311_report_publishing.py
+++ b/dags/dts_311_report_publishing.py
@@ -175,7 +175,8 @@ with DAG(
     prev_year_env = get_env_vars_task(PREV_YEAR_SECRETS)
     two_years_env = get_env_vars_task(TWO_YEARS_AGO_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    cur_year_requests_report_to_socrata = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="cur_year_requests_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -186,7 +187,7 @@ with DAG(
         tty=True,
     )
 
-    t2 = DockerOperatorWithFallback(
+    cur_year_flex_note_report_to_socrata = DockerOperatorWithFallback(
         task_id="cur_year_flex_note_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -197,7 +198,7 @@ with DAG(
         tty=True,
     )
 
-    t3 = DockerOperatorWithFallback(
+    cur_year_activities_report_to_socrata = DockerOperatorWithFallback(
         task_id="cur_year_activities_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -208,7 +209,7 @@ with DAG(
         tty=True,
     )
 
-    t4 = DockerOperatorWithFallback(
+    prev_year_requests_report_to_socrata = DockerOperatorWithFallback(
         task_id="prev_year_requests_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -219,7 +220,7 @@ with DAG(
         tty=True,
     )
 
-    t5 = DockerOperatorWithFallback(
+    prev_year_flex_note_report_to_socrata = DockerOperatorWithFallback(
         task_id="prev_year_flex_note_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -230,7 +231,7 @@ with DAG(
         tty=True,
     )
 
-    t6 = DockerOperatorWithFallback(
+    prev_year_activities_report_to_socrata = DockerOperatorWithFallback(
         task_id="prev_year_activities_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -241,7 +242,7 @@ with DAG(
         tty=True,
     )
 
-    t7 = DockerOperatorWithFallback(
+    two_years_ago_requests_report_to_socrata = DockerOperatorWithFallback(
         task_id="two_years_ago_requests_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -252,7 +253,7 @@ with DAG(
         tty=True,
     )
 
-    t8 = DockerOperatorWithFallback(
+    two_years_ago_flex_note_report_to_socrata = DockerOperatorWithFallback(
         task_id="two_years_ago_flex_note_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -263,7 +264,7 @@ with DAG(
         tty=True,
     )
 
-    t9 = DockerOperatorWithFallback(
+    two_years_ago_activities_report_to_socrata = DockerOperatorWithFallback(
         task_id="two_years_ago_activities_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -274,4 +275,14 @@ with DAG(
         tty=True,
     )
 
-    t1 >> t2 >> t3 >> t4 >> t5 >> t6 >> t7 >> t8 >> t9
+    (
+        cur_year_requests_report_to_socrata
+        >> cur_year_flex_note_report_to_socrata
+        >> cur_year_activities_report_to_socrata
+        >> prev_year_requests_report_to_socrata
+        >> prev_year_flex_note_report_to_socrata
+        >> prev_year_activities_report_to_socrata
+        >> two_years_ago_requests_report_to_socrata
+        >> two_years_ago_flex_note_report_to_socrata
+        >> two_years_ago_activities_report_to_socrata
+    )

--- a/dags/dts_311_report_publishing.py
+++ b/dags/dts_311_report_publishing.py
@@ -175,7 +175,7 @@ with DAG(
     prev_year_env = get_env_vars_task(PREV_YEAR_SECRETS)
     two_years_env = get_env_vars_task(TWO_YEARS_AGO_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="cur_year_requests_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -186,7 +186,7 @@ with DAG(
         tty=True,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="cur_year_flex_note_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -197,7 +197,7 @@ with DAG(
         tty=True,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="cur_year_activities_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -208,7 +208,7 @@ with DAG(
         tty=True,
     )
 
-    t4 = DockerOperator(
+    t4 = DockerOperatorWithFallback(
         task_id="prev_year_requests_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -219,7 +219,7 @@ with DAG(
         tty=True,
     )
 
-    t5 = DockerOperator(
+    t5 = DockerOperatorWithFallback(
         task_id="prev_year_flex_note_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -230,7 +230,7 @@ with DAG(
         tty=True,
     )
 
-    t6 = DockerOperator(
+    t6 = DockerOperatorWithFallback(
         task_id="prev_year_activities_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -241,7 +241,7 @@ with DAG(
         tty=True,
     )
 
-    t7 = DockerOperator(
+    t7 = DockerOperatorWithFallback(
         task_id="two_years_ago_requests_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -252,7 +252,7 @@ with DAG(
         tty=True,
     )
 
-    t8 = DockerOperator(
+    t8 = DockerOperatorWithFallback(
         task_id="two_years_ago_flex_note_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -263,7 +263,7 @@ with DAG(
         tty=True,
     )
 
-    t9 = DockerOperator(
+    t9 = DockerOperatorWithFallback(
         task_id="two_years_ago_activities_report_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/dts_finances_report_publishing.py
+++ b/dags/dts_finances_report_publishing.py
@@ -3,7 +3,7 @@ from os import getenv
 from datetime import timedelta
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -117,7 +117,6 @@ with DAG(
         command=f"python etl/rev_exp_report_to_s3.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
     )
 
     t2 = DockerOperator(
@@ -129,7 +128,6 @@ with DAG(
         command=f"python etl/mstro_reports_to_socrata.py",
         environment=env_vars,
         tty=True,
-        force_pull=False,
     )
 
     t1 >> t2

--- a/dags/dts_finances_report_publishing.py
+++ b/dags/dts_finances_report_publishing.py
@@ -108,7 +108,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="download_microstrategy_reports",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -119,7 +119,7 @@ with DAG(
         tty=True,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="update_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/dts_finances_report_publishing.py
+++ b/dags/dts_finances_report_publishing.py
@@ -108,7 +108,8 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    download_microstrategy_reports = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="download_microstrategy_reports",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -119,7 +120,7 @@ with DAG(
         tty=True,
     )
 
-    t2 = DockerOperatorWithFallback(
+    update_socrata = DockerOperatorWithFallback(
         task_id="update_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -130,4 +131,4 @@ with DAG(
         tty=True,
     )
 
-    t1 >> t2
+    download_microstrategy_reports >> update_socrata

--- a/dags/dts_inspector_priority.py
+++ b/dags/dts_inspector_priority.py
@@ -123,7 +123,8 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    amanda_row_inspector_permit_list = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="amanda_row_inspector_permit_list",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -137,7 +138,7 @@ with DAG(
         trigger_rule="all_done",
     )
 
-    t2 = DockerOperatorWithFallback(
+    amanda_row_inspector_segment_list = DockerOperatorWithFallback(
         task_id="amanda_row_inspector_segment_list",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -151,7 +152,7 @@ with DAG(
         trigger_rule="all_done",
     )
 
-    t3 = DockerOperatorWithFallback(
+    agol_street_segment_tagging = DockerOperatorWithFallback(
         task_id="agol_street_segment_tagging",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -163,7 +164,7 @@ with DAG(
         trigger_rule="all_done",
     )
 
-    t4 = DockerOperatorWithFallback(
+    inspector_prioritization = DockerOperatorWithFallback(
         task_id="inspector_prioritization",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -175,4 +176,9 @@ with DAG(
         trigger_rule="all_done",
     )
 
-    t1 >> t2 >> t3 >> t4
+    (
+        amanda_row_inspector_permit_list
+        >> amanda_row_inspector_segment_list
+        >> agol_street_segment_tagging
+        >> inspector_prioritization
+    )

--- a/dags/dts_inspector_priority.py
+++ b/dags/dts_inspector_priority.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -131,7 +131,6 @@ with DAG(
         command=f"python amanda/amanda_to_s3.py --query row_inspector_permit_list",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
         retries=3,
         retry_delay=duration(seconds=60),

--- a/dags/dts_inspector_priority.py
+++ b/dags/dts_inspector_priority.py
@@ -123,7 +123,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="amanda_row_inspector_permit_list",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -137,7 +137,7 @@ with DAG(
         trigger_rule="all_done",
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="amanda_row_inspector_segment_list",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -151,7 +151,7 @@ with DAG(
         trigger_rule="all_done",
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="agol_street_segment_tagging",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -163,7 +163,7 @@ with DAG(
         trigger_rule="all_done",
     )
 
-    t4 = DockerOperator(
+    t4 = DockerOperatorWithFallback(
         task_id="inspector_prioritization",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/dts_maximo_reporting.py
+++ b/dags/dts_maximo_reporting.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -99,7 +99,6 @@ with DAG(
         command=f"python etl/maximo_to_socrata.py --query work_orders",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 
@@ -111,7 +110,6 @@ with DAG(
         command=f"python etl/maximo_to_socrata.py --query service_requests",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -123,7 +121,6 @@ with DAG(
         command=f"python etl/maximo_to_socrata.py --query work_order_status_history",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -135,7 +132,6 @@ with DAG(
         command=f"python etl/maximo_to_socrata.py --query work_order_time_logs",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -147,7 +143,6 @@ with DAG(
         command=f"python etl/maximo_to_socrata.py --query work_order_materials",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -159,7 +154,6 @@ with DAG(
         command=f"python etl/maximo_to_socrata.py --query work_order_specifications",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 
@@ -171,7 +165,6 @@ with DAG(
         command=f"python etl/maximo_to_socrata.py --query locations",
         environment=env_vars,
         tty=True,
-        force_pull=False,
         mount_tmp_dir=False,
     )
 

--- a/dags/dts_maximo_reporting.py
+++ b/dags/dts_maximo_reporting.py
@@ -91,7 +91,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="maximo_workorders_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -102,7 +102,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="maximo_service_requests_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -113,7 +113,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperator(
+    t3 = DockerOperatorWithFallback(
         task_id="maximo_work_order_history_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -124,7 +124,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperator(
+    t4 = DockerOperatorWithFallback(
         task_id="work_order_time_logs_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -135,7 +135,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t5 = DockerOperator(
+    t5 = DockerOperatorWithFallback(
         task_id="work_order_materials_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -146,7 +146,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t6 = DockerOperator(
+    t6 = DockerOperatorWithFallback(
         task_id="work_order_specifications_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -157,7 +157,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t7 = DockerOperator(
+    t7 = DockerOperatorWithFallback(
         task_id="maximo_locations_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/dts_maximo_reporting.py
+++ b/dags/dts_maximo_reporting.py
@@ -91,7 +91,8 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    maximo_workorders_to_socrata = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="maximo_workorders_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -102,7 +103,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    maximo_service_requests_to_socrata = DockerOperatorWithFallback(
         task_id="maximo_service_requests_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -113,7 +114,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t3 = DockerOperatorWithFallback(
+    maximo_work_order_history_to_socrata = DockerOperatorWithFallback(
         task_id="maximo_work_order_history_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -124,7 +125,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t4 = DockerOperatorWithFallback(
+    work_order_time_logs_to_socrata = DockerOperatorWithFallback(
         task_id="work_order_time_logs_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -135,7 +136,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t5 = DockerOperatorWithFallback(
+    work_order_materials_to_socrata = DockerOperatorWithFallback(
         task_id="work_order_materials_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -146,7 +147,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t6 = DockerOperatorWithFallback(
+    work_order_specifications_to_socrata = DockerOperatorWithFallback(
         task_id="work_order_specifications_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -157,7 +158,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t7 = DockerOperatorWithFallback(
+    maximo_locations_to_socrata = DockerOperatorWithFallback(
         task_id="maximo_locations_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -168,4 +169,12 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t1 >> t2 >> t3 >> t4 >> t5 >> t6 >> t7
+    (
+        maximo_workorders_to_socrata
+        >> maximo_service_requests_to_socrata
+        >> maximo_work_order_history_to_socrata
+        >> work_order_time_logs_to_socrata
+        >> work_order_materials_to_socrata
+        >> work_order_specifications_to_socrata
+        >> maximo_locations_to_socrata
+    )

--- a/dags/dts_open_311_scrape.py
+++ b/dags/dts_open_311_scrape.py
@@ -94,7 +94,8 @@ with DAG(
         fallback_date=one_day_ago.to_iso8601_string()
     )
 
-    t1 = DockerOperatorWithFallback(
+    open311_to_socrata = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="open311_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -105,4 +106,4 @@ with DAG(
         tty=True,
     )
 
-    t1
+    open311_to_socrata

--- a/dags/dts_open_311_scrape.py
+++ b/dags/dts_open_311_scrape.py
@@ -94,7 +94,7 @@ with DAG(
         fallback_date=one_day_ago.to_iso8601_string()
     )
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="open311_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/dts_open_311_scrape.py
+++ b/dags/dts_open_311_scrape.py
@@ -3,7 +3,7 @@ from os import getenv
 from datetime import timedelta
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration, now
 
 from utils.onepassword import get_env_vars_task
@@ -103,7 +103,6 @@ with DAG(
         command=f"python -m etl.open311.open311_to_socrata -d {prev_run_time}",
         environment=env_vars,
         tty=True,
-        force_pull=True,
     )
 
     t1

--- a/dags/dts_pavement_ops_reporting.py
+++ b/dags/dts_pavement_ops_reporting.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
@@ -97,7 +97,6 @@ with DAG(
         command=f"python etl/report_to_socrata.py --report VW_UPDATED_PROJECTS_SEGMENTS",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/dts_pavement_ops_reporting.py
+++ b/dags/dts_pavement_ops_reporting.py
@@ -89,7 +89,8 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    projects_segments_to_socrata = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="VW_UPDATED_PROJECTS_SEGMENTS_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -100,4 +101,4 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t1
+    projects_segments_to_socrata

--- a/dags/dts_pavement_ops_reporting.py
+++ b/dags/dts_pavement_ops_reporting.py
@@ -89,7 +89,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="VW_UPDATED_PROJECTS_SEGMENTS_to_socrata",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/dts_public_safety_incident_reports.py
+++ b/dags/dts_public_safety_incident_reports.py
@@ -106,7 +106,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="public_safety_incident_reports_to_postgres",
         docker_conn_id="docker_default",
         image=docker_image,
@@ -117,7 +117,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperator(
+    t2 = DockerOperatorWithFallback(
         task_id="public_safety_incident_reports_to_socrata",
         docker_conn_id="docker_default",
         image=docker_image,

--- a/dags/dts_public_safety_incident_reports.py
+++ b/dags/dts_public_safety_incident_reports.py
@@ -106,7 +106,8 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    public_safety_incident_reports_to_postgres = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="public_safety_incident_reports_to_postgres",
         docker_conn_id="docker_default",
         image=docker_image,
@@ -117,7 +118,7 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    t2 = DockerOperatorWithFallback(
+    public_safety_incident_reports_to_socrata = DockerOperatorWithFallback(
         task_id="public_safety_incident_reports_to_socrata",
         docker_conn_id="docker_default",
         image=docker_image,
@@ -128,4 +129,8 @@ with DAG(
         mount_tmp_dir=False,
     )
 
-    date_filter_arg >> t1 >> t2
+    (
+        date_filter_arg
+        >> public_safety_incident_reports_to_postgres
+        >> public_safety_incident_reports_to_socrata
+    )

--- a/dags/dts_public_safety_incident_reports.py
+++ b/dags/dts_public_safety_incident_reports.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration, now
 
 from utils.onepassword import get_env_vars_task
@@ -114,7 +114,6 @@ with DAG(
         command=f"python records_to_postgrest.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/dts_row_reporting.py
+++ b/dags/dts_row_reporting.py
@@ -167,6 +167,7 @@ with DAG(
 
     commands = [
         {
+            "force_pull": True,
             "task_id": "amanda_applications_received",
             "command": "python amanda/amanda_to_s3.py --query applications_received",
             "image": docker_image,
@@ -227,6 +228,7 @@ with DAG(
             "env": env_vars,
         },
         {
+            "force_pull": True,
             "task_id": "backup_active_permits",
             "command": f"./atd-knack-services/services/backup_socrata.py --dataset {dataset_id}",
             "image": knack_services_image,

--- a/dags/dts_row_reporting.py
+++ b/dags/dts_row_reporting.py
@@ -132,7 +132,7 @@ def get_dataset_id(env_vars):
 
 
 def knack_services_task_template(task_id, image, command, env_vars):
-    return DockerOperator(
+    return DockerOperatorWithFallback(
         task_id=task_id,
         image=image,
         docker_conn_id="docker_default",

--- a/dags/dts_row_reporting.py
+++ b/dags/dts_row_reporting.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import chain, task, DAG
 from pendulum import datetime, duration, now
 
@@ -131,7 +131,7 @@ def get_dataset_id(env_vars):
     return env_vars["ACTIVE_DATASET"]
 
 
-def knack_services_task_template(task_id, image, command, env_vars, pull=False):
+def knack_services_task_template(task_id, image, command, env_vars):
     return DockerOperator(
         task_id=task_id,
         image=image,
@@ -140,7 +140,6 @@ def knack_services_task_template(task_id, image, command, env_vars, pull=False):
         command=command,
         environment=env_vars,
         tty=True,
-        force_pull=pull,
         mount_tmp_dir=False,
         trigger_rule="all_done",
         retries=3,
@@ -292,18 +291,12 @@ with DAG(
     tasks = []
 
     for cmd in commands:
-        # We want the first task to pull the latest docker image
-        if len(tasks) == 0:
-            pull = True
-        else:
-            pull = False
         tasks.append(
             knack_services_task_template(
                 task_id=cmd["task_id"],
                 image=cmd["image"],
                 command=cmd["command"],
                 env_vars=cmd["env"],
-                pull=pull,
             )
         )
 

--- a/dags/dts_work_zone_data_feed.py
+++ b/dags/dts_work_zone_data_feed.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import task, DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime, duration, now
 
 from utils.onepassword import get_env_vars_task
@@ -125,7 +125,6 @@ with DAG(
         command=f"python data_sources/amanda_closure_publishing.py",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
         retries=3,
         retry_delay=duration(seconds=60),

--- a/dags/dts_work_zone_data_feed.py
+++ b/dags/dts_work_zone_data_feed.py
@@ -117,7 +117,7 @@ with DAG(
 ) as dag:
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperator(
+    t1 = DockerOperatorWithFallback(
         task_id="work_zone_data_publishing",
         image=docker_image,
         docker_conn_id="docker_default",

--- a/dags/dts_work_zone_data_feed.py
+++ b/dags/dts_work_zone_data_feed.py
@@ -117,7 +117,8 @@ with DAG(
 ) as dag:
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    t1 = DockerOperatorWithFallback(
+    work_zone_data_publishing = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="work_zone_data_publishing",
         image=docker_image,
         docker_conn_id="docker_default",
@@ -130,4 +131,4 @@ with DAG(
         retry_delay=duration(seconds=60),
     )
 
-    t1
+    work_zone_data_publishing

--- a/dags/maximo_geo_emergency_mgmt_email_parser.py
+++ b/dags/maximo_geo_emergency_mgmt_email_parser.py
@@ -69,6 +69,7 @@ def maximo_geo_emergency_mgmt_email_parser():
     env_vars = get_env_vars()
 
     DockerOperatorWithFallback(
+        force_pull=True,
         task_id="parse_email",
         image="atddocker/maximo-geo-emergency-mgmt:production",
         api_version="auto",

--- a/dags/maximo_geo_emergency_mgmt_email_parser.py
+++ b/dags/maximo_geo_emergency_mgmt_email_parser.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.sdk import dag, task
 from pendulum import datetime, duration
 
@@ -76,7 +76,6 @@ def maximo_geo_emergency_mgmt_email_parser():
         auto_remove="force",
         environment=env_vars,
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/maximo_geo_emergency_mgmt_email_parser.py
+++ b/dags/maximo_geo_emergency_mgmt_email_parser.py
@@ -68,7 +68,7 @@ def maximo_geo_emergency_mgmt_email_parser():
 
     env_vars = get_env_vars()
 
-    DockerOperator(
+    DockerOperatorWithFallback(
         task_id="parse_email",
         image="atddocker/maximo-geo-emergency-mgmt:production",
         api_version="auto",

--- a/dags/test_docker_failure.py
+++ b/dags/test_docker_failure.py
@@ -30,6 +30,7 @@ def test_docker_failure():
     """Test stacked exception handling in Docker container."""
 
     docker_failure = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="docker_failure",
         image="atddocker/atd-airflow:production",
         doc_md="This is an example of task specific documentation",

--- a/dags/test_docker_failure.py
+++ b/dags/test_docker_failure.py
@@ -29,7 +29,7 @@ DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 def test_docker_failure():
     """Test stacked exception handling in Docker container."""
 
-    docker_failure = DockerOperator(
+    docker_failure = DockerOperatorWithFallback(
         task_id="docker_failure",
         image="atddocker/atd-airflow:production",
         doc_md="This is an example of task specific documentation",

--- a/dags/test_docker_failure.py
+++ b/dags/test_docker_failure.py
@@ -5,7 +5,7 @@ from os import getenv
 import pendulum
 
 from airflow.sdk import dag
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 
 from utils.slack_operator import task_fail_slack_alert, slack_member_ids
 

--- a/dags/test_docker_operator_wrapper.py
+++ b/dags/test_docker_operator_wrapper.py
@@ -30,7 +30,6 @@ def test_docker_operator_wrapper():
         auto_remove="force",
         tty=True,
         mount_tmp_dir=False,
-        force_pull=True,
     )
 
 

--- a/dags/test_docker_operator_wrapper.py
+++ b/dags/test_docker_operator_wrapper.py
@@ -22,6 +22,7 @@ from utils.docker_operator import DockerOperatorWithFallback
 )
 def test_docker_operator_wrapper():
     DockerOperatorWithFallback(
+        force_pull=True,
         task_id="hello_world",
         image="python:3",
         command=["python3", "-c", "print('hello world')"],

--- a/dags/utils/docker_operator.py
+++ b/dags/utils/docker_operator.py
@@ -32,7 +32,11 @@ class _DockerHookWithLoginFallback(DockerHook):
                 response = getattr(e, "response", None)
                 status_code = getattr(response, "status_code", None)
 
-            if not isinstance(status_code, int) or status_code < 500 or status_code >= 600:
+            if (
+                not isinstance(status_code, int)
+                or status_code < 500
+                or status_code >= 600
+            ):
                 raise
 
             self.log.warning(
@@ -86,7 +90,7 @@ class DockerOperatorWithFallback(DockerOperator):
         """
         Original Method:https://github.com/apache/airflow/blob/dc939331f4cd90892fd201931c466dffff977a4f/providers/docker/src/airflow/providers/docker/operators/docker.py#L343
         """
-        
+
         tls_config = DockerHook.construct_tls_config(
             ca_cert=self.tls_ca_cert,
             client_cert=self.tls_client_cert,

--- a/dags/vz_afd_ems_import.py
+++ b/dags/vz_afd_ems_import.py
@@ -88,7 +88,6 @@ def etl_data_import():
         auto_remove="force",
         command="ems",
         tty=True,
-        force_pull=True,
         mount_tmp_dir=False,
     )
 

--- a/dags/vz_afd_ems_import.py
+++ b/dags/vz_afd_ems_import.py
@@ -81,6 +81,7 @@ def etl_data_import():
 
     # EMS
     ems_import = DockerOperatorWithFallback(
+        force_pull=True,  # runs in parallel with afd_import
         task_id="run_ems_import",
         environment=env_vars,
         image=docker_image,
@@ -93,6 +94,7 @@ def etl_data_import():
 
     # AFD
     afd_import = DockerOperatorWithFallback(
+        force_pull=True,  # runs in parallel with ems_import
         task_id="run_afd_import",
         environment=env_vars,
         image=docker_image,

--- a/dags/vz_afd_ems_import.py
+++ b/dags/vz_afd_ems_import.py
@@ -1,7 +1,7 @@
 from os import getenv
 
 from airflow.sdk import dag
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 from pendulum import datetime
 
 from utils.onepassword import get_env_vars_task
@@ -80,7 +80,7 @@ def etl_data_import():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     # EMS
-    ems_import = DockerOperator(
+    ems_import = DockerOperatorWithFallback(
         task_id="run_ems_import",
         environment=env_vars,
         image=docker_image,
@@ -92,7 +92,7 @@ def etl_data_import():
     )
 
     # AFD
-    afd_import = DockerOperator(
+    afd_import = DockerOperatorWithFallback(
         task_id="run_afd_import",
         environment=env_vars,
         image=docker_image,

--- a/dags/vz_cris_import.py
+++ b/dags/vz_cris_import.py
@@ -16,6 +16,7 @@ from os import getenv
 from pendulum import datetime, duration
 
 from airflow.sdk import DAG
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.providers.docker.operators.docker import DockerOperator
 
 from utils.onepassword import get_env_vars_task
@@ -92,7 +93,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    cris_import = DockerOperator(
+    cris_import = DockerOperatorWithFallback(
         task_id="run_cris_import",
         docker_conn_id="docker_default",
         image=docker_image_cris_import,
@@ -100,7 +101,6 @@ with DAG(
         environment=env_vars,
         auto_remove="force",
         tty=True,
-        force_pull=True,
     )
 
     ocr_crash_narratives = DockerOperator(
@@ -121,7 +121,6 @@ with DAG(
         environment=env_vars,
         auto_remove="force",
         tty=True,
-        force_pull=True,
     )
 
     cris_import >> ocr_crash_narratives >> match_ems_to_people

--- a/dags/vz_cris_import.py
+++ b/dags/vz_cris_import.py
@@ -17,11 +17,9 @@ from pendulum import datetime, duration
 
 from airflow.sdk import DAG
 from utils.docker_operator import DockerOperatorWithFallback
-from airflow.providers.docker.operators.docker import DockerOperator
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert, slack_member_ids
-
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT")
 secrets_env_prefix = None
@@ -94,6 +92,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     cris_import = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="run_cris_import",
         docker_conn_id="docker_default",
         image=docker_image_cris_import,
@@ -103,7 +102,7 @@ with DAG(
         tty=True,
     )
 
-    ocr_crash_narratives = DockerOperator(
+    ocr_crash_narratives = DockerOperatorWithFallback(
         task_id="ocr_crash_narratives",
         docker_conn_id="docker_default",
         image=docker_image_cris_import,
@@ -113,7 +112,8 @@ with DAG(
         tty=True,
     )
 
-    match_ems_to_people = DockerOperator(
+    match_ems_to_people = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="match_ems_to_people",
         docker_conn_id="docker_default",
         image=docker_image_ems_match,

--- a/dags/vz_moped_component_crashes.py
+++ b/dags/vz_moped_component_crashes.py
@@ -22,11 +22,9 @@ from pendulum import datetime, duration
 
 from airflow.sdk import DAG
 from utils.docker_operator import DockerOperatorWithFallback
-from airflow.providers.docker.operators.docker import DockerOperator
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
-
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT")
 secrets_env_prefix = None
@@ -115,6 +113,7 @@ with DAG(
     env_vars_socrata = get_env_vars_task(REQUIRED_SECRETS_SOCRATA)
 
     vz_moped_spatial_join = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="vz_moped_spatial_join",
         docker_conn_id="docker_default",
         image=docker_image_vz_moped_join,
@@ -124,7 +123,8 @@ with DAG(
         tty=True,
     )
 
-    socrata_export_crash_components = DockerOperator(
+    socrata_export_crash_components = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="socrata_export_crashes",
         docker_conn_id="docker_default",
         image=docker_image_socrata_export,

--- a/dags/vz_moped_component_crashes.py
+++ b/dags/vz_moped_component_crashes.py
@@ -21,6 +21,7 @@ from os import getenv
 from pendulum import datetime, duration
 
 from airflow.sdk import DAG
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.providers.docker.operators.docker import DockerOperator
 
 from utils.onepassword import get_env_vars_task
@@ -113,7 +114,7 @@ with DAG(
     env_vars_moped_join = get_env_vars_task(REQUIRED_SECRETS_MOPED_JOIN)
     env_vars_socrata = get_env_vars_task(REQUIRED_SECRETS_SOCRATA)
 
-    vz_moped_spatial_join = DockerOperator(
+    vz_moped_spatial_join = DockerOperatorWithFallback(
         task_id="vz_moped_spatial_join",
         docker_conn_id="docker_default",
         image=docker_image_vz_moped_join,
@@ -121,7 +122,6 @@ with DAG(
         environment=env_vars_moped_join,
         auto_remove="force",
         tty=True,
-        force_pull=True,
     )
 
     socrata_export_crash_components = DockerOperator(
@@ -132,7 +132,6 @@ with DAG(
         environment=env_vars_socrata,
         auto_remove="force",
         tty=True,
-        force_pull=True,
     )
 
     (

--- a/dags/vz_refresh_location_crashes.py
+++ b/dags/vz_refresh_location_crashes.py
@@ -11,7 +11,6 @@ from utils.docker_operator import DockerOperatorWithFallback
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
 
-
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT")
 secrets_env_prefix = None
 
@@ -60,6 +59,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     refresh_location_crashes = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="refresh_location_crashes",
         docker_conn_id="docker_default",
         image=docker_image,

--- a/dags/vz_refresh_location_crashes.py
+++ b/dags/vz_refresh_location_crashes.py
@@ -6,7 +6,7 @@ from os import getenv
 from pendulum import datetime, duration
 
 from airflow.sdk import DAG
-from airflow.providers.docker.operators.docker import DockerOperator
+from utils.docker_operator import DockerOperatorWithFallback
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert
@@ -59,7 +59,7 @@ with DAG(
 ) as dag:
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    refresh_location_crashes = DockerOperator(
+    refresh_location_crashes = DockerOperatorWithFallback(
         task_id="refresh_location_crashes",
         docker_conn_id="docker_default",
         image=docker_image,
@@ -67,7 +67,6 @@ with DAG(
         environment=env_vars,
         auto_remove="force",
         tty=True,
-        force_pull=True,
     )
 
     refresh_location_crashes

--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -19,7 +19,6 @@ from pendulum import datetime, duration
 
 from airflow.sdk import DAG
 from utils.docker_operator import DockerOperatorWithFallback
-from airflow.providers.docker.operators.docker import DockerOperator
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert, slack_member_ids
@@ -109,6 +108,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     socrata_export_crashes = DockerOperatorWithFallback(
+        force_pull=True,
         task_id="socrata_export_crashes",
         docker_conn_id="docker_default",
         image=docker_image,
@@ -118,7 +118,7 @@ with DAG(
         tty=True,
     )
 
-    socrata_export_people = DockerOperator(
+    socrata_export_people = DockerOperatorWithFallback(
         task_id="socrata_export_people",
         docker_conn_id="docker_default",
         image=docker_image,

--- a/dags/vz_socrata_export.py
+++ b/dags/vz_socrata_export.py
@@ -18,6 +18,7 @@ from os import getenv
 from pendulum import datetime, duration
 
 from airflow.sdk import DAG
+from utils.docker_operator import DockerOperatorWithFallback
 from airflow.providers.docker.operators.docker import DockerOperator
 
 from utils.onepassword import get_env_vars_task
@@ -107,7 +108,7 @@ with DAG(
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
-    socrata_export_crashes = DockerOperator(
+    socrata_export_crashes = DockerOperatorWithFallback(
         task_id="socrata_export_crashes",
         docker_conn_id="docker_default",
         image=docker_image,
@@ -115,7 +116,6 @@ with DAG(
         environment=env_vars,
         auto_remove="force",
         tty=True,
-        force_pull=True,
     )
 
     socrata_export_people = DockerOperator(
@@ -126,7 +126,6 @@ with DAG(
         environment=env_vars,
         auto_remove="force",
         tty=True,
-        force_pull=False,
         trigger_rule="all_done",  # always run this task regardless of outcome of crashes task
     )
 


### PR DESCRIPTION
## Note

Reviewing this PR is 😵‍💫 -- i've tried to make it as easy as possible, but it's a thing.

This PR merges into the one which contains just the new Docker Operator with custom behavior, found in #341. This is all the DAG refacatoring to use the new operator.

This updated multiple DAG files to replace the deprecated DockerOperator with DockerOperatorWithFallback. This change enhances the robustness of Docker operations by allowing fallback to local images if pulling fails. Additionally, removed the force_pull parameter from DockerOperator calls to streamline the configuration.

## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/25196

## Associated repo

airflow itself

## Testing

* Read the code, and ask yourself if you like this pattern
* Fire up a few DAGs, the more the merrier. You're testing when docker hub is up.
* Simulating a docker hub failure is tricky, I don't have a good suggestion on how. 
  * I tried giving the docker hub important hostnames nonroutable IPs in my `/etc/hosts` but the containers have their own DNS systems and don't depend on the OS running on my local hardware. I'm open to any ideas!
---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
