### PR TITLE
Create DAG to monitor health of CCTV redirect service

### DIFF
--- a/dags/cctv_service_healthcheck.py
+++ b/dags/cctv_service_healthcheck.py
@@ -27,6 +27,10 @@ DEFAULT_ARGS = {
 doc_md = """
 Checks that the cctv-service endpoint is reachable and that CCTV asset data is fresh.
 
+If the cctv asset data becomes stale, it is possible that some cameras will not direct to the correct IP address. This is a minor issue unless it persists for multiple days.
+
+If the service is down, MMC staff will not be re-directed to CCTV camera IPs from the [traffic cameras dashboard](https://data.mobility.austin.gov/traffic-cameras). This is a more significant issue and should addressed immediately.
+
 See the atd-cctv-service readme for more details on deployment and how to restart.
 """
 

--- a/dags/cctv_service_healthcheck.py
+++ b/dags/cctv_service_healthcheck.py
@@ -65,7 +65,7 @@ with DAG(
     description="Checks the healthiness of the atd-cctv-service app",
     doc_md=doc_md,
     default_args=DEFAULT_ARGS,
-    schedule="*/10 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    schedule="7 */1 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
     tags=["repo:atd-cctv-service", "cctv"],
     catchup=False,
 ) as dag:

--- a/dags/cctv_service_healthcheck.py
+++ b/dags/cctv_service_healthcheck.py
@@ -1,0 +1,75 @@
+from os import getenv
+from airflow import DAG
+from airflow.sdk import task
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert, slack_member_ids
+
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
+
+REQUIRED_SECRETS = {
+    "endpoint": {
+        "opitem": "CCTV Service redirect endpoint",
+        "opfield": f"{"production" if DEPLOYMENT_ENVIRONMENT == "production" else "development"}.endpoint",
+    },
+}
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2026, 1, 1, tz="America/Chicago"),
+    "retries": 0,
+    "execution_timeout": duration(seconds=30),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+doc_md = """
+Checks that the cctv-service endpoint is reachable and that CCTV asset data is fresh.
+
+See the atd-cctv-service readme for more details on deployment and how to restart.
+"""
+
+
+@task(task_id="healthcheck")
+def healthcheck(env_vars):
+    import requests
+    from airflow.exceptions import AirflowException
+
+    endpoint = env_vars["endpoint"]
+    url = f"{endpoint}/healthz"
+
+    try:
+        res = requests.get(url, timeout=10)
+    except requests.exceptions.RequestException as e:
+        # A ConnnectionError would raise here, for example
+        raise AirflowException(f"Could not reach {url}: {e}")
+
+    try:
+        data = res.json()
+    except ValueError:
+        # Non-JSON response — this would be a 500 or similar unhandled error
+        raise AirflowException(f"{res.status_code}): {res.text[:200]}")
+
+    if res.status_code != 200:
+        # Get error message from response payload, if available
+        message = data.get("message", "unknown error")
+        raise AirflowException(f"cctv-service unhealthy: {message}")
+
+    # log healthy check results
+    print(data)
+
+
+with DAG(
+    dag_id="cctv_service_healthcheck",
+    description="Checks the healthiness of the atd-cctv-service app",
+    doc_md=doc_md,
+    default_args=DEFAULT_ARGS,
+    schedule="*/10 * * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:atd-cctv-service", "cctv"],
+    catchup=False,
+) as dag:
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    healthcheck(env_vars)


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/29218

## Associated repo

* atd-cctv-service

## Testing

### Set up

1. Get on VPN or make sure your IP is whitelisted to reach the 1Password connect server
2. Checkout this Airflow branch and start Airflow
3. Follow [the readme](https://github.com/cityofaustin/atd-cctv-service#local-development) to spin up the CCTV redirect app. Make sure you're on the `production` branch. Watch the log output until you see that the `fetcher` task has done it's thing. This should be less than a minute:

```
atd-cctv-service-fetcher-1        | 2026-07-07 20:14:44,086 INFO __main__ Wrote 1004 cameras to /data/cameras.json
atd-cctv-service-fetcher-1        | 2026-07-07 20:14:44,086 INFO __main__ Updated fetch log timestamp to 1783455284
```
### Testing

1. First, just trigger the `cctv_service_healthcheck` DAG. It should run without error ✅ 

Now, we're going to a test a variety of failure modes by executing commands from the root of your local `atd-cctv-service` repo. Leave the CCTV app running and open a new terminal window to execute the commands below.

2. This command will replace the camera fetch log with an old timestamp. Execute the command, then trigger the DAG again and verify you see the correct exception in the logs. 

```
# execute from ./atd-cctv-service
docker compose exec fetcher sh -c "echo $(( $(date +%s) - 50000 )) > /data/cameras.log"
```

> cctv-service unhealthy: Camera data is stale (age: 835 minutes)

3. This command will corrupt the camera log with an invalid timestamp

```
docker compose exec fetcher sh -c "echo 'not-a-timestamp' > /data/cameras.log"
```

> cctv-service unhealthy: Unable to read last fetch timestamp

3. These commands will (1) Restore the camera log timestamp and (2) corrupt the `cameras.json` file. Run the commands, then trigger the DAG.

```
# restore cameras.log with a current timestamp
docker compose exec fetcher sh -c "echo $(date +%s) > /data/cameras.log"

# replace the cameras.json file with garbage
docker compose exec fetcher sh -c "echo '{not valid json' > /data/cameras.json"
```

> cctv-service unhealthy: Unable to load camera data

4. Lastly, spin down the CCTV service completely, then trigger the DAG one last time.

```
docker compose down -v
```

> Could not reach http://host.docker.internal:5001/healthz: HTTPConnectionPool(host='host.docker.internal', port=5001


#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
