### PR TITLE
add license_agreements to AMANDA DAG

### DIFF
--- a/dags/dts_row_reporting.py
+++ b/dags/dts_row_reporting.py
@@ -233,7 +233,7 @@ with DAG(
             "env": env_vars_knack_services,
         },
         {
-            "task_id": "license_agreements_socrata",
+            "task_id": "license_agreements_timeline_socrata",
             "command": "python metrics/s3_to_socrata.py --dataset license_agreements_timeline",
             "image": docker_image,
             "env": env_vars,
@@ -295,6 +295,18 @@ with DAG(
         {
             "task_id": "active_contractors_socrata",
             "command": "python metrics/s3_to_socrata.py --dataset active_contractors",
+            "image": docker_image,
+            "env": env_vars,
+        },
+        {
+            "task_id": "license_agreements_s3",
+            "command": "python amanda/amanda_to_s3.py --query license_agreements",
+            "image": docker_image,
+            "env": env_vars,
+        },
+        {
+            "task_id": "license_agreements_socrata",
+            "command": "python metrics/s3_to_socrata.py --dataset license_agreements",
             "image": docker_image,
             "env": env_vars,
         },


### PR DESCRIPTION
## Associated issues
closes [#28811](https://github.com/cityofaustin/atd-data-tech/issues/28811#issuecomment-5131886773) - Publish ODP for License Agreement AMANDA data

## Associated repo
https://github.com/cityofaustin/dts-right-of-way-reporting/
## Testing

**Steps to test:**
1. Be on city VPN
2. checkout `#28811-charlie-license-agreements`
3. 
```
docker pull atddocker/atd-knack-services:production
```
4. 
```
docker pull atddocker/dts-right-of-way-reporting:production
```
5. 
```
docker compose up
```
6. Go to: http://localhost:8080/dags/dts_row_reporting/
7. Trigger the DAG and make sure all tasks succeed 
---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
- [ ] Add new images `airflow_docker_image_pull.py` DAG
