### PR TITLE
Bump to Airflow 3.2.2, add invocation details and fix timetable expression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:3.2.1
+FROM apache/airflow:3.2.2
 
 USER root
 RUN apt-get update

--- a/README.md
+++ b/README.md
@@ -211,7 +211,17 @@ with DAG(
     <snip>
 ```
 
-**To test the Slack operator locally**, see the DAGs `test_slack_notifier` and `test_docker_failure`.
+#### Testing the delivery functionality of the messages
+
+When testing, it's helpful to be able to see the messages that the slack operator generates without sending them all the way to the #atd-airflow channel in slack. The utility will always print out a copy of the message into the `STDOUT` which can be seen in the output of `docker compose up` or `docker compose logs -f`. Additionally, to test the full delivery pipeline, one can comment out check on the `DEVELOPMENT_ENVIRONMENT` to allow the `slack` connection to be used to send the message to the Slack API. 
+
+
+#### Testing the slack notifier's content
+
+To test the Slack operator, see the DAGs `test_slack_notifier` and `test_docker_failure`.
+
+In particular, look into the `test_slack_notifier` DAG and observe that there is a commented out schedule. The slack notifier has slightly different behavior in how it reports the DAG run schedule based on if it was kicked off manually or by the system itself. You can comment this schedule in and out and look for messages in the logs to test to see how this is working.
+
 
 ## Useful Commands
 

--- a/dags/test_docker_failure.py
+++ b/dags/test_docker_failure.py
@@ -1,3 +1,9 @@
+# Test DAG that exercises failure handling for Dockerized tasks. It runs a
+# DockerOperator whose inline Python script raises chained exceptions
+# (ConnectionError -> ValueError -> RuntimeError) and exits non-zero, so the
+# resulting stacked traceback and Slack failure alert can be inspected.
+# Manually triggered only.
+
 from __future__ import annotations
 
 from os import getenv

--- a/dags/test_slack_notifier.py
+++ b/dags/test_slack_notifier.py
@@ -14,6 +14,7 @@ DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 @dag(
     dag_id=f"test_slack_notifier_{DEPLOYMENT_ENVIRONMENT}",
     schedule=None,
+    # schedule="* * * * *",
     start_date=pendulum.datetime(2015, 12, 1, tz="America/Chicago"),
     catchup=False,
     tags=["slack"],

--- a/dags/test_slack_notifier.py
+++ b/dags/test_slack_notifier.py
@@ -1,3 +1,8 @@
+# Test DAG that verifies the Slack failure notifier is working. It defines a
+# single task that deliberately raises an exception, triggering the
+# task_fail_slack_alert callback so the resulting Slack alert (including the
+# custom byline and icon) can be inspected. 
+
 from __future__ import annotations
 
 from os import getenv
@@ -14,7 +19,11 @@ DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 @dag(
     dag_id=f"test_slack_notifier_{DEPLOYMENT_ENVIRONMENT}",
     schedule=None,
+
+    # The following schedule is used in local development to test the slack notifier.
+    # In particular, it is used to test the slack notifier's schedule parsing logic.
     # schedule="* * * * *",
+
     start_date=pendulum.datetime(2015, 12, 1, tz="America/Chicago"),
     catchup=False,
     tags=["slack"],

--- a/dags/test_slack_notifier.py
+++ b/dags/test_slack_notifier.py
@@ -17,7 +17,7 @@ DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
 
 @dag(
-    dag_id=f"test_slack_notifier_{DEPLOYMENT_ENVIRONMENT}",
+    dag_id=f"test_slack_notifier",
     schedule=None,
 
     # The following schedule is used in local development to test the slack notifier.

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -200,8 +200,7 @@ def task_fail_slack_alert(context):
 
     slack_message_text = "\n\t\t".join(slack_message)
 
-    if DEPLOYMENT_ENVIRONMENT == "development":
-        print(f"\n\n\n⚠️ slack_message_text: {slack_message_text}\n\n\n")
+    print(f"\n\n\n⚠️ slack_message_text: {slack_message_text}\n\n\n")
 
     if DEPLOYMENT_ENVIRONMENT != "production":
         return

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -179,7 +179,7 @@ def task_fail_slack_alert(context):
 
     slack_message = (
         [
-            f"{icon} {env_indicator} *Task failure*",
+            f"{icon}{env_indicator} *Task failure*",
         ]
         + byline
         + [

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -91,7 +91,7 @@ def get_central_time_exec_data(context):
 
 def build_exception_text(all_exceptions):
     # Format all exceptions for display
-    exceptions_text = ""
+    exceptions_text = []
     if len(all_exceptions) == 1:
         # Single exception - use original format with source
         exception_type = all_exceptions[-1][0]
@@ -101,7 +101,7 @@ def build_exception_text(all_exceptions):
         exceptions_text.append(f"*Exception Message*: `{exception_message}`")
     else:
         # Multiple exceptions - list them all with sources
-        exceptions_text = f"*Exceptions Found ({len(all_exceptions)} total)*:"
+        exceptions_text = [f"*Exceptions Found ({len(all_exceptions)} total)*:"]
         for i, exc_tuple in enumerate(all_exceptions, 1):
             exc_type = exc_tuple[0]
             exc_msg = exc_tuple[1]

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -163,7 +163,7 @@ def task_fail_slack_alert(context):
     all_exceptions = extract_all_exceptions(context)
     exceptions = build_exception_text(all_exceptions)
 
-    byline_value = getattr(dag, "byline", None) 
+    byline_value = getattr(dag, "byline", None)
     byline = [byline_value] if byline_value else []
     icon = getattr(dag, "icon", ":warning:")
 
@@ -183,7 +183,6 @@ def task_fail_slack_alert(context):
         ]
         + byline
         + [
-
             f"*DAG*: `{dag_id}`",
             f"*Task*: `{task_id}`",
             f"*Execution Time*: `{exec_date}`",

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -2,6 +2,7 @@ from os import getenv
 import logging
 
 from cron_descriptor import get_description
+from airflow.utils.types import DagRunType
 from airflow.exceptions import AirflowException
 from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
 from utils.log_parsing import extract_all_exceptions_from_log, extract_all_exceptions
@@ -96,7 +97,8 @@ def build_exception_text(all_exceptions):
         exception_type = all_exceptions[-1][0]
         exception_message = all_exceptions[-1][1]
         source = all_exceptions[0][2] if len(all_exceptions[0]) > 2 else "Unknown"
-        exceptions_text = f"*Exception Type*: `{exception_type}` _(from {source})_\n        *Exception Message*: `{exception_message}`"
+        exceptions_text = [f"*Exception Type*: `{exception_type}` _(from {source})_"]
+        exceptions_text.append(f"*Exception Message*: `{exception_message}`")
     else:
         # Multiple exceptions - list them all with sources
         exceptions_text = f"*Exceptions Found ({len(all_exceptions)} total)*:"
@@ -104,9 +106,7 @@ def build_exception_text(all_exceptions):
             exc_type = exc_tuple[0]
             exc_msg = exc_tuple[1]
             source = exc_tuple[2] if len(exc_tuple) > 2 else "Unknown"
-            exceptions_text += (
-                f"\n        {i}. *{exc_type}* _(from {source})_: `{exc_msg}`"
-            )
+            exceptions_text.append(f"{i}. *{exc_type}* _(from {source})_: `{exc_msg}`")
     return exceptions_text
 
 
@@ -123,10 +123,28 @@ def get_task_duration_seconds(task_instance):
     return None
 
 
+def format_run_type_slack_lines(dag_run):
+    if dag_run is None:
+        return ["*Run Type*: `Unknown`"]
+
+    run_type = dag_run.run_type
+    run_type_value = run_type.value if hasattr(run_type, "value") else str(run_type)
+    run_type_label = run_type_value.replace("_", " ").title()
+    lines = [f"*Run Type*: `{run_type_label}`"]
+
+    if run_type in (DagRunType.MANUAL, "manual"):
+        username = getattr(dag_run, "triggering_user_name", None)
+        if username:
+            lines.append(f"*Triggered By*: `{username}`")
+
+    return lines
+
+
 def task_fail_slack_alert(context):
     logger = logging.getLogger(__name__)
     task_instance = context.get("task_instance")
     dag = context.get("dag")
+    dag_run = context.get("dag_run")
     dag_id = task_instance.dag_id
     task_id = task_instance.task_id
     exec_date = get_central_time_exec_data(context)
@@ -139,47 +157,61 @@ def task_fail_slack_alert(context):
     schedule_description = (
         format_schedule(dag.timetable.expression)
         if dag and hasattr(getattr(dag, "timetable", None), "expression")
-        else "Manual Run / None"
+        else None
     )
 
-    print("⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ")
-    print(f"schedule_description: {schedule_description}")
-    print(f"dag: {dag}")
-    print(f"dag.timetable: {dag.timetable}")
-    # print(f"dag.timetable.expression: {dag.timetable.expression}")
-    print("⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ")
-
     all_exceptions = extract_all_exceptions(context)
-    exceptions_text = build_exception_text(all_exceptions)
+    exceptions = build_exception_text(all_exceptions)
 
-    byline = getattr(dag, "byline", "")
-    icon = getattr(dag, "icon", ":three:")
-
-    if (DEPLOYMENT_ENVIRONMENT != "production"):
-        return
+    byline_value = getattr(dag, "byline", None) 
+    byline = [byline_value] if byline_value else []
+    icon = getattr(dag, "icon", ":warning:")
 
     # Add deployment environment indication if not production
     env_indicator = ""
     if DEPLOYMENT_ENVIRONMENT != "production":
         env_indicator = f" *{DEPLOYMENT_ENVIRONMENT.capitalize()} Environment*"
 
-    slack_msg = f"""
-        {icon}{env_indicator} *Task failure* 
-        {'\n\t\t' + byline if byline else ''}
-        *DAG*: `{dag_id}`
-        *Task*: `{task_id}`
-        *Execution Time*: `{exec_date}`
-        *Schedule*: `{schedule_description}`
-        *Duration*: `{duration} seconds`
-        {exceptions_text}
-        <{log_url}|*View Task Log*>
-    """
+    run_type_lines = format_run_type_slack_lines(dag_run)  # array
+    schedule_line = (
+        [f"*Schedule*: `{schedule_description}`"] if schedule_description else []
+    )
+
+    slack_message = (
+        [
+            f"{icon} {env_indicator} *Task failure*",
+        ]
+        + byline
+        + [
+
+            f"*DAG*: `{dag_id}`",
+            f"*Task*: `{task_id}`",
+            f"*Execution Time*: `{exec_date}`",
+        ]
+        + schedule_line
+        + run_type_lines
+        + [
+            f"*Duration*: `{duration} seconds`",
+        ]
+        + exceptions
+        + [
+            f"<{log_url}|*View Task Log*>",
+        ]
+    )
+
+    slack_message_text = "\n".join(slack_message)
+
+    if DEPLOYMENT_ENVIRONMENT == "development":
+        print(f"\n\n\n⚠️ slack_message_text: {slack_message_text}\n\n\n")
+
+    if DEPLOYMENT_ENVIRONMENT != "production":
+        return
 
     failed_alert = SlackWebhookHook(
         slack_webhook_conn_id=SLACK_CONN_ID,
     )
     try:
-        return failed_alert.send(text=slack_msg)
+        return failed_alert.send(text=slack_message_text)
     except AirflowException as exc:
         logger.warning("Slack failure alert failed: %s", exc)
         return False

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -199,7 +199,7 @@ def task_fail_slack_alert(context):
         ]
     )
 
-    slack_message_text = "\n".join(slack_message)
+    slack_message_text = "\n\t\t".join(slack_message)
 
     if DEPLOYMENT_ENVIRONMENT == "development":
         print(f"\n\n\n⚠️ slack_message_text: {slack_message_text}\n\n\n")

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -202,6 +202,8 @@ def task_fail_slack_alert(context):
 
     print(f"\n\n\n⚠️ slack_message_text: {slack_message_text}\n\n\n")
 
+    # Comment out this guard to test the full, error -> notification delivery pipeline. 
+    # Remember, you'll need to have a `slack` connection in the Airflow UI defined. 
     if DEPLOYMENT_ENVIRONMENT != "production":
         return
 

--- a/dags/utils/slack_operator.py
+++ b/dags/utils/slack_operator.py
@@ -137,16 +137,26 @@ def task_fail_slack_alert(context):
     )
 
     schedule_description = (
-        format_schedule(dag.timetable.summary)
-        if dag and hasattr(getattr(dag, "timetable", None), "summary")
+        format_schedule(dag.timetable.expression)
+        if dag and hasattr(getattr(dag, "timetable", None), "expression")
         else "Manual Run / None"
     )
+
+    print("⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ")
+    print(f"schedule_description: {schedule_description}")
+    print(f"dag: {dag}")
+    print(f"dag.timetable: {dag.timetable}")
+    # print(f"dag.timetable.expression: {dag.timetable.expression}")
+    print("⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ")
 
     all_exceptions = extract_all_exceptions(context)
     exceptions_text = build_exception_text(all_exceptions)
 
     byline = getattr(dag, "byline", "")
     icon = getattr(dag, "icon", ":three:")
+
+    if (DEPLOYMENT_ENVIRONMENT != "production"):
+        return
 
     # Add deployment environment indication if not production
     env_indicator = ""


### PR DESCRIPTION
## Associated issues

This Pr hopes to close https://github.com/cityofaustin/atd-data-tech/issues/28763.

## Associated repo

Airflow itself

## Testing
 
* Configure your local stack to use a local build, not from docker hub
  * edit `docker-compose.yaml` and uncomment in `build: .` and comment out `image: atddocker/atd-airflow:production`. 
* `docker compose build` to build the local stack. This will build 3.2.2.
* `docker compose up` to spin up the stack
  * We'll be looking in this log later for local printouts of the slack error message
* In your local airflow, kick off `test_slack_notifier_development`. Look in that log stream for a ⚠️ symbol; it's there to help you pick out the slack message. Inspect the message. Does it make sense for a DAG you just manually ran?
* Edit the `test_slack_notifier.py` DAG. Swap the comment on the two `schedule` lines so that you're adding a `* * * * *` schedule. Save the file, and this DAG should now run every minute. Make sure the DAG is enabled if it's not, but it should be from your previous manual trigger.
* Watch your log stream and inspect the next error message that comes out (you may have to wait up to 1 minute). Does it make sense for an error on a notification that was run on a schedule, as opposed to manually?
* If you want, you can comment out the following lines near the bottom of the slack utility to allow development error messages be sent to the slack API into `#atd-airflow`.
  * Note: You must have the `slack` connection as described in the 1PW entry `Airflow - Slack Bot` for this to work.

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
