### PR TITLE
Add task timeout to CAD incident dag

### DIFF
--- a/dags/vz_cad_import.py
+++ b/dags/vz_cad_import.py
@@ -4,7 +4,7 @@ from airflow.sdk import dag, task, Param
 from airflow.providers.docker.operators.docker import DockerOperator
 from docker.types import Mount
 
-from pendulum import datetime
+from pendulum import datetime, duration
 
 from utils.onepassword import get_env_vars_task
 from utils.slack_operator import task_fail_slack_alert, slack_member_ids
@@ -65,6 +65,7 @@ DEFAULT_ARGS = {
     "email_on_retry": False,
     "retries": 0,
     "on_failure_callback": task_fail_slack_alert,
+    "execution_timeout": duration(minutes=45),
 }
 
 # for local dev, replace `"/your/path/here"` with the abs path to your testing files


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/28951

## Associated repo

- vision-zero

## Testing

Spin up Airflow and see that the DAG imports without errors.

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
