### PR TITLE
Open311 fixing task order and parsing bug

### DIFF
--- a/dags/dts_open_311_scrape.py
+++ b/dags/dts_open_311_scrape.py
@@ -89,9 +89,14 @@ with DAG(
     docker_image = "atddocker/dts-311-reporting:production"
 
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
-    one_day_ago = now("America/Chicago").subtract(days=1)
+
+    @task 
+    def one_day_prev():
+        return now("America/Chicago").subtract(days=1).to_iso8601_string()
+
+    one_day_ago = one_day_prev()
     prev_run_time = get_previous_success_start_time(
-        fallback_date=one_day_ago.to_iso8601_string()
+        fallback_date=one_day_ago
     )
 
     t1 = DockerOperator(
@@ -106,4 +111,4 @@ with DAG(
         force_pull=True,
     )
 
-    t1
+    env_vars >> one_day_ago >> prev_run_time >> t1


### PR DESCRIPTION
I was getting a warning saying this DAG was creating new versions over and over again in Franks airflow upgrade PR. Also, a race condition was coming up where the date argument task was not being completed before having to pass it to the docker task.

Threads:
- [Parse warning](https://austininnovation.slack.com/archives/CHZE6BC6L/p1779385496893669)
- [Race condition](https://austininnovation.slack.com/archives/CHZE6BC6L/p1779128823378989)

## Associated issues
none

## Associated repo
https://github.com/cityofaustin/dts-311-reporting

## Testing

Feel free to trigger this DAG, if you have run history you may end up with a previous start date from a few months ago, which will eventually cause the 311 scraping task to timeout. So, you might need to clear your run history to fully test this. 

Before:
<img width="851" height="343" alt="Screenshot 2026-05-21 at 1 02 05 PM" src="https://github.com/user-attachments/assets/fc46dc64-2447-4e2d-9f0b-94c302a28171" />


After:
<img width="966" height="232" alt="Screenshot 2026-05-21 at 1 01 45 PM" src="https://github.com/user-attachments/assets/c0aa6a4e-b5f9-429f-a0b3-17e63508d98c" />

**Steps to test:**


---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
