### PR TITLE
Adds `--no-files-pass` flag to CAD incident import DAG

### DIFF
--- a/dags/vz_cad_import.py
+++ b/dags/vz_cad_import.py
@@ -103,6 +103,17 @@ def get_incident_link_limit(params):
         return ""
 
 
+@task(
+    task_id="get_no_files_pass",
+)
+def get_no_files_pass(params):
+    """Return ` --no-files-pass` if the no_files_pass param has been set"""
+    if bool(params["no_files_pass"]):
+        return " --no-files-pass"
+    else:
+        return ""
+
+
 @dag(
     dag_id="vz-cad-incidents-import",
     description="A DAG which imports CAD records into the Vision Zero database.",
@@ -126,13 +137,22 @@ def get_incident_link_limit(params):
             type=["integer", "null"],
             description_md="The maximum number of records to link via incident_linker.py. Otherwise the script's default limit will be applied.",
         ),
+        "no_files_pass": Param(
+            title="No files, no problem",
+            default=False,
+            type="boolean",
+            description_md="Don't throw an error if any stage does not find files to process.",
+        ),
     },
 )
 def etl_data_import():
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     dry_run_arg = get_is_dry_run_arg()
+
     incident_link_limit = get_incident_link_limit()
+
+    no_files_pass = get_no_files_pass()
 
     incidents_to_s3 = DockerOperator(
         task_id="cad_incidents_to_s3",
@@ -140,7 +160,7 @@ def etl_data_import():
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f"incidents_to_s3.py --remove{dry_run_arg}",
+        command=f"incidents_to_s3.py --remove{dry_run_arg}{no_files_pass}",
         tty=True,
         force_pull=True,
         mount_tmp_dir=False,
@@ -153,7 +173,7 @@ def etl_data_import():
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f"incidents_import.py --archive{dry_run_arg}",
+        command=f"incidents_import.py --archive{dry_run_arg}{no_files_pass}",
         tty=True,
         mount_tmp_dir=False,
         mounts=[files_volume_mount],

--- a/dags/vz_cad_import.py
+++ b/dags/vz_cad_import.py
@@ -191,7 +191,7 @@ def etl_data_import():
     )
 
     (
-        [env_vars, dry_run_arg, incident_link_limit]
+        [env_vars, dry_run_arg, incident_link_limit, no_files_pass]
         >> incidents_to_s3
         >> incidents_import
         >> incidents_linker


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/29006
* See also: https://github.com/cityofaustin/vision-zero/pull/2064

This PR fixes the problem of the various tasks of this ETL being blocked when no files are available to process. 

For example, if the first task (incidents_to_s3) succeeds but the incident import fails, it will not be possible to re-trigger this because the first task will fail when it does not find new files to process.

This update makes use of the `--no-files-pass` flag so that this DAG is effectively idempotent and can be triggered as needed at any time and all tasks will run.

## Associated repo

- vision-zero

## Testing

**Steps to test:**

1. Edit L74 of this DAG by replacing "/your/path/here" to the absolute path to your vision zero repo's CAD test data folder:

```
/your/path/to/vision-zero/etl/cad_incidents_import/test_data
```

2. If you have any CSV files in your test data folder, remove them.

3. Start Airflow and trigger this DAG. Enable the new **No files, no problem** toggle in the trigger modal before you proceed.

4. Observe that the `cad_incidents_to_s3` and `cad_incident_import` succeed despite the logs showing there are no files to process.

✅ 

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
