### PR TITLE
Update slack notifier to check if summary is defined on the `dag` object when checking the timetable

### DIFF
--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -138,8 +138,8 @@ def task_fail_slack_alert(context):
 
     schedule_description = (
         format_schedule(dag.timetable.summary)
-        if dag and hasattr(dag, "timetable")
-        else "Not available"
+        if dag and hasattr(getattr(dag, "timetable", None), "summary")
+        else "Manual Run / None"
     )
 
     all_exceptions = extract_all_exceptions(context)


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/28749

This intends to fix the broken notifications in slack we have been encountering since I updated the stack to 3.2.1 on Friday.

## Associated repo

Airflow itself

## Testing

Observe the organic notification in production [here](https://austininnovation.slack.com/archives/C013G4RNJ01/p1780338106589719).  This happened today after the fix was put in place via an _ad hoc_ change that will be replaced by the same change found here in this PR. If you agree that notifications are working again: ✅ 

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
