### PR TITLE
Use image stored on Docker Hub instead of locally built image in production

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,8 +7,8 @@ x-airflow-common: &airflow-common
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
 
-  build: .
-  #image: atddocker/atd-airflow:production
+  # build: .
+  image: atddocker/atd-airflow:production
 
   environment: &airflow-common-env # Some DTS specific environment variables
     OP_API_TOKEN: ${OP_API_TOKEN}


### PR DESCRIPTION
## Associated issues

none, this change should have been a last-second commit into `frank/airflow-three` to take it out of local debug mode and configure it for production just prior to merging. I forgot to do this, and I realized this was missing when I went to deploy.

## Associated repo

Airflow itself

## Testing

To get airflow up and running after I pulled down `production`, I made this change in place. If you login to `02` and do a `docker ps`, you can see that we're running airflow images from `atddocker/atd-airflow:production` meaning that this change has worked. 

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
