### PR TITLE
Work Zone segment updater

### DIFF
--- a/dags/dts_work_zone_segment_updater.py
+++ b/dags/dts_work_zone_segment_updater.py
@@ -16,7 +16,7 @@ This DAG updates a socrata dataset of directional street segments daily.
 
 You do NOT need to be on city VPN to run this locally.
 
-Please investigate any long term outages of this DAG as if it continually fails we might become out of sync with the source segment dataset.
+Please investigate any long term outages of this DAG as if it continually fails we might become out of sync with the source segment dataset. 
 
 """
 
@@ -28,8 +28,6 @@ DEFAULT_ARGS = {
     "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 0,
-    "execution_timeout": duration(minutes=15),
     "on_failure_callback": task_fail_slack_alert,
 }
 
@@ -75,7 +73,7 @@ with DAG(
     env_vars = get_env_vars_task(REQUIRED_SECRETS)
 
     t1 = DockerOperator(
-        task_id="work_zone_data_publishing",
+        task_id="directional_segment_updater",
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
@@ -86,6 +84,7 @@ with DAG(
         mount_tmp_dir=False,
         retries=3,
         retry_delay=duration(seconds=5*60),
+        execution_timeout=duration(minutes=15),
     )
 
     t1

--- a/dags/dts_work_zone_segment_updater.py
+++ b/dags/dts_work_zone_segment_updater.py
@@ -1,0 +1,91 @@
+from os import getenv
+
+from airflow.sdk import task, DAG
+from airflow.providers.docker.operators.docker import DockerOperator
+from pendulum import datetime, duration, now
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+doc_md = """
+## Work Zone Datafeed street segment updater (WZDX)
+
+This DAG updates a socrata dataset of directional street segments daily.
+
+## Troubleshooting
+
+You do NOT need to be on city VPN to run this locally.
+
+Please investigate any long term outages of this DAG as if it continually fails we might become out of sync with the source segment dataset.
+
+"""
+
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=15),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+docker_image = "atddocker/dts-work-zone-data-feed:production"
+
+REQUIRED_SECRETS = {
+    # Socrata
+    "SO_USER": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SO_PASS": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SO_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "SO_WEB": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.endpoint",
+    },
+    "SEGMENT_DATASET": {
+        "opitem": "Work Zone Data Feed",
+        "opfield": "production.segment dataset ID",
+    },
+    "SOURCE_SEGMENT_DATASET": {
+        "opitem": "Work Zone Data Feed",
+        "opfield": "production.source segment dataset ID",
+    },
+}
+
+with DAG(
+    dag_id="dts_work_zone_segment_updater",
+    description="Updates street segments for the work zone feed",
+    doc_md=doc_md,
+    default_args=DEFAULT_ARGS,
+    schedule="13 3 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:dts-work-zone-data-feed", "amanda", "socrata", "work zone", "wzdx", "segments"],
+    catchup=False,
+) as dag:
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    t1 = DockerOperator(
+        task_id="work_zone_data_publishing",
+        image=docker_image,
+        docker_conn_id="docker_default",
+        auto_remove="force",
+        command=f"python geometry/street_segment_directionality.py",
+        environment=env_vars,
+        tty=True,
+        force_pull=True,
+        mount_tmp_dir=False,
+        retries=3,
+        retry_delay=duration(seconds=5*60),
+    )
+
+    t1


### PR DESCRIPTION
Adding 3:13AM daily refresh of directional street segments, related to this [PR](https://github.com/cityofaustin/dts-work-zone-data-feed/pull/8).


***

## Associated issues
[#26891](https://github.com/cityofaustin/atd-data-tech/issues/26891) - Update the Direction field in our WZDX

## Associated repo
https://github.com/cityofaustin/dts-work-zone-data-feed/pull/8

## Testing

**Steps to test:**
You do not need to be on VPN

1. If you are on mac: `docker pull --platform linux/amd64 atddocker/dts-work-zone-data-feed:production`, otherwise you should be OK to skip this step 
2. checkout this branch
3. `docker compose run --rm airflow-cli dags test dts_work_zone_segment_updater` OR `docker compose up` and use the UI to trigger the dag: `work_zone_data_publishing`
4. Check that it completes without errors.

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
