### PR TITLE
Add incident linker task to CAD incident DAG

### DIFF
--- a/dags/vz_cad_import.py
+++ b/dags/vz_cad_import.py
@@ -67,12 +67,11 @@ DEFAULT_ARGS = {
     "on_failure_callback": task_fail_slack_alert,
 }
 
-# for local dev, replace `"/your/path/here"` with the abs path to your testing files, e.g.,
-# /Users/john/atd/vision-zero/etl/cad_incidents_import/test_data
+# for local dev, replace `"/your/path/here"` with the abs path to your testing files
 mount_source = (
     "/mnt/vision_zero_cad"
     if DEPLOYMENT_ENVIRONMENT == "production"
-    else "/Users/john/atd/vision-zero/etl/cad_incidents_import/test_data"
+    else "/your/path/here"
 )
 
 files_volume_mount = Mount(
@@ -115,7 +114,18 @@ def get_incident_link_limit(params):
     default_args=DEFAULT_ARGS,
     tags=["repo:atd-vz-data", "vision-zero", "cad", "import"],
     params={
-        "dry_run": Param(default=False, type="boolean"),
+        "dry_run": Param(
+            title="Dry run",
+            default=False,
+            type="boolean",
+            description_md="Applies the dry-run flag to all tasks. No records will be procesesd.",
+        ),
+        "incident_link_limit": Param(
+            title="Incident link limit",
+            default=None,
+            type=["integer", "null"],
+            description_md="The maximum number of records to link via incident_linker.py. Otherwise the script's default limit will be applied.",
+        ),
     },
 )
 def etl_data_import():

--- a/dags/vz_cad_import.py
+++ b/dags/vz_cad_import.py
@@ -81,13 +81,25 @@ files_volume_mount = Mount(
     type="bind",
 )
 
+
 @task(
-    task_id="get_args",
+    task_id="get_is_dry_run_arg",
 )
 def get_is_dry_run_arg(params):
     """Return ` --dry-run` if the dry_run param has been set"""
     if bool(params["dry_run"]):
         return " --dry-run"
+    else:
+        return ""
+
+
+@task(
+    task_id="get_incident_link_limit",
+)
+def get_incident_link_limit(params):
+    """Return ` --limit {number}` if the incident_link_limit param has been set"""
+    if bool(params["incident_link_limit"]):
+        return f" --limit {params["incident_link_limit"]}"
     else:
         return ""
 
@@ -110,7 +122,7 @@ def etl_data_import():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     dry_run_arg = get_is_dry_run_arg()
-
+    incident_link_limit = get_incident_link_limit()
 
     incidents_to_s3 = DockerOperator(
         task_id="cad_incidents_to_s3",
@@ -137,7 +149,23 @@ def etl_data_import():
         mounts=[files_volume_mount],
     )
 
-    [env_vars, dry_run_arg] >> incidents_to_s3 >> incidents_import
+    incidents_linker = DockerOperator(
+        task_id="cad_incidents_links",
+        environment=env_vars,
+        image=docker_image,
+        docker_conn_id="docker_default",
+        auto_remove="force",
+        command=f"incident_linker.py{dry_run_arg}{incident_link_limit}",
+        tty=True,
+        mount_tmp_dir=False,
+    )
+
+    (
+        [env_vars, dry_run_arg, incident_link_limit]
+        >> incidents_to_s3
+        >> incidents_import
+        >> incidents_linker
+    )
 
 
 etl_data_import()

--- a/dags/vz_cad_import.py
+++ b/dags/vz_cad_import.py
@@ -118,7 +118,7 @@ def get_incident_link_limit(params):
             title="Dry run",
             default=False,
             type="boolean",
-            description_md="Applies the dry-run flag to all tasks. No records will be procesesd.",
+            description_md="Applies the dry-run flag to all tasks. No records will be processed.",
         ),
         "incident_link_limit": Param(
             title="Incident link limit",


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/27761

## Associated repo

- `vision-zero`

## Testing

**Steps to test:**

Sorry for all the yak shaving needed to test this DAG 🙃 

1. Pull airflow prod if you haven't spun it up lately: `docker pull atddocker/atd-airflow:production`

2. In the VZ repo, checkout and pull the `main` branch, start your local stack, and apply migrations and metadata.

3. In AWS S3, navigate to [atd-vision-zero/dev/cad_incidents/archive](https://us-east-1.console.aws.amazon.com/s3/buckets/atd-vision-zero?region=us-east-1&prefix=dev/cad_incidents/archive/), sort by **Last modified**, select the top two files and use the **Actions** menu to **Move** these files into the inbox. **Destination** `s3://atd-vision-zero/dev/cad_incidents/inbox/`

<img width="1190" height="568" alt="Screenshot 2026-06-10 at 1 19 54 PM" src="https://github.com/user-attachments/assets/e03a528e-129e-426b-8252-0aff2c13bd15" />


4. Go to the S3 `cad_incidents/inbox` and download copies of the files you just moved there. Save them in your VZ repo at `./etl/cad_incidents_import/test_data`. 

5. Modify this DAG by setting the `mount_source` variable to the  absolute path to the test data directory where you just saved those files (replace `"/your/path/here"` with the your path).

6. Start airflow, and trigger this DAG: Flip the **Dry run** toggle to be enabled and set the **Incident link limit** to an integer value.

7.  Confirm that the task for each of three processing tasks are have dry-run logging showing that files/records would be processed. The last task—the incident linker—should log a # of records to be processed that matches the limit you provided.

8. Trigger the DAG again without the **Dry run** toggle or **Incident link limit** param. Confirm that:

* the files have been removed from your local `test_data` directory ✅ 
* CAD incidents inbox ([atd-vision-zero/dev/cad_incidents/inbox](https://us-east-1.console.aws.amazon.com/s3/buckets/atd-vision-zero?region=us-east-1&prefix=dev/cad_incidents/inbox/)) is clear of files ✅ 
* the incident linker script ran successfully after processing 5k files ✅ 

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
