### PR TITLE
Update Certbot script to use full chain of trust for PEM certificate files

### DIFF
--- a/toolbox/certbot/renew_domain_with_certbot.sh
+++ b/toolbox/certbot/renew_domain_with_certbot.sh
@@ -37,7 +37,7 @@ docker run --rm --name certbot \
 -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
 certbot/dns-route53 certonly -n --dns-route53 -d $DOMAIN
 
-cat /etc/letsencrypt/live/$DOMAIN/cert.pem > $ATD_AIRFLOW_HOMEDIR/haproxy/ssl/$DOMAIN.pem
+cat /etc/letsencrypt/live/$DOMAIN/fullchain.pem > $ATD_AIRFLOW_HOMEDIR/haproxy/ssl/$DOMAIN.pem
 
 cat /etc/letsencrypt/live/$DOMAIN/privkey.pem >> $ATD_AIRFLOW_HOMEDIR/haproxy/ssl/$DOMAIN.pem
 


### PR DESCRIPTION
## Associated issues

This is a https://github.com/cityofaustin/atd-data-tech/issues/26895 late-comer.

As part of some airflow work this morning wrapping up the above issue and hunting other problems, I noticed that the file we had symlinked into `/etc/cron.d/` had an underscore in its name, which prevented it from running. I fixed this, so now we're asking certbot for fresh certificates on a schedule, and as a side effect, we're rebuilding our keys in our `.pem` files and restarting `haproxy` with them.

So.., at noon, it ran, and it built new PEM files and restarted `haproxy` as expected, and when I came back from lunch, I learned:

At some point since we launched airflow v3, it's become required to provide the whole chain of trust for certbot SSL/TLS certificates. I bet this is a browser change in chromium or something like that. 

Anyway, this single-line PR updates our airflow system to build these complete PEM files instead of relying on the browser to have that chain of trust known internally. 

## Associated repo

Airflow Itself

## Testing

Another easy one:

Click https://airflow.austinmobility.io

No SSL error? ✅ 

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
