### PR TITLE
add AGOL secrets to workzone DAG

### DIFF
--- a/dags/dts_work_zone_data_feed.py
+++ b/dags/dts_work_zone_data_feed.py
@@ -104,6 +104,15 @@ REQUIRED_SECRETS = {
         "opitem": "Work Zone Data Feed",
         "opfield": "coordinate.coordinate password",
     },
+    # ArcGIS Online
+    "AGOL_USERNAME": {
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.username",
+    },
+    "AGOL_PASSWORD": {
+        "opitem": "ArcGIS Online (AGOL) Scripts Publisher",
+        "opfield": "production.password",
+    },
 }
 
 with DAG(

--- a/dags/dts_work_zone_data_feed.py
+++ b/dags/dts_work_zone_data_feed.py
@@ -65,6 +65,10 @@ REQUIRED_SECRETS = {
         "opitem": "Work Zone Data Feed",
         "opfield": "production.segment dataset ID",
     },
+    "CRITICAL_DATASET": {
+        "opitem": "Work Zone Data Feed",
+        "opfield": "production.Critical Corridors Feed dataset ID",
+    },
     # AMANDA
     "HOST": {
         "opitem": "Amanda Read-Only (RO) replica database",


### PR DESCRIPTION
Related PR, deploy around the same time: https://github.com/cityofaustin/dts-work-zone-data-feed/pull/10

## Associated issues
Closes [#29581](https://github.com/cityofaustin/atd-data-tech/issues/29581) - Create new work zone feed for CPP and filter for critical corridors

## Associated repo
https://github.com/cityofaustin/dts-work-zone-data-feed/

## Testing

**Steps to test:**
1. be on VPN
2. Follow the steps in [this PR](https://github.com/cityofaustin/dts-work-zone-data-feed/pull/10)
3. Replace `production` with `local` on line 36.
4. `docker compose up`
5. Trigger the DAG [here](http://localhost:8080/dags/dts_work_zone_data_feed) and make sure it completes ✅ 

If you don't feel like doing all that you can also just run this with the production docker image but check the output of the `get_env_vars` task and make sure it includes `AGOL_USERNAME` `AGOL_PASSWORD` and `CRITICAL_DATASET`.

---

#### Ship list

- [ ] Code reviewed
- [ ] Product manager approved
- [ ] Add note to 1PW secrets moved to API vault and check for duplicates
- [ ] Add new images `airflow_docker_image_pull.py` DAG
