### PR TITLE
Update Moped AGOL ETL script to use staging/development endpoint locally

### DIFF
--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -23,11 +23,11 @@ DEFAULT_ARGS = {
 REQUIRED_SECRETS = {
     "HASURA_ENDPOINT": {
         "opitem": "Moped Hasura Admin",
-        "opfield": "production.Endpoint",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Endpoint",
     },
     "HASURA_ADMIN_SECRET": {
         "opitem": "Moped Hasura Admin",
-        "opfield": "production.Admin Secret",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.Admin Secret",
     },
     "AGOL_USERNAME": {
         "opitem": "ArcGIS Online (AGOL) Scripts Publisher",

--- a/dags/atd_moped_components_to_agol.py
+++ b/dags/atd_moped_components_to_agol.py
@@ -37,6 +37,10 @@ REQUIRED_SECRETS = {
         "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
         "opfield": "production.password",
     },
+    "AGOL_COMPONENTS_ENDPOINT": {
+        "opitem": "Moped ETLs",
+        "opfield": f"{DEPLOYMENT_ENVIRONMENT}.AGOL_COMPONENTS_ENDPOINT",
+    },
 }
 
 


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/29427

## Associated repo
https://github.com/cityofaustin/atd-moped/pull/1902

## Testing

**Steps to test:**
1. Start your local Airflow instance
2. Start up your local Moped stack replicated production data
3. Using the dry mode option, trigger the DAG. This will take a while to query all the data since you probably don't have a last successful run for the DAG to reference in incremental mode.
4. While this runs, you can check the logging of the `get_env_vars` task to confirm that it picked up `https://services.arcgis.com/0L95CJ0VTaxqcmED/arcgis/rest/services/Staging_Moped_Project_Components/FeatureServer` as the AGOL endpoint
5. Don't sweat it if it fails or you forgot to toggle dry run because we are interacting with the staging feature service and not production 💥 

---

#### Ship list

- [x] Code reviewed
- [x] Product manager approved
- ~[ ] Add note to 1PW secrets moved to API vault and check for duplicates~
