### PR TITLE
Rework DockerOperatorWithFallback and test DAG

### DIFF
--- a/dags/test_docker_operator_wrapper.py
+++ b/dags/test_docker_operator_wrapper.py
@@ -10,7 +10,7 @@ _TEST_IMAGE = "python:3-slim"
 doc_md = """
 ## DockerOperatorWithFallback test DAG
 
-Hint: This is much easier to read by closing this modal and examining the code tab below.
+Hint: This documentation is much easier to read by closing this modal and examining the code tab below.
 
 ---
 

--- a/dags/test_docker_operator_wrapper.py
+++ b/dags/test_docker_operator_wrapper.py
@@ -10,6 +10,10 @@ _TEST_IMAGE = "python:3-slim"
 doc_md = """
 ## DockerOperatorWithFallback test DAG
 
+Hint: This is much easier to read by closing this modal and examining the code tab below.
+
+---
+
 Validates all failure modes of `DockerOperatorWithFallback`
 (`dags/utils/docker_operator_with_fallback.py`).
 

--- a/dags/test_docker_operator_wrapper.py
+++ b/dags/test_docker_operator_wrapper.py
@@ -1,44 +1,86 @@
-from airflow.sdk import DAG
+import docker
+import requests
+from airflow.sdk import DAG, task
 from pendulum import datetime, duration
 
 from utils.docker_operator_with_fallback import DockerOperatorWithFallback
 
+_TEST_IMAGE = "python:3-slim"
+
 doc_md = """
 ## DockerOperatorWithFallback test DAG
 
-Validates the `DockerOperatorWithFallback` wrapper in `utils/docker_operator_with_fallback.py`.
+Validates all failure modes of `DockerOperatorWithFallback`
+(`dags/utils/docker_operator_with_fallback.py`).
 
-### Tasks
+Trigger this DAG manually with no configuration. Two setup tasks automatically detect
+whether the test image is cached locally and whether Docker Hub is reachable, then route
+to only the tasks that are meaningful given the current environment.
 
-- **pull_succeeds**: normal happy path — `force_pull=True`, Docker Hub is reachable.
-  The image is pulled fresh and the container runs `echo`.
+---
 
-### Testing the fallback path
+## Which tasks run
 
-To exercise the "Hub is down, use cache" behavior without actually taking Hub offline:
+| Registry reachable? | Image cached locally? | Tasks that run |
+|---|---|---|
+| Yes | (either) | `happy_path`, `non_retryable_4xx` |
+| No | Yes | `transient_failure_with_cache` |
+| No | No | `transient_failure_no_cache` |
 
-1. Make sure `python:3-slim` is already cached locally:
-   ```
-   docker pull python:3-slim
-   ```
-2. Add a `/etc/hosts` entry to make the registry unreachable:
-   ```
-   sudo sh -c 'echo "127.0.0.1 registry-1.docker.io" >> /etc/hosts'
-   ```
-3. Trigger this DAG manually from the Airflow UI.
-4. Confirm the task logs contain a `WARNING: Failed to pull image … Running with cached image.`
-   line and that the task still succeeds.
-5. Remove the hosts entry when done:
-   ```
-   sudo sed -i '' '/registry-1.docker.io/d' /etc/hosts
-   ```
+---
 
-### Testing the "no cache + hub down" failure path
+## Simulating an outage
 
-With the `/etc/hosts` block in place:
-1. Remove the local image: `docker rmi python:3-slim`
-2. Trigger the DAG — the task should **fail** because there is no cached image to fall back to.
+To force the registry-unreachable scenarios, block Docker Hub via `/etc/hosts`:
+
+```
+sudo sh -c 'echo "127.0.0.1 registry-1.docker.io" >> /etc/hosts'
+```
+
+Restore when done:
+
+```
+sudo sed -i '' '/registry-1.docker.io/d' /etc/hosts
+```
+
+To also test `transient_failure_no_cache`, remove the local image before triggering:
+
+```
+docker rmi python:3-slim
+```
+
+---
+
+## Expected outcomes
+
+**`happy_path`** — Pull succeeds, container runs.
+Pull progress lines appear in the collapsed log group. Container prints `DockerOperatorWithFallback: OK`.
+
+**`non_retryable_4xx`** — Tag does not exist on Docker Hub. Task fails quickly with:
+```
+AirflowException: Pull failed for python:this-tag-does-not-exist with a non-retryable error
+(check image name and credentials): manifest for python:this-tag-does-not-exist not found ...
+```
+
+**`transient_failure_with_cache`** — Pull times out after ~1 minute. Task succeeds with a visible warning:
+```
+WARNING - Pull failed for python:3-slim (transient): ... dial tcp ... Running with cached image.
+```
+Container prints `Running from cached image after transient pull failure`.
+
+**`transient_failure_no_cache`** — Pull times out after ~1 minute. Task fails with:
+```
+AirflowException: Pull failed for python:3-slim (transient) and no cached image exists to fall back to: ...
+```
 """
