### PR TITLE
Add a dag to check citybase health

### DIFF
--- a/dags/citybase_healthcheck.py
+++ b/dags/citybase_healthcheck.py
@@ -3,7 +3,7 @@ from airflow import DAG
 from airflow.providers.http.sensors.http import HttpSensor
 from pendulum import datetime, duration
 
-from utils.slack_operator import task_fail_slack_alert
+from utils.slack_operator import task_fail_slack_alert, slack_member_ids
 
 DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
 
@@ -13,7 +13,7 @@ DEFAULT_ARGS = {
     "start_date": datetime(2026, 1, 1, tz="America/Chicago"),
     "retries": 0,
     "execution_timeout": duration(seconds=30),
-    # "on_failure_callback": task_fail_slack_alert,
+    "on_failure_callback": task_fail_slack_alert,
 }
 
 doc_md = ""

--- a/dags/citybase_healthcheck.py
+++ b/dags/citybase_healthcheck.py
@@ -16,7 +16,14 @@ DEFAULT_ARGS = {
     "on_failure_callback": task_fail_slack_alert,
 }
 
-doc_md = ""
+doc_md = """
+Checks that the citybase postback service is running and reachable.
+The application runs on the bastion.
+
+See the atd-citybase readme for more details on deployment and how to restart.
+
+If the postback is down for an extended period of time, inform Hanna so she can check Revenue Managment for missed transactions.
+"""
 
 with DAG(
     dag_id="citybase_postback_healthcheck",
@@ -33,7 +40,7 @@ with DAG(
 
     check_citybase_endpoint = HttpSensor(
         task_id="check_citybase_postback_endpoint",
-        http_conn_id="check_citybase",
+        http_conn_id="http_default",
         endpoint="citybase.austinmobility.io",
         request_params={},
         response_check=lambda response: response.status_code == 200,

--- a/dags/citybase_healthcheck.py
+++ b/dags/citybase_healthcheck.py
@@ -30,7 +30,7 @@ with DAG(
     description="Checks citybase postback for 200 response",
     doc_md=doc_md,
     default_args=DEFAULT_ARGS,
-    schedule="0 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule="*/10 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-citybase", "citybase"],
     catchup=False,
 ) as dag:

--- a/dags/citybase_healthcheck.py
+++ b/dags/citybase_healthcheck.py
@@ -1,0 +1,42 @@
+from os import getenv
+from airflow import DAG
+from airflow.providers.http.sensors.http import HttpSensor
+from pendulum import datetime, duration
+
+from utils.slack_operator import task_fail_slack_alert
+
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2026, 1, 1, tz="America/Chicago"),
+    "retries": 0,
+    "execution_timeout": duration(seconds=30),
+    # "on_failure_callback": task_fail_slack_alert,
+}
+
+doc_md = ""
+
+with DAG(
+    dag_id="citybase_postback_healthcheck",
+    description="Checks citybase postback for 200 response",
+    doc_md=doc_md,
+    default_args=DEFAULT_ARGS,
+    schedule="0 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:atd-citybase", "citybase"],
+    catchup=False,
+) as dag:
+
+    dag.byline = f"Citybase postback healthcheck failed, {slack_member_ids['Chia']}"
+
+
+    check_citybase_endpoint = HttpSensor(
+        task_id="check_citybase_postback_endpoint",
+        http_conn_id="check_citybase",
+        endpoint="citybase.austinmobility.io",
+        request_params={},
+        response_check=lambda response: response.status_code == 200,
+    )
+
+    check_citybase_endpoint

--- a/dags/citybase_healthcheck.py
+++ b/dags/citybase_healthcheck.py
@@ -41,8 +41,8 @@ with DAG(
         task_id="check_citybase_postback_endpoint",
         http_conn_id="http_default",
         endpoint="citybase.austinmobility.io",
-        request_params={"verify": True, "timeout": 30},
-        response_check=lambda response: response.status_code == 200,
+        extra_options={"verify": True, "timeout": 30},
+        response_check=lambda response: response.json().get("status") == "OK",
     )
 
     check_citybase_endpoint

--- a/dags/citybase_healthcheck.py
+++ b/dags/citybase_healthcheck.py
@@ -1,6 +1,6 @@
 from os import getenv
 from airflow import DAG
-from airflow.providers.http.sensors.http import HttpSensor
+from airflow.providers.http.operators.http import HttpOperator
 from pendulum import datetime, duration
 
 from utils.slack_operator import task_fail_slack_alert, slack_member_ids
@@ -37,11 +37,12 @@ with DAG(
 
     dag.byline = f"Citybase postback healthcheck failed, {slack_member_ids['Chia']}"
 
-    check_citybase_endpoint = HttpSensor(
+    check_citybase_endpoint = HttpOperator(
         task_id="check_citybase_postback_endpoint",
-        http_conn_id="http_default",
-        endpoint="citybase.austinmobility.io",
-        extra_options={"verify": True, "timeout": 30},
+        http_conn_id="citybase_https",
+        endpoint="/",
+        method="GET",
+        extra_options={"verify": True, "timeout": 5},
         response_check=lambda response: response.json().get("status") == "OK",
     )
 

--- a/dags/citybase_healthcheck.py
+++ b/dags/citybase_healthcheck.py
@@ -37,12 +37,11 @@ with DAG(
 
     dag.byline = f"Citybase postback healthcheck failed, {slack_member_ids['Chia']}"
 
-
     check_citybase_endpoint = HttpSensor(
         task_id="check_citybase_postback_endpoint",
         http_conn_id="http_default",
         endpoint="citybase.austinmobility.io",
-        request_params={},
+        request_params={"verify": True, "timeout": 30},
         response_check=lambda response: response.status_code == 200,
     )
 


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/26146

## Associated repo

## Testing

**Steps to test:**

1. start airflow locally
2. From the lefthand menu choose Admin, Connections. Use the button to open the add connection modal. Add one that looks like
<img width="799" height="767" alt="Image" src="https://github.com/user-attachments/assets/aeaf077c-9604-4adc-a119-0180d7257550" />
3. Trigger the "citybase_postback_healthcheck" dag. You must be on the city network to access the healthcheck. 


I have added the https connection to prod

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
