### PR TITLE
EcoCounters DAG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ db/*
 .vscode/*
 
 users/
+/.idea

--- a/dags/airflow_docker_image_pull.py
+++ b/dags/airflow_docker_image_pull.py
@@ -39,7 +39,7 @@ DOCKER_IMAGES = [
     "atddocker/dts-pavement-ops-reporting:production",
     "atddocker/dts-right-of-way-reporting:production",
     "atddocker/dts-traffic-signal-metrics:production",
-    "atddocker/dts-transportation-counter-data:production"
+    "atddocker/dts-transportation-counter-data:production",
     "atddocker/dts-work-zone-data-feed:production",
     "atddocker/maximo-geo-emergency-mgmt:production",
     "atddocker/vz-afd-ems-import:production",

--- a/dags/airflow_docker_image_pull.py
+++ b/dags/airflow_docker_image_pull.py
@@ -39,6 +39,7 @@ DOCKER_IMAGES = [
     "atddocker/dts-pavement-ops-reporting:production",
     "atddocker/dts-right-of-way-reporting:production",
     "atddocker/dts-traffic-signal-metrics:production",
+    "atddocker/dts-transportation-counter-data:production"
     "atddocker/dts-work-zone-data-feed:production",
     "atddocker/maximo-geo-emergency-mgmt:production",
     "atddocker/vz-afd-ems-import:production",

--- a/dags/dts_transportation_counter_data.py
+++ b/dags/dts_transportation_counter_data.py
@@ -103,7 +103,13 @@ with DAG(
     doc_md=doc_md,
     default_args=DEFAULT_ARGS,
     schedule="30 5 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
-    tags=["repo:dts-transportation-counter-data", "socrata", "trail counters", "ecocounters", "active transportation"],
+    tags=[
+        "repo:dts-transportation-counter-data",
+        "socrata",
+        "trail counters",
+        "ecocounters",
+        "active transportation",
+    ],
     catchup=False,
     params={
         "dry_run": Param(
@@ -127,7 +133,7 @@ with DAG(
         image=docker_image,
         docker_conn_id="docker_default",
         auto_remove="force",
-        command=f"-s {start_date}{dry_run_arg}",
+        command=f"active-transportation-counters/get_eco_counter_data.py -s {start_date}{dry_run_arg}",
         environment=env_vars,
         tty=True,
         mount_tmp_dir=False,

--- a/dags/dts_transportation_counter_data.py
+++ b/dags/dts_transportation_counter_data.py
@@ -78,7 +78,7 @@ REQUIRED_SECRETS = {
 @task(task_id="get_start_date")
 def get_start_date(**context):
     # Returns the start date of this ETL. If there is no run history it will get the date 3 days in the past.
-    # If there is run history it will get the date it was last run succesfully, minus 3 days.
+    # If there is run history it will get the date it was last run successfully, minus 3 days.
     from pendulum import now
 
     prev_start_date = context.get("prev_start_date_success") or now()

--- a/dags/dts_transportation_counter_data.py
+++ b/dags/dts_transportation_counter_data.py
@@ -1,0 +1,138 @@
+from os import getenv
+
+from airflow.sdk import DAG, task, Param
+from airflow.providers.docker.operators.docker import DockerOperator
+from pendulum import datetime, duration
+
+from utils.onepassword import get_env_vars_task
+from utils.slack_operator import task_fail_slack_alert
+
+doc_md = """
+## Transportation Counter ETL
+
+This DAG downloads ecocounter data and publishes it to the open data portal. 
+
+[Dataset link](https://datahub.austintexas.gov/dataset/Active-Transportation-Counter-Traffic-Counts/u4i6-pw3h/about_data)
+
+### Troubleshooting
+
+The most common issue with this script might be periodic timeouts with Socrata as this DAG can upsert a lot of data.
+
+If that happens, a retry will usually be successful. Check [socrata status page](https://status.socrata.com/) as well.
+
+If there is a large backlog of dates to process you may need to manually remove the run history of this DAG to get it to complete before the 45 minute timeout.
+
+This DAG is configured to run daily so that should not happen...
+
+"""
+
+DEPLOYMENT_ENVIRONMENT = getenv("ENVIRONMENT", "development")
+
+DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2015, 1, 1, tz="America/Chicago"),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "execution_timeout": duration(minutes=45),
+    "on_failure_callback": task_fail_slack_alert,
+}
+
+REQUIRED_SECRETS = {
+    "SOCRATA_API_KEY": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeyId",
+    },
+    "SOCRATA_SECRET_KEY": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.apiKeySecret",
+    },
+    "SOCRATA_TOKEN": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.appToken",
+    },
+    "SOCRATA_ENDPOINT": {
+        "opitem": "Socrata Key ID, Secret, and Token",
+        "opfield": "socrata.endpoint",
+    },
+    "ECO_COUNTER_OBSERVATIONS_DATASET": {
+        "opitem": "Ecocounters",
+        "opfield": "socrata.observations dataset",
+    },
+    "ECO_COUNTER_FLOWS_DATASET": {
+        "opitem": "Ecocounters",
+        "opfield": "socrata.flows dataset",
+    },
+    "ECO_VISIO_API_KEY": {
+        "opitem": "Ecocounters",
+        "opfield": "ecovisio.API Key",
+    },
+    "ECO_VISIO_API_BASE_URL": {
+        "opitem": "Ecocounters",
+        "opfield": "ecovisio.base URL",
+    },
+}
+
+
+@task(task_id="get_start_date")
+def get_start_date(**context):
+    # Returns the start date of this ETL. If there is no run history it will get the date 3 days in the past.
+    # If there is run history it will get the date it was last run succesfully, minus 3 days.
+    from pendulum import now
+
+    prev_start_date = context.get("prev_start_date_success") or now()
+    prev_start_date = prev_start_date.subtract(days=3)
+    return prev_start_date.strftime("%Y-%m-%d")
+
+
+@task(
+    task_id="get_is_dry_run_arg",
+)
+def get_is_dry_run_arg(params):
+    """Return ` --dry-run` if the dry_run param has been set"""
+    if bool(params["dry_run"]):
+        return " --dry-run"
+    else:
+        return ""
+
+
+with DAG(
+    dag_id="dts_transportation_counter_data",
+    description="Uploads INRIX traffic signal metrics to socrata for the past few days.",
+    doc_md=doc_md,
+    default_args=DEFAULT_ARGS,
+    schedule="30 5 * * *" if DEPLOYMENT_ENVIRONMENT == "production" else None,
+    tags=["repo:dts-transportation-counter-data", "socrata", "trail counters", "ecocounters", "active transportation"],
+    catchup=False,
+    params={
+        "dry_run": Param(
+            title="Dry run",
+            default=False,
+            type="boolean",
+            description_md="Applies the dry-run flag. Only tests authenticating with APIs.",
+        ),
+    },
+) as dag:
+    docker_image = "atddocker/dts-transportation-counter-data:production"
+
+    env_vars = get_env_vars_task(REQUIRED_SECRETS)
+
+    start_date = get_start_date()
+
+    dry_run_arg = get_is_dry_run_arg()
+
+    t1 = DockerOperator(
+        task_id="ecocounter_data_to_socrata",
+        image=docker_image,
+        docker_conn_id="docker_default",
+        auto_remove="force",
+        command=f"-s {start_date}{dry_run_arg}",
+        environment=env_vars,
+        tty=True,
+        mount_tmp_dir=False,
+        retries=3,
+        retry_delay=duration(seconds=60),
+    )
+
+    env_vars >> start_date >> dry_run_arg >> t1


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/27137

## Associated repo
https://github.com/cityofaustin/dts-transportation-counter-data/

## Testing

**Steps to test:**

The only thing needing VPN access/IP whitelisting is 1pass

1. checkout this branch and also:
```bash
docker pull atddocker/dts-transportation-counter-data:production
```
2. `docker compose up` then go to here: http://localhost:8080/dags/dts_transportation_counter_data
3. Trigger the DAG. It should download the last 3 days of data.
4. Try triggering the DAG with a dry run. (I did this in reverse order so it would be good to unintuitively run dry run last.)
<img width="904" height="549" alt="Screenshot 2026-07-30 at 5 35 07 PM" src="https://github.com/user-attachments/assets/de57be01-f024-4c79-af30-0df4edf9ff88" />

Make sure these ran successfully.  

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
- [ ] Add new images `airflow_docker_image_pull.py` DAG