+
+_COMMON_KWARGS = dict(
+    force_pull=True,
+    auto_remove="force",
+    execution_timeout=duration(minutes=5),
+    docker_url="unix://var/run/docker.sock",
+    network_mode="bridge",
+)
 
 with DAG(
     dag_id="test_docker_operator_wrapper",
@@ -49,13 +91,83 @@ with DAG(
     tags=["test"],
     doc_md=doc_md,
 ) as dag:
-    DockerOperatorWithFallback(
-        task_id="pull_succeeds",
-        image="python:3-slim",
+
+    @task
+    def check_image_cached() -> bool:
+        """Return True if the test image is already present in the local Docker image cache."""
+        client = docker.APIClient(base_url="unix://var/run/docker.sock")
+        return bool(client.images(name=_TEST_IMAGE))
+
+    @task
+    def check_registry_reachable() -> bool:
+        """Return True if Docker Hub's registry API is reachable.
+
+        Probes the v2 API endpoint directly with a short timeout. A 401 response means
+        the registry is up but unauthenticated (normal for an anonymous probe). Any 5xx,
+        connection error, DNS failure, or timeout is treated as unreachable.
+
+        Using a 5-second timeout here is important: without it, a real network outage
+        would block this probe for the same ~1 minute as the actual pull, defeating the
+        purpose of detecting the state up front.
+        """
+        try:
+            resp = requests.get("https://registry-1.docker.io/v2/", timeout=5)
+            # 401 = registry is up, just unauthenticated (expected for anonymous probe)
+            # 2xx or other 4xx = registry is reachable
+            # 5xx = registry is having trouble, treat same as unreachable
+            return resp.status_code < 500
+        except requests.exceptions.RequestException:
+            # DNS failure, connection refused, timeout — registry is unreachable
+            return False
+
+    @task.branch(task_id="select_tests")
+    def select_tests(image_cached: bool, registry_reachable: bool) -> list[str]:
+        """Return the task ids that are valid to run given the current environment."""
+        if registry_reachable:
+            # Hub is reachable: test the happy path and the 4xx hard-failure behavior.
+            # The 4xx task needs a live registry to actually return a 404 — if the registry
+            # were unreachable, that error would look like a transient TCP failure instead.
+            return ["happy_path", "non_retryable_4xx"]
+
+        if image_cached:
+            # Hub is unreachable and the image is cached: the wrapper should fall back gracefully.
+            return ["transient_failure_with_cache"]
+
+        # Hub is unreachable and the image is NOT cached: nothing to fall back to, must fail.
+        return ["transient_failure_no_cache"]
+
+    cached = check_image_cached()
+    reachable = check_registry_reachable()
+    branch = select_tests(cached, reachable)
+
+    happy_path = DockerOperatorWithFallback(
+        task_id="happy_path",
+        image=_TEST_IMAGE,
         command=["python", "-c", "print('DockerOperatorWithFallback: OK')"],
-        force_pull=True,
-        auto_remove="force",
-        execution_timeout=duration(minutes=5),
-        docker_url="unix://var/run/docker.sock",
-        network_mode="bridge",
+        **_COMMON_KWARGS,
     )
+
+    transient_failure_with_cache = DockerOperatorWithFallback(
+        task_id="transient_failure_with_cache",
+        image=_TEST_IMAGE,
+        command=["python", "-c", "print('Running from cached image after transient pull failure')"],
+        **_COMMON_KWARGS,
+    )
+
+    transient_failure_no_cache = DockerOperatorWithFallback(
+        task_id="transient_failure_no_cache",
+        image=_TEST_IMAGE,
+        command=["python", "-c", "print('This should never run')"],
+        **_COMMON_KWARGS,
+    )
+
+    # Intentionally nonexistent tag. With a live registry this gets a 404, which the
+    # wrapper must re-raise rather than fall back on.
+    non_retryable_4xx = DockerOperatorWithFallback(
+        task_id="non_retryable_4xx",
+        image="python:this-tag-does-not-exist",
+        command=["python", "-c", "print('This should never run')"],
+        **_COMMON_KWARGS,
+    )
+
+    branch >> [happy_path, transient_failure_with_cache, transient_failure_no_cache, non_retryable_4xx]

--- a/dags/test_docker_operator_wrapper.py
+++ b/dags/test_docker_operator_wrapper.py
@@ -157,7 +157,7 @@ with DAG(
     transient_failure_no_cache = DockerOperatorWithFallback(
         task_id="transient_failure_no_cache",
         image=_TEST_IMAGE,
-        command=["python", "-c", "print('This should never run')"],
+        command=["python", "-c", "print('This should never run, transient_failure_no_cache')"],
         **_COMMON_KWARGS,
     )
 
@@ -166,7 +166,7 @@ with DAG(
     non_retryable_4xx = DockerOperatorWithFallback(
         task_id="non_retryable_4xx",
         image="python:this-tag-does-not-exist",
-        command=["python", "-c", "print('This should never run')"],
+        command=["python", "-c", "print('This should never run, non_retryable_4xx')"],
         **_COMMON_KWARGS,
     )
 

--- a/dags/test_docker_operator_wrapper.py
+++ b/dags/test_docker_operator_wrapper.py
@@ -85,6 +85,7 @@ _COMMON_KWARGS = dict(
     auto_remove="force",
     execution_timeout=duration(minutes=5),
     network_mode="bridge",
+    docker_conn_id="docker_default",
 )
 
 with DAG(

--- a/dags/test_docker_operator_wrapper.py
+++ b/dags/test_docker_operator_wrapper.py
@@ -43,9 +43,11 @@ sudo sh -c 'echo "127.0.0.1 registry-1.docker.io" >> /etc/hosts'
 
 Restore when done:
 
-```
-sudo sed -i '' '/registry-1.docker.io/d' /etc/hosts
-```
+    # Linux (GNU sed)
+    sudo sed -i '/registry-1.docker.io/d' /etc/hosts
+
+    # macOS (BSD sed)
+    sudo sed -i '' '/registry-1.docker.io/d' /etc/hosts
 
 To also test `transient_failure_no_cache`, remove the local image before triggering:
 

--- a/dags/test_docker_operator_wrapper.py
+++ b/dags/test_docker_operator_wrapper.py
@@ -84,7 +84,6 @@ _COMMON_KWARGS = dict(
     force_pull=True,
     auto_remove="force",
     execution_timeout=duration(minutes=5),
-    docker_url="unix://var/run/docker.sock",
     network_mode="bridge",
 )
 

--- a/dags/test_docker_operator_wrapper.py
+++ b/dags/test_docker_operator_wrapper.py
@@ -1,0 +1,61 @@
+from airflow.sdk import DAG
+from pendulum import datetime, duration
+
+from utils.docker_operator_with_fallback import DockerOperatorWithFallback
+
+doc_md = """
+## DockerOperatorWithFallback test DAG
+
+Validates the `DockerOperatorWithFallback` wrapper in `utils/docker_operator_with_fallback.py`.
+
+### Tasks
+
+- **pull_succeeds**: normal happy path — `force_pull=True`, Docker Hub is reachable.
+  The image is pulled fresh and the container runs `echo`.
+
+### Testing the fallback path
+
+To exercise the "Hub is down, use cache" behavior without actually taking Hub offline:
+
+1. Make sure `python:3-slim` is already cached locally:
+   ```
+   docker pull python:3-slim
+   ```
+2. Add a `/etc/hosts` entry to make the registry unreachable:
+   ```
+   sudo sh -c 'echo "127.0.0.1 registry-1.docker.io" >> /etc/hosts'
+   ```
+3. Trigger this DAG manually from the Airflow UI.
+4. Confirm the task logs contain a `WARNING: Failed to pull image … Running with cached image.`
+   line and that the task still succeeds.
+5. Remove the hosts entry when done:
+   ```
+   sudo sed -i '' '/registry-1.docker.io/d' /etc/hosts
+   ```
+
+### Testing the "no cache + hub down" failure path
+
+With the `/etc/hosts` block in place:
+1. Remove the local image: `docker rmi python:3-slim`
+2. Trigger the DAG — the task should **fail** because there is no cached image to fall back to.
+"""
+
+with DAG(
+    dag_id="test_docker_operator_wrapper",
+    description="Manual smoke test for DockerOperatorWithFallback",
+    start_date=datetime(2024, 1, 1, tz="America/Chicago"),
+    schedule=None,
+    catchup=False,
+    tags=["test"],
+    doc_md=doc_md,
+) as dag:
+    DockerOperatorWithFallback(
+        task_id="pull_succeeds",
+        image="python:3-slim",
+        command=["python", "-c", "print('DockerOperatorWithFallback: OK')"],
+        force_pull=True,
+        auto_remove="force",
+        execution_timeout=duration(minutes=5),
+        docker_url="unix://var/run/docker.sock",
+        network_mode="bridge",
+    )

--- a/dags/utils/docker_operator_with_fallback.py
+++ b/dags/utils/docker_operator_with_fallback.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from docker.errors import APIError
 from requests.exceptions import RequestException
 
@@ -5,18 +7,57 @@ from airflow.exceptions import AirflowException
 from airflow.providers.docker.operators.docker import DockerOperator
 
 
+# Below are substrings that identify a pull failure as a temporary infrastructure problem —
+# a registry outage, network hiccup, or TCP-level failure — rather than a
+# configuration or authentication error. Only errors that match one of these patterns
+# will trigger the cached-image fallback. Everything else (4xx auth/not-found errors,
+# or anything we don't recognize) is re-raised so the task fails visibly.
+#
+# WHY a whitelist instead of a blacklist of 4xx patterns:
+#   The Docker daemon does not include the raw HTTP status code in streamed error dicts.
+#   It only gives us an error message string. Whitelisting known transient patterns is
+#   safer than trying to blacklist every possible 4xx message phrasing — unrecognized
+#   errors default to a hard failure rather than a silent fallback.
+_TRANSIENT_PULL_ERROR_PATTERNS = (
+    "dial tcp",                  # TCP connection failure (refused, unreachable, etc.)
+    "i/o timeout",               # read/write timeout on the socket
+    "context deadline exceeded",  # overall request deadline hit (daemon-level timeout)
+    "no such host",              # DNS resolution failed
+    " EOF",                      # connection dropped mid-stream; leading space avoids matching
+                                 # "errorDetail.EOF" or similar field names in error dicts
+    "TLS handshake timeout",     # TLS negotiation timed out (often precedes a connection drop)
+    "500 Internal Server Error",
+    "502 Bad Gateway",
+    "503 Service Unavailable",
+    "504 Gateway Timeout",
+)
+
+
+def _is_transient_pull_error(error: str) -> bool:
+    """Return True if the error string indicates a temporary infrastructure failure.
+
+    Returns False for anything that doesn't match a known transient pattern, which
+    causes the caller to re-raise rather than fall back. This means 4xx errors
+    (wrong image name, expired credentials, unauthorized) always fail loudly.
+    """
+    return any(pattern in error for pattern in _TRANSIENT_PULL_ERROR_PATTERNS)
+
+
 class DockerOperatorWithFallback(DockerOperator):
-    """DockerOperator that attempts force_pull but falls back to the cached image on pull failure.
+    """DockerOperator that attempts force_pull but falls back to the cached image on transient pull failures.
 
     The standard DockerOperator with force_pull=True will fail the entire task if the registry
     is unreachable, even when a perfectly usable image is already cached on the host. This
-    wrapper changes that behavior: it tries to pull, and if the pull fails for any reason
-    (registry outage, DNS failure, timeout, etc.), it logs a warning and runs the cached image
-    instead.
+    wrapper changes that behavior for temporary infrastructure failures: it tries to pull, and
+    if the pull fails due to a network outage or registry 5xx, it logs a warning and runs the
+    cached image instead.
 
-    There is one case where a pull failure still causes the task to fail: when force_pull=True
-    but there is no cached image on the host yet. In that case there is nothing to fall back to,
-    so failing is the correct behavior.
+    NOT all pull failures trigger the fallback. 4xx errors (wrong image tag, expired credentials,
+    unauthorized access) are re-raised immediately so they don't silently mask misconfigurations.
+    Any error string that doesn't match a known transient pattern is also re-raised by default.
+
+    There is one additional case where a transient failure still causes the task to fail: when
+    there is no cached image on the host. In that case there is nothing to fall back to.
 
     Usage is identical to DockerOperator — just swap the class name. All other parameters,
     behavior, and inherited methods (xcom, auto_remove, on_kill, etc.) are unchanged.
@@ -28,12 +69,13 @@ class DockerOperatorWithFallback(DockerOperator):
         #   - if the image isn't cached locally at all, we must try to pull regardless
         if self.force_pull or not self.cli.images(name=self.image):
 
-            # ::group:: / ::endgroup:: are Airflow log-grouping markers
+            # ::group:: / ::endgroup:: are Airflow log-grouping markers that collapse the
+            # verbose layer-by-layer pull output in the UI, matching the parent's behavior.
             self.log.info("::group::Pulling docker image %s", self.image)
 
             # pull_error stays None if the pull succeeds. If anything goes wrong — whether
             # an exception is raised or Docker streams back an error message — we capture
-            # the error text here so both failure paths can share the same fallback logic below.
+            # the error text here so both failure paths share the same classification logic below.
             pull_error: str | None = None
 
             try:
@@ -50,13 +92,18 @@ class DockerOperatorWithFallback(DockerOperator):
                         continue
 
                     if isinstance(output, dict):
-                        # IMPORTANT: When the registry is unreachable, the Docker daemon does
-                        # NOT raise a Python exception. Instead it streams back a JSON object
-                        # with an "error" key, e.g.:
-                        #   {"error": "Get \"https://registry-1.docker.io/v2/\": dial tcp ..."}
-                        # If we don't check for this key, the loop completes silently and the
-                        # container runs from cache without any log entry — making it impossible
-                        # to tell whether the pull actually succeeded or was silently skipped.
+                        # IMPORTANT: When the registry is unreachable or returns an error,
+                        # the Docker daemon does NOT raise a Python exception. Instead it
+                        # streams back a JSON object with an "error" key, for example:
+                        #
+                        #   4xx: {"error": "manifest for python:bad-tag not found: manifest unknown"}
+                        #   4xx: {"error": "pull access denied: repository does not exist or may require 'docker login'"}
+                        #   5xx: {"error": "Get \"https://registry-1.docker.io/v2/\": unexpected status code 503 Service Unavailable"}
+                        #  TCP: {"error": "Get \"https://registry-1.docker.io/v2/\": dial tcp 127.0.0.1:443: connect: connection refused"}
+                        #
+                        # If we don't check for this key, the loop completes silently and
+                        # the container runs from cache with no log entry — making it
+                        # impossible to tell whether the pull succeeded or was skipped.
                         if "error" in output:
                             pull_error = output["error"]
                             break
@@ -77,32 +124,47 @@ class DockerOperatorWithFallback(DockerOperator):
                                 latest_status[output_id] = output_status
 
             except (APIError, RequestException) as e:
-                # True Python exceptions can still occur in some failure modes — for example,
-                # if the Docker daemon itself is unreachable (socket error) rather than the
-                # registry being unreachable. Capture the message so it flows through the
-                # same fallback logic as the streamed-error-dict case above.
+                # True Python exceptions can still occur in some failure modes. For example:
+                #   - RequestException: network error talking to the Docker daemon socket itself
+                #     (distinct from the daemon talking to the registry). Always transient.
+                #   - APIError: the daemon rejected the pull request at the API level.
+                #     Apply the same pattern check as streamed error dicts.
                 pull_error = str(e)
 
             # Close the log group regardless of whether the pull succeeded or failed,
-            # so the UI doesn't leave an unclosed collapsible section. The warning below
+            # so the UI doesn't leave an unclosed collapsible section. Everything below
             # is intentionally placed AFTER ::endgroup:: so it is always visible in the
             # logs and never hidden inside the collapsed pull output section.
             self.log.info("::endgroup::")
 
             if pull_error:
+                if not _is_transient_pull_error(pull_error):
+                    # The error doesn't match any known transient pattern — treat it as a
+                    # hard failure. This covers 4xx errors (wrong image name, bad credentials,
+                    # unauthorized) and anything else we don't recognize. We never silently
+                    # fall back for these, even if a cached image happens to exist, because
+                    # that would mask real misconfigurations.
+                    raise AirflowException(
+                        f"Pull failed for {self.image} with a non-retryable error "
+                        f"(check image name and credentials): {pull_error}"
+                    )
+
+                # The error is a known transient failure (network outage, 5xx). Now check
+                # whether we actually have something to fall back to.
                 if self.cli.images(name=self.image):
                     # A cached image exists — we can run it. Log a prominent warning so
                     # it's obvious in the task logs that the pull failed and the cached
                     # image was used instead of a freshly pulled one.
                     self.log.warning(
-                        "Pull failed for %s: %s. Running with cached image.", self.image, pull_error
+                        "Pull failed for %s (transient): %s. Running with cached image.",
+                        self.image,
+                        pull_error,
                     )
                 else:
-                    # No cached image and the pull failed — there is nothing to run.
-                    # Fail the task with a clear message rather than letting Docker raise
-                    # a cryptic "image not found" error from _run_image().
+                    # Transient failure AND no cached image — there is nothing to run.
                     raise AirflowException(
-                        f"Pull failed for {self.image} and no cached image exists: {pull_error}"
+                        f"Pull failed for {self.image} (transient) and no cached image "
+                        f"exists to fall back to: {pull_error}"
                     )
 
         # Delegate container creation and execution entirely to the parent. Nothing about

--- a/dags/utils/docker_operator_with_fallback.py
+++ b/dags/utils/docker_operator_with_fallback.py
@@ -28,8 +28,7 @@ class DockerOperatorWithFallback(DockerOperator):
         #   - if the image isn't cached locally at all, we must try to pull regardless
         if self.force_pull or not self.cli.images(name=self.image):
 
-            # ::group:: / ::endgroup:: are Airflow log-grouping markers that collapse the
-            # verbose layer-by-layer pull output in the UI, matching the parent's behavior.
+            # ::group:: / ::endgroup:: are Airflow log-grouping markers
             self.log.info("::group::Pulling docker image %s", self.image)
 
             # pull_error stays None if the pull succeeds. If anything goes wrong — whether

--- a/dags/utils/docker_operator_with_fallback.py
+++ b/dags/utils/docker_operator_with_fallback.py
@@ -1,0 +1,52 @@
+from docker.errors import APIError
+from requests.exceptions import RequestException
+
+from airflow.exceptions import AirflowException
+from airflow.providers.docker.operators.docker import DockerOperator
+
+
+class DockerOperatorWithFallback(DockerOperator):
+    """DockerOperator that attempts force_pull but falls back to the cached image on pull failure.
+
+    Useful when force_pull=True is desired for freshness but a registry outage should not
+    prevent the task from running with the last successfully pulled image.
+
+    If the pull fails and no local image exists, the task fails as normal.
+    """
+
+    def execute(self, context):
+        if self.force_pull or not self.cli.images(name=self.image):
+            self.log.info("::group::Pulling docker image %s", self.image)
+            pull_error: str | None = None
+            try:
+                latest_status: dict[str, str] = {}
+                for output in self.cli.pull(self.image, stream=True, decode=True):
+                    if isinstance(output, str):
+                        self.log.info("%s", output)
+                        continue
+                    if isinstance(output, dict):
+                        if "error" in output:
+                            pull_error = output["error"]
+                            break
+                        if "status" in output:
+                            output_status = output["status"]
+                            if "id" not in output:
+                                self.log.info("%s", output_status)
+                                continue
+                            output_id = output["id"]
+                            if latest_status.get(output_id) != output_status:
+                                self.log.info("%s: %s", output_id, output_status)
+                                latest_status[output_id] = output_status
+            except (APIError, RequestException) as e:
+                pull_error = str(e)
+            self.log.info("::endgroup::")
+            if pull_error:
+                if self.cli.images(name=self.image):
+                    self.log.warning(
+                        "Pull failed for %s: %s. Running with cached image.", self.image, pull_error
+                    )
+                else:
+                    raise AirflowException(
+                        f"Pull failed for {self.image} and no cached image exists: {pull_error}"
+                    )
+        return self._run_image()

--- a/dags/utils/docker_operator_with_fallback.py
+++ b/dags/utils/docker_operator_with_fallback.py
@@ -8,45 +8,104 @@ from airflow.providers.docker.operators.docker import DockerOperator
 class DockerOperatorWithFallback(DockerOperator):
     """DockerOperator that attempts force_pull but falls back to the cached image on pull failure.
 
-    Useful when force_pull=True is desired for freshness but a registry outage should not
-    prevent the task from running with the last successfully pulled image.
+    The standard DockerOperator with force_pull=True will fail the entire task if the registry
+    is unreachable, even when a perfectly usable image is already cached on the host. This
+    wrapper changes that behavior: it tries to pull, and if the pull fails for any reason
+    (registry outage, DNS failure, timeout, etc.), it logs a warning and runs the cached image
+    instead.
 
-    If the pull fails and no local image exists, the task fails as normal.
+    There is one case where a pull failure still causes the task to fail: when force_pull=True
+    but there is no cached image on the host yet. In that case there is nothing to fall back to,
+    so failing is the correct behavior.
+
+    Usage is identical to DockerOperator — just swap the class name. All other parameters,
+    behavior, and inherited methods (xcom, auto_remove, on_kill, etc.) are unchanged.
     """
 
     def execute(self, context):
+        # Replicate the parent's condition for deciding whether to attempt a pull:
+        #   - force_pull=True means "always try to pull the latest from the registry"
+        #   - if the image isn't cached locally at all, we must try to pull regardless
         if self.force_pull or not self.cli.images(name=self.image):
+
+            # ::group:: / ::endgroup:: are Airflow log-grouping markers that collapse the
+            # verbose layer-by-layer pull output in the UI, matching the parent's behavior.
             self.log.info("::group::Pulling docker image %s", self.image)
+
+            # pull_error stays None if the pull succeeds. If anything goes wrong — whether
+            # an exception is raised or Docker streams back an error message — we capture
+            # the error text here so both failure paths can share the same fallback logic below.
             pull_error: str | None = None
+
             try:
+                # cli.pull() with stream=True and decode=True returns a generator that yields
+                # JSON-decoded progress dicts as the Docker daemon streams them. The actual
+                # network connection to the registry happens lazily as we iterate — meaning
+                # registry errors surface during the loop, not at the cli.pull() call itself.
                 latest_status: dict[str, str] = {}
                 for output in self.cli.pull(self.image, stream=True, decode=True):
+
                     if isinstance(output, str):
+                        # Occasionally the daemon yields a plain string instead of a dict.
                         self.log.info("%s", output)
                         continue
+
                     if isinstance(output, dict):
+                        # IMPORTANT: When the registry is unreachable, the Docker daemon does
+                        # NOT raise a Python exception. Instead it streams back a JSON object
+                        # with an "error" key, e.g.:
+                        #   {"error": "Get \"https://registry-1.docker.io/v2/\": dial tcp ..."}
+                        # If we don't check for this key, the loop completes silently and the
+                        # container runs from cache without any log entry — making it impossible
+                        # to tell whether the pull actually succeeded or was silently skipped.
                         if "error" in output:
                             pull_error = output["error"]
                             break
+
                         if "status" in output:
+                            # Normal progress message. Each image layer reports status updates
+                            # like "Pulling fs layer", "Downloading", "Pull complete", etc.
+                            # We deduplicate by (layer id, status) to avoid spamming the log
+                            # with repeated lines for the same layer state.
                             output_status = output["status"]
                             if "id" not in output:
+                                # Status line with no layer id (e.g. "Pulling from library/python")
                                 self.log.info("%s", output_status)
                                 continue
                             output_id = output["id"]
                             if latest_status.get(output_id) != output_status:
                                 self.log.info("%s: %s", output_id, output_status)
                                 latest_status[output_id] = output_status
+
             except (APIError, RequestException) as e:
+                # True Python exceptions can still occur in some failure modes — for example,
+                # if the Docker daemon itself is unreachable (socket error) rather than the
+                # registry being unreachable. Capture the message so it flows through the
+                # same fallback logic as the streamed-error-dict case above.
                 pull_error = str(e)
+
+            # Close the log group regardless of whether the pull succeeded or failed,
+            # so the UI doesn't leave an unclosed collapsible section. The warning below
+            # is intentionally placed AFTER ::endgroup:: so it is always visible in the
+            # logs and never hidden inside the collapsed pull output section.
             self.log.info("::endgroup::")
+
             if pull_error:
                 if self.cli.images(name=self.image):
+                    # A cached image exists — we can run it. Log a prominent warning so
+                    # it's obvious in the task logs that the pull failed and the cached
+                    # image was used instead of a freshly pulled one.
                     self.log.warning(
                         "Pull failed for %s: %s. Running with cached image.", self.image, pull_error
                     )
                 else:
+                    # No cached image and the pull failed — there is nothing to run.
+                    # Fail the task with a clear message rather than letting Docker raise
+                    # a cryptic "image not found" error from _run_image().
                     raise AirflowException(
                         f"Pull failed for {self.image} and no cached image exists: {pull_error}"
                     )
+
+        # Delegate container creation and execution entirely to the parent. Nothing about
+        # how the container actually runs is changed by this wrapper.
         return self._run_image()


### PR DESCRIPTION
## Note

This PR contains a new DockerOperator wrapper named DockerOperatorWithFallback. It also contains a test DAG which can be used to test the wrapper. This PR closes and replaces #341 because it implements the same feature in a less brittle, more understandable way. 

🤖 This set of changes was created using Claude Code and was heavily influenced by the first attempt in #341 and even more so by the feedback that that PR received. 
✅ I think the code in this PR is of reasonable complexity and can be worked on without a requirement of AI tooling.

I believe this new PR is worth starting the review process over with because it is both much easier to read and understand. I feel it more completely addresses the concerns and advice given in the last PR's reviews.

## Refactoring the DAGs

This PR works with the existing refactor PR, no changes needed. That existing refactor PR is #342.

## Associated issues

This PR closes https://github.com/cityofaustin/atd-data-tech/issues/25196.

## Associated repo

Airflow Itself

## Testing

The goal here is to test the behavior of the docker wrapper in the four combinations of conditions:

* Having, or not having, a cached copy of an image you want to run
* If there is, or is not, a transient error preventing you from communicating with docker hub

Examples of transient/temporary errors are network problems, 500s from docker hub, it being unable to respond to a request when reached, etc. An non-example is when docker hub says "400 - image does not exist" -- that's a permanent error that should have an exception raised. 

### Testing Operations

Here's some stuff you're going to need to be able to do during the test.

Mask or inhibit docker hub from being reachable:

```
sudo sh -c 'echo "127.0.0.1 registry-1.docker.io" >> /etc/hosts'
```

Undo or uninhibit docker hub from being reachable, making it reachable again:

```
sudo sed -i '' '/registry-1.docker.io/d' /etc/hosts
```

Cache the test image:

```
docker pull python:3-slim

# Having a DAG's task pull the image caches it as well, BTW
```

Remove cache of docker image:

```
docker rmi python:3-slim
```

#### Testing Information

<img width="776" height="507" alt="image" src="https://github.com/user-attachments/assets/63e8c888-270e-48f3-bac4-55ff751442f5" />

☝️ The test DAG will detect those two run time conditions and run appropriate tasks based on what it finds as shown in this graph.

#### Test Steps

Now that you have the background and the tools to set the state on your machine, work through the numbered list below.

The result of each testing instruction row should match the image where the columns match up to the numbered tasks. Be sure to click on the individual tasks of each tests and read the logs for a complete understanding of what happened. The `check_image_cached` and `check_registry_reachable` tasks' logs will tell you what the DAG detected for each of those run time conditions.

<img width="565" height="528" alt="image" src="https://github.com/user-attachments/assets/6b0cbbc7-8813-43c7-9193-f2404ee5eea2" />

1) Remove image from local cache in case you just happen to have it laying around and, do not inhibit docker hub DNS, then trigger DAG.
2) Trigger DAG again. You're testing now that you have it cached.
3) Inhibit the docker hub DNS via /etc/hosts. Trigger the DAG.
4) Remove the image from local cache, and leave DNS inhibited. Trigger the DAG.
5) Remove the masking entry from your /etc/hosts. The image remains uncached. This is the same test as 1. Trigger the DAG.
6) You've got it cached now, so trigger it and expect the same results as 2. 


---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
