### PR TITLE
Adopt primary airflow host name for airflow 3 instance

### DIFF
--- a/toolbox/certbot/renew.sh
+++ b/toolbox/certbot/renew.sh
@@ -5,6 +5,7 @@ echo "$(date '+%Y-%m-%d %H:%M:%S')"
 echo "Renewing the certificates for the Airflow stack"
 
 
+/srv/atd-airflow/toolbox/certbot/renew_domain_with_certbot.sh airflow.austinmobility.io
 /srv/atd-airflow/toolbox/certbot/renew_domain_with_certbot.sh airflow-v3.austinmobility.io
 
 cd /srv/atd-airflow


### PR DESCRIPTION
## Associated issues

This PR is the last step of the issue and should close https://github.com/cityofaustin/atd-data-tech/issues/26895.

This change came out of the recent tear-down of airflow V2, which freed up the `airflow.austinmobility.io` domain name to point at our Airflow V3 instance.

## Associated repo

Airflow itself

## Testing

Easy one:

* Be on the city network and click this link: https://airflow.austinmobility.io/. 
* Did you get to airflow? ✅ 



---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
